### PR TITLE
Remove redundant Pending status apply on first reconcile

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -86,14 +86,6 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
 
-	// Set initial phase
-	if mcpServer.Status.Phase == "" {
-		if err := r.applyStatus(ctx, mcpServer, acv1alpha1.MCPServerStatus().WithPhase(PhasePending)); err != nil {
-			logger.Error(err, "Failed to update MCPServer status")
-			return ctrl.Result{}, err
-		}
-	}
-
 	// Reconcile Deployment
 	existingDeployment, err := r.reconcileDeployment(ctx, mcpServer)
 	if err != nil {


### PR DESCRIPTION
The initial `Phase=Pending` SSA status apply was immediately overwritten by the full status apply at the end of `Reconcile()`, making it a wasted API server round-trip. The full status apply already sets the correct phase (`Pending`, `Running`, or `Failed`) based on deployment state.