### PR TITLE
Fix indentation in a logging statement

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -251,7 +251,7 @@ func (r *MCPServerReconciler) reconcileDeployment(
 
 	var needsUpdate bool
 	if len(oldPodSpec.Containers) == 0 {
-	    logger.Info("Recovering deployment with empty containers list", "name", existingDeployment.Name)
+		logger.Info("Recovering deployment with empty containers list", "name", existingDeployment.Name)
 		needsUpdate = true
 	} else {
 		needsUpdate = !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec) ||


### PR DESCRIPTION
Was getting:
`internal/controller/mcpserver_controller.go:254:1: File is not properly formatted (gofmt)`

cc @matzew 