### PR TITLE
fix: use production logging by default instead of hardcoded dev mode

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,9 +82,7 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,6 +59,8 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          # Uncomment to enable development-style logging (human-readable, debug level):
+          # - --zap-devel
         image: controller:latest
         name: manager
         ports: []


### PR DESCRIPTION
The zap logger was hardcoded to Development: true, which produces debug-level human-readable output unsuitable for production. Default to production logging and document --zap-devel flag in the Deployment args for when development logging is needed.