### PR TITLE
Log error when updateStatusFailed fails to write status

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -523,7 +523,9 @@ func (r *MCPServerReconciler) updateStatusFailed(ctx context.Context, mcpServer 
 		Message:            message,
 		ObservedGeneration: mcpServer.Generation,
 	})
-	_ = r.Status().Update(ctx, mcpServer)
+	if err := r.Status().Update(ctx, mcpServer); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to update MCPServer status to Failed")
+	}
 }
 
 // defaultContainerSecurityContext returns the "restricted" Pod Security Standard


### PR DESCRIPTION
Instead of silently discarding the error from the status update, log it so that conflicts or API errors are visible in the controller logs.