### PR TITLE
Apply restricted Pod Security Standard to all deployments

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,13 +53,6 @@ spec:
       #             operator: In
       #             values:
       #               - linux
-      securityContext:
-        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
-        # This ensures that deployments meet the highest security requirements for Kubernetes.
-        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -70,11 +63,14 @@ spec:
         name: manager
         ports: []
         securityContext:
-          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop:
             - "ALL"
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
@@ -91,7 +92,6 @@ require (
 	k8s.io/component-base v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -291,8 +292,12 @@ func (r *MCPServerReconciler) createDeployment(ctx context.Context, mcpServer *m
 		container.EnvFrom = mcpServer.Spec.EnvFrom
 	}
 
-	// Add security context if specified
-	container.SecurityContext = mcpServer.Spec.SecurityContext
+	// Apply security context: use user-specified if provided, otherwise apply restricted defaults
+	if mcpServer.Spec.SecurityContext != nil {
+		container.SecurityContext = mcpServer.Spec.SecurityContext
+	} else {
+		container.SecurityContext = defaultContainerSecurityContext()
+	}
 
 	// Add volume mount if ConfigMapRef is specified
 	var volumes []corev1.Volume
@@ -393,8 +398,10 @@ func (r *MCPServerReconciler) createDeployment(ctx context.Context, mcpServer *m
 		},
 	}
 
-	// Add pod security context if specified
-	deployment.Spec.Template.Spec.SecurityContext = mcpServer.Spec.PodSecurityContext
+	// Apply pod security context if specified
+	if mcpServer.Spec.PodSecurityContext != nil {
+		deployment.Spec.Template.Spec.SecurityContext = mcpServer.Spec.PodSecurityContext
+	}
 
 	return deployment, nil
 }
@@ -481,6 +488,18 @@ func serviceAccountName(name string) string {
 		return "default"
 	}
 	return name
+}
+
+// defaultContainerSecurityContext returns the "restricted" Pod Security Standard
+// security context applied to MCP server containers by default.
+func defaultContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		RunAsNonRoot:             ptr.To(true),
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -487,7 +487,7 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(*containerSC.ReadOnlyRootFilesystem).To(BeTrue())
 		})
 
-		It("should not set security contexts when not specified", func() {
+		It("should apply default restricted security contexts when not specified", func() {
 			resource := &mcpv1alpha1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName + "-none",
@@ -516,11 +516,22 @@ var _ = Describe("MCPServer Controller", func() {
 			}, deployment)
 			Expect(err).NotTo(HaveOccurred())
 
+			By("Verifying no pod security context is set by default")
 			podSC := deployment.Spec.Template.Spec.SecurityContext
 			if podSC != nil {
 				Expect(*podSC).To(Equal(corev1.PodSecurityContext{}))
 			}
-			Expect(deployment.Spec.Template.Spec.Containers[0].SecurityContext).To(BeNil())
+
+			By("Verifying default container security context")
+			containerSC := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+			Expect(containerSC).NotTo(BeNil())
+			Expect(*containerSC.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(*containerSC.ReadOnlyRootFilesystem).To(BeTrue())
+			Expect(*containerSC.RunAsNonRoot).To(BeTrue())
+			Expect(containerSC.Capabilities).NotTo(BeNil())
+			Expect(containerSC.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+			Expect(containerSC.SeccompProfile).NotTo(BeNil())
+			Expect(containerSC.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName + "-none", Namespace: "default"}, mcpServer)).To(Succeed())


### PR DESCRIPTION
Ensure operator-created `MCPServer` deployments can run in namespaces enforcing the "restricted" Pod Security Standard without requiring users to manually configure security contexts on every `MCPServer` CR.

Applied same to pattern to controller's deployment too 