### PR TITLE
chore: update make test target to only run where _test files exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" \
+		go test $$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v /e2e) -coverprofile cover.out
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.


### PR DESCRIPTION
currently there is a go version mismatch between what is in the `go.mod` file (1.25.8) and what the CI job uses (1.24) which might be causing a dynamic download of 1.25.8 in the CI, which doesn't include the `covdata` tool
Hence we are currently seeing an error in CI when `make test` runs against folders that don't contain any _test files 

```sh
Setting up envtest binaries for Kubernetes version 1.35...
/home/prow/go/src/github.com/kubernetes-sigs/mcp-lifecycle-operator/bin/k8s/1.35.0-linux-amd64KUBEBUILDER_ASSETS="/home/prow/go/src/github.com/kubernetes-sigs/mcp-lifecycle-operator/bin/k8s/1.35.0-linux-amd64" go test $(go list ./... | grep -v /e2e) -coverprofile cover.out
ok  	github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1	13.481s	coverage: 0.7% of statements
# github.com/kubernetes-sigs/mcp-lifecycle-operator/cmd
go: no such tool "covdata"
# github.com/kubernetes-sigs/mcp-lifecycle-operator/test/utils
go: no such tool "covdata"
ok  	github.com/kubernetes-sigs/mcp-lifecycle-operator/internal/controller	10.688s	coverage: 78.7% of statements
make: *** [Makefile:65: test] Error 1
```

as we can see, the actual tests run fine, it only fails on folders that don't contain any test files
This PR updates the make target so that it skips those folders

A separate PR has been raised to update the CI image to 1.25 - https://github.com/kubernetes/test-infra/pull/36688