### PR TITLE
add aggregation labels to clustrroles

### DIFF
--- a/config/rbac/mcpserver_admin_role.yaml
+++ b/config/rbac/mcpserver_admin_role.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-lifecycle-operator
     app.kubernetes.io/managed-by: kustomize
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: mcpserver-admin-role
 rules:
 - apiGroups:

--- a/config/rbac/mcpserver_admin_role.yaml
+++ b/config/rbac/mcpserver_admin_role.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-lifecycle-operator
     app.kubernetes.io/managed-by: kustomize
+    # Add these permissions to the "admin" default role.
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: mcpserver-admin-role
 rules:

--- a/config/rbac/mcpserver_editor_role.yaml
+++ b/config/rbac/mcpserver_editor_role.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-lifecycle-operator
     app.kubernetes.io/managed-by: kustomize
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: mcpserver-editor-role
 rules:
 - apiGroups:

--- a/config/rbac/mcpserver_editor_role.yaml
+++ b/config/rbac/mcpserver_editor_role.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-lifecycle-operator
     app.kubernetes.io/managed-by: kustomize
+    # Add these permissions to the "edit" default role.
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: mcpserver-editor-role
 rules:

--- a/config/rbac/mcpserver_viewer_role.yaml
+++ b/config/rbac/mcpserver_viewer_role.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-lifecycle-operator
     app.kubernetes.io/managed-by: kustomize
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: mcpserver-viewer-role
 rules:
 - apiGroups:

--- a/config/rbac/mcpserver_viewer_role.yaml
+++ b/config/rbac/mcpserver_viewer_role.yaml
@@ -14,6 +14,7 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-lifecycle-operator
     app.kubernetes.io/managed-by: kustomize
+    # Add these permissions to the "view" default role.
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: mcpserver-viewer-role
 rules:


### PR DESCRIPTION
This would allow namespace admins to automatically manage MCP server CRs in their namespaces without needing a cluster admin to intervene
also allows aggregation for edit and viewer roles