### PR TITLE
CI/CD: add cloudbuild yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,23 @@
+timeout: 2700s
+steps:
+  # This step runs the python script to build and push the Docker image.
+  # We use the gcloud builder because it comes with python and the docker client.
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud"
+    entrypoint: "python3"
+    args:
+      - "./dev/tools/push-images"
+      # Assuming the script accepts project and tag arguments.
+      # Using standard Cloud Build substitutions.
+      - "--image-prefix=${_IMAGE_PREFIX}/"
+      - "--extra-image-tag=${_GIT_TAG}-${_CONFIG}"
+      - "--extra-image-tag=latest-${_CONFIG}"
+
+options:
+  enableStructuredLogging: true
+  # Using a more powerful machine type can speed up docker builds.
+  machineType: "E2_HIGHCPU_8"
+  substitution_option: "ALLOW_LOOSE"
+substitutions:
+  _GIT_TAG: "v0.0.1"
+  _CONFIG: main
+  _IMAGE_PREFIX: "us-central1-docker.pkg.dev/k8s-staging-images/mcp-lifecycle-operator"


### PR DESCRIPTION
adds a cloudbuild.yaml needed for prow jobs being added in https://github.com/kubernetes/test-infra/pull/36673 
based on example in https://github.com/kubernetes-sigs/agent-sandbox/blob/main/cloudbuild.yaml 

closes : #15 