### PR TITLE
Bump to latest lint and go versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.7.2
+GOLANGCI_LINT_VERSION ?= v2.10.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.25.3
+go 1.25.8
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2


### PR DESCRIPTION
Noticed that the initial (generated) commit from kubebuilder had an older version of GO and some older version of lint.

Addressing those now.