### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -44,4 +44,8 @@ fi
 echo "==> Running: make lint"
 make lint
 
+# 4. Run unit tests
+echo "==> Running: make test"
+make test
+
 echo "==> All pre-commit checks passed."

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,3 +1,6 @@
+# Generated from kubebuilder template:
+# https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.1/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/role.go
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Add pre-commit hook that runs linting. testing and manfiest generation to ensure commits to this repo are always in good shape and help speed up PR reviews and CI runs 

examples:

successful commit:

```shell
git commit -s -m "add make test step"                                                                                                                                      ─╯
==> Pre-commit hook: running checks...
==> Running: make manifests generate
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/controller-gen" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/controller-gen" object:headerFile="hack/boilerplate.go.txt" paths="./..."
==> Running: make fmt vet
go fmt ./...
go vet ./...
==> Running: make lint
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/golangci-lint" run
0 issues.
==> Running: make test
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/controller-gen" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/controller-gen" object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
Setting up envtest binaries for Kubernetes version 1.35...
/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/k8s/1.35.0-darwin-arm64KUBEBUILDER_ASSETS="/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/k8s/1.35.0-darwin-arm64" go test $(go list ./... | grep -v /e2e) -coverprofile cover.out
        github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1          coverage: 0.0% of statements
        github.com/kubernetes-sigs/mcp-lifecycle-operator/cmd           coverage: 0.0% of statements
ok      github.com/kubernetes-sigs/mcp-lifecycle-operator/internal/controller   6.246s  coverage: 67.2% of statements
        github.com/kubernetes-sigs/mcp-lifecycle-operator/test/utils            coverage: 0.0% of statements
==> All pre-commit checks passed.
[pre-commit-hook 2598e8a] add make test step
 1 file changed, 4 insertions(+)

```


unsuccessful commit: 
```shell
╰─ git commit -s -m "add pre-commit hooks to repo"                                                                                                                            ─╯
==> Pre-commit hook: running checks...
==> Running: make manifests generate
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/controller-gen" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/controller-gen" object:headerFile="hack/boilerplate.go.txt" paths="./..."
==> Running: make fmt vet
go fmt ./...
go vet ./...
==> Running: make lint
"/Users/jrao/projects/k8s-mcp-lifecycle-operator/bin/golangci-lint" run
internal/controller/mcpserver_controller.go:76:28: string `Pending` has 3 occurrences, make it a constant (goconst)
                mcpServer.Status.Phase = "Pending"
                                         ^
internal/controller/mcpserver_controller.go:58:1: cyclomatic complexity 37 of func `(*MCPServerReconciler).Reconcile` is high (> 30) (gocyclo)
func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
^
cmd/main.go:18:1: The line is 125 characters long, which exceeds the maximum of 120 characters. (lll)
// https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.1/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
^
test/utils/utils.go:18:1: The line is 133 characters long, which exceeds the maximum of 120 characters. (lll)
// https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.1/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
^
internal/controller/mcpserver_controller.go:59:2: import-shadowing: The name 'log' shadows an import name (revive)
        log := log.FromContext(ctx)
        ^
5 issues:
* goconst: 1
* gocyclo: 1
* lll: 2
* revive: 1
make: *** [lint] Error 1
``` 

The hook can be skipped by adding `--no-verify` while committing if required 