### PR TITLE
Add equal checks for Args and ServiceAccountName removal detection

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -236,12 +236,14 @@ func (r *MCPServerReconciler) reconcileDeployment(
 	oldPodSpec := existingDeployment.Spec.Template.Spec
 	newPodSpec := deployment.Spec.Template.Spec
 	needsUpdate := !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Args, newPodSpec.Containers[0].Args) ||
 		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Env, newPodSpec.Containers[0].Env) ||
 		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].EnvFrom, newPodSpec.Containers[0].EnvFrom) ||
 		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].SecurityContext, newPodSpec.Containers[0].SecurityContext) ||
 		!equality.Semantic.DeepEqual(oldPodSpec.SecurityContext, newPodSpec.SecurityContext) ||
 		!equality.Semantic.DeepEqual(oldPodSpec.Volumes, newPodSpec.Volumes) ||
-		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].VolumeMounts, newPodSpec.Containers[0].VolumeMounts)
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].VolumeMounts, newPodSpec.Containers[0].VolumeMounts) ||
+		oldPodSpec.ServiceAccountName != newPodSpec.ServiceAccountName
 	if needsUpdate {
 		logger.Info("Updating Deployment", "name", existingDeployment.Name)
 		existingDeployment.Spec.Template.Spec = deployment.Spec.Template.Spec
@@ -383,7 +385,7 @@ func (r *MCPServerReconciler) createDeployment(ctx context.Context, mcpServer *m
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: mcpServer.Spec.ServiceAccountName,
+					ServiceAccountName: serviceAccountName(mcpServer.Spec.ServiceAccountName),
 					Containers:         []corev1.Container{container},
 					Volumes:            volumes,
 				},
@@ -471,6 +473,14 @@ func (r *MCPServerReconciler) updateStatusFailed(ctx context.Context, mcpServer 
 		ObservedGeneration: mcpServer.Generation,
 	})
 	_ = r.Status().Update(ctx, mcpServer)
+}
+
+// serviceAccountName returns the given name, defaulting to "default" if empty.
+func serviceAccountName(name string) string {
+	if name == "" {
+		return "default"
+	}
+	return name
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -194,6 +194,150 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 	})
 
+	Context("When reconciling a resource with args", func() {
+		const resourceName = "test-resource-args"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("should update deployment when args are removed", func() {
+			resource := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image: "test-image:latest",
+					Port:  8080,
+					Args:  []string{"--verbose", "--port=8080"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Reconciling to create the initial deployment with args")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"--verbose", "--port=8080"}))
+
+			By("Removing args from the MCPServer")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			mcpServer.Spec.Args = nil
+			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+			By("Reconciling again to pick up the removal")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(BeEmpty())
+		})
+	})
+
+	Context("When reconciling a resource with serviceAccountName", func() {
+		const resourceName = "test-resource-sa"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("should update deployment when serviceAccountName is removed", func() {
+			resource := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Image:              "test-image:latest",
+					Port:               8080,
+					ServiceAccountName: "my-sa",
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Reconciling to create the initial deployment with serviceAccountName")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal("my-sa"))
+
+			By("Removing serviceAccountName from the MCPServer")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			mcpServer.Spec.ServiceAccountName = ""
+			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+			By("Reconciling again to pick up the removal")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal("default"))
+		})
+	})
+
 	Context("When reconciling a resource with security context", func() {
 		const resourceName = "test-resource-secctx"
 


### PR DESCRIPTION
`DeepDerivative` treats nil/empty values as "don't care", so removing `Args` or `ServiceAccountName` from an `MCPServer` spec would _not_ trigger a Deployment update. Add explicit equality checks to catch these removals.

