### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+# main branch
+  - package-ecosystem: "gomod"
+    target-branch: main
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+    - dependencies
+    groups:
+      k8sio:
+        patterns:
+        - k8s.io/*
+
+  - package-ecosystem: "docker"
+    target-branch: main
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+    - dependencies
+
+  - package-ecosystem: "github-actions"
+    target-branch: main
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+    - dependencies


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for automated dependency updates
- Configures daily updates for gomod, docker, and github-actions ecosystems
- Groups k8s.io dependencies (excluding klog) into single PRs
- All PRs labeled with `dependencies`

## Reference

Inspired by [NVIDIA/nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/.github/dependabot.yml)