### PR TITLE
feat: add listType=map validation to reject duplicate storage mount paths

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverconfig.go
@@ -50,6 +50,7 @@ type ServerConfigApplyConfiguration struct {
 	// Storage defines storage mounts for ConfigMaps and Secrets.
 	// Each item uses native Kubernetes volume source types for consistency and feature parity.
 	// If specified, must contain at least 1 item. Maximum 64 items.
+	// Each storage mount must have a unique path.
 	Storage []StorageMountApplyConfiguration `json:"storage,omitempty"`
 	// Path is the HTTP path where the MCP server listens for SSE/Streamable HTTP connections.
 	// This path is appended to the service address in the status URL.

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -192,9 +192,12 @@ type ServerConfig struct {
 	// Storage defines storage mounts for ConfigMaps and Secrets.
 	// Each item uses native Kubernetes volume source types for consistency and feature parity.
 	// If specified, must contain at least 1 item. Maximum 64 items.
+	// Each storage mount must have a unique path.
 	// +optional
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=64
+	// +listType=map
+	// +listMapKey=path
 	Storage []StorageMount `json:"storage,omitempty"`
 
 	// Path is the HTTP path where the MCP server listens for SSE/Streamable HTTP connections.

--- a/api/v1alpha1/mcpserver_validation_test.go
+++ b/api/v1alpha1/mcpserver_validation_test.go
@@ -929,6 +929,51 @@ var _ = Describe("MCPServer Validation", func() {
 			}
 			Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
 		})
+
+		It("should reject multiple storage mounts with duplicate paths", func() {
+			mcpServer := &MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "duplicate-storage-path",
+					Namespace: namespace.Name,
+				},
+				Spec: MCPServerSpec{
+					Source: Source{
+						Type: SourceTypeContainerImage,
+						ContainerImage: &ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: ServerConfig{
+						Port: 8080,
+						Storage: []StorageMount{
+							{
+								Path: "/etc/config",
+								Source: StorageSource{
+									Type: StorageTypeConfigMap,
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "config-one",
+										},
+									},
+								},
+							},
+							{
+								Path: "/etc/config",
+								Source: StorageSource{
+									Type: StorageTypeConfigMap,
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "config-two",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpServer)).NotTo(Succeed())
+		})
 	})
 
 	Context("RuntimeConfig validation", func() {

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -325,6 +325,7 @@ spec:
                       Storage defines storage mounts for ConfigMaps and Secrets.
                       Each item uses native Kubernetes volume source types for consistency and feature parity.
                       If specified, must contain at least 1 item. Maximum 64 items.
+                      Each storage mount must have a unique path.
                     items:
                       description: |-
                         StorageMount defines a storage mount combining volume source and mount configuration.
@@ -526,6 +527,9 @@ spec:
                     maxItems: 64
                     minItems: 1
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - path
+                    x-kubernetes-list-type: map
                 required:
                 - port
                 type: object


### PR DESCRIPTION
Multiple storage mounts with the same path are accepted by the CRD but cause Pod creation failures at runtime. Use `+listType=map` with `+listMapKey=path` on the Storage field to enforce unique paths at admission time.