### PR TITLE
Adding Everything MCP Server as an example 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,12 @@ See [kubernetes-mcp-server/README.md](./kubernetes-mcp-server/README.md) for:
 - ConfigMap-based configuration
 - Testing and verification
 
+## everything-mcp-server
+
+Deploys the [Everything MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything), one of the reference servers from the Model Context Protocol project that exercises all MCP features.
+
+See [everything-mcp-server/README.md](./everything-mcp-server/README.md) for details.
+
 ## Quick Start
 
 ```bash

--- a/examples/everything-mcp-server/README.md
+++ b/examples/everything-mcp-server/README.md
@@ -1,0 +1,37 @@
+# Everything MCP Server Example
+
+This example deploys the Everything MCP Server, one of the [reference servers](https://github.com/modelcontextprotocol/servers) from the Model Context Protocol project. It exercises all MCP features including prompts, resources, and tools.
+
+Source code: https://github.com/modelcontextprotocol/servers/tree/main/src/everything
+
+## Deployment
+
+```bash
+kubectl apply -f mcpserver.yaml
+```
+
+This creates:
+- Deployment running the MCP server
+- Service exposing port 3001
+
+Check status:
+
+```bash
+kubectl get mcpserver everything-mcp-server
+```
+
+## Testing
+
+Port-forward to the service:
+
+```bash
+kubectl port-forward svc/everything-mcp-server 3001:3001
+```
+
+Connect with an MCP client at `http://localhost:3001/mcp`.
+
+## Cleanup
+
+```bash
+kubectl delete -f mcpserver.yaml
+```

--- a/examples/everything-mcp-server/mcpserver.yaml
+++ b/examples/everything-mcp-server/mcpserver.yaml
@@ -1,0 +1,8 @@
+apiVersion: mcp.x-k8s.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: everything-mcp-server
+  namespace: default
+spec:
+  image: quay.io/matzew/mcp-everything:latest
+  port: 3001


### PR DESCRIPTION
The [Everything MCP Server](https://github.com/modelcontextprotocol/servers/blob/main/src/everything/README.md) is one of the reference mcp servers. 

Adding it here as an example for show-casing for the operator