### PR TITLE
Migrate MCPServer status from Phase to Kubernetes-style Conditions

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
@@ -27,24 +27,36 @@ import (
 //
 // MCPServerStatus defines the observed state of MCPServer.
 type MCPServerStatusApplyConfiguration struct {
-	// Phase represents the current lifecycle phase of the MCPServer.
-	// Possible values: Pending, Running, Failed
-	Phase *string `json:"phase,omitempty"`
+	// ObservedGeneration reflects the generation most recently observed by the controller.
+	// This allows users to determine if the status reflects the latest spec changes.
+	// When observedGeneration matches metadata.generation, the status is up-to-date.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 	// DeploymentName is the name of the Deployment created for this MCPServer.
 	DeploymentName *string `json:"deploymentName,omitempty"`
 	// ServiceName is the name of the Service created for this MCPServer.
 	ServiceName *string `json:"serviceName,omitempty"`
 	// Address contains the address of the MCP server service.
 	Address *MCPServerAddressApplyConfiguration `json:"address,omitempty"`
-	// Conditions represent the current state of the MCPServer resource.
-	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	// Conditions represent the latest available observations of the MCPServer's state.
 	//
-	// Standard condition types include "Ready", "Progressing", and "Degraded".
-	// The "Ready" condition indicates the resource is fully functional and available.
-	// The "Progressing" condition indicates the resource is being created or updated.
-	// The "Degraded" condition indicates the resource failed to reach or maintain its desired state.
+	// Standard condition types:
+	// - "Accepted": Configuration is valid and all referenced resources exist
+	// - "Ready": MCP server is operational and ready to serve requests
 	//
-	// The status of each condition is one of True, False, or Unknown.
+	// The "Accepted" condition validates configuration before creating resources.
+	// Reasons: Valid (True), Invalid (False with details in message)
+	//
+	// The "Ready" condition indicates overall server readiness.
+	// Status=True means at least one instance is healthy and serving requests.
+	// Reasons:
+	// - Available: Server is ready (Status=True)
+	// - ConfigurationInvalid: Accepted=False, cannot proceed
+	// - DeploymentUnavailable: No healthy instances (all deployment/pod issues)
+	// - ScaledToZero: Deployment scaled to 0 replicas
+	// - Initializing: Waiting for initial status
+	//
+	// Note: Specific failure details (ImagePullBackOff, OOMKilled, CrashLoop, etc.)
+	// are included in the condition message, not the reason.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 
@@ -54,11 +66,11 @@ func MCPServerStatus() *MCPServerStatusApplyConfiguration {
 	return &MCPServerStatusApplyConfiguration{}
 }
 
-// WithPhase sets the Phase field in the declarative configuration to the given value
+// WithObservedGeneration sets the ObservedGeneration field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the Phase field is set to the value of the last call.
-func (b *MCPServerStatusApplyConfiguration) WithPhase(value string) *MCPServerStatusApplyConfiguration {
-	b.Phase = &value
+// If called multiple times, the ObservedGeneration field is set to the value of the last call.
+func (b *MCPServerStatusApplyConfiguration) WithObservedGeneration(value int64) *MCPServerStatusApplyConfiguration {
+	b.ObservedGeneration = &value
 	return b
 }
 

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -360,10 +360,11 @@ type MCPServerAddress struct {
 
 // MCPServerStatus defines the observed state of MCPServer.
 type MCPServerStatus struct {
-	// Phase represents the current lifecycle phase of the MCPServer.
-	// Possible values: Pending, Running, Failed
+	// ObservedGeneration reflects the generation most recently observed by the controller.
+	// This allows users to determine if the status reflects the latest spec changes.
+	// When observedGeneration matches metadata.generation, the status is up-to-date.
 	// +optional
-	Phase string `json:"phase,omitempty"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// DeploymentName is the name of the Deployment created for this MCPServer.
 	// +optional
@@ -377,15 +378,27 @@ type MCPServerStatus struct {
 	// +optional
 	Address *MCPServerAddress `json:"address,omitempty"`
 
-	// Conditions represent the current state of the MCPServer resource.
-	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	// Conditions represent the latest available observations of the MCPServer's state.
 	//
-	// Standard condition types include "Ready", "Progressing", and "Degraded".
-	// The "Ready" condition indicates the resource is fully functional and available.
-	// The "Progressing" condition indicates the resource is being created or updated.
-	// The "Degraded" condition indicates the resource failed to reach or maintain its desired state.
+	// Standard condition types:
+	// - "Accepted": Configuration is valid and all referenced resources exist
+	// - "Ready": MCP server is operational and ready to serve requests
 	//
-	// The status of each condition is one of True, False, or Unknown.
+	// The "Accepted" condition validates configuration before creating resources.
+	// Reasons: Valid (True), Invalid (False with details in message)
+	//
+	// The "Ready" condition indicates overall server readiness.
+	// Status=True means at least one instance is healthy and serving requests.
+	// Reasons:
+	//   - Available: Server is ready (Status=True)
+	//   - ConfigurationInvalid: Accepted=False, cannot proceed
+	//   - DeploymentUnavailable: No healthy instances (all deployment/pod issues)
+	//   - ScaledToZero: Deployment scaled to 0 replicas
+	//   - Initializing: Waiting for initial status
+	//
+	// Note: Specific failure details (ImagePullBackOff, OOMKilled, CrashLoop, etc.)
+	// are included in the condition message, not the reason.
+	//
 	// +listType=map
 	// +listMapKey=type
 	// +optional
@@ -395,7 +408,8 @@ type MCPServerStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:ac:generate=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="Accepted")].status`
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.source.containerImage.ref`
 // +kubebuilder:printcolumn:name="Port",type=integer,JSONPath=`.spec.config.port`
 // +kubebuilder:printcolumn:name="Address",type=string,JSONPath=`.status.address.url`

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -15,8 +15,11 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.phase
-      name: Phase
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
       type: string
     - jsonPath: .spec.source.containerImage.ref
       name: Image
@@ -1531,15 +1534,26 @@ spec:
                 type: object
               conditions:
                 description: |-
-                  Conditions represent the current state of the MCPServer resource.
-                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+                  Conditions represent the latest available observations of the MCPServer's state.
 
-                  Standard condition types include "Ready", "Progressing", and "Degraded".
-                  The "Ready" condition indicates the resource is fully functional and available.
-                  The "Progressing" condition indicates the resource is being created or updated.
-                  The "Degraded" condition indicates the resource failed to reach or maintain its desired state.
+                  Standard condition types:
+                  - "Accepted": Configuration is valid and all referenced resources exist
+                  - "Ready": MCP server is operational and ready to serve requests
 
-                  The status of each condition is one of True, False, or Unknown.
+                  The "Accepted" condition validates configuration before creating resources.
+                  Reasons: Valid (True), Invalid (False with details in message)
+
+                  The "Ready" condition indicates overall server readiness.
+                  Status=True means at least one instance is healthy and serving requests.
+                  Reasons:
+                    - Available: Server is ready (Status=True)
+                    - ConfigurationInvalid: Accepted=False, cannot proceed
+                    - DeploymentUnavailable: No healthy instances (all deployment/pod issues)
+                    - ScaledToZero: Deployment scaled to 0 replicas
+                    - Initializing: Waiting for initial status
+
+                  Note: Specific failure details (ImagePullBackOff, OOMKilled, CrashLoop, etc.)
+                  are included in the condition message, not the reason.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -1602,11 +1616,13 @@ spec:
                 description: DeploymentName is the name of the Deployment created
                   for this MCPServer.
                 type: string
-              phase:
+              observedGeneration:
                 description: |-
-                  Phase represents the current lifecycle phase of the MCPServer.
-                  Possible values: Pending, Running, Failed
-                type: string
+                  ObservedGeneration reflects the generation most recently observed by the controller.
+                  This allows users to determine if the status reflects the latest spec changes.
+                  When observedGeneration matches metadata.generation, the status is up-to-date.
+                format: int64
+                type: integer
               serviceName:
                 description: ServiceName is the name of the Service created for this
                   MCPServer.

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -22,6 +22,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,13 +44,39 @@ import (
 	acv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1/applyconfiguration/api/v1alpha1"
 )
 
-// Phase constants for MCPServer status.
 const (
-	PhasePending = "Pending"
-	PhaseRunning = "Running"
-	PhaseFailed  = "Failed"
-
 	fieldManager = "mcpserver-controller"
+)
+
+// Condition types for MCPServer status.
+const (
+	// ConditionTypeAccepted indicates the MCPServer configuration is valid.
+	ConditionTypeAccepted = "Accepted"
+	// ConditionTypeReady indicates the MCPServer is ready to serve requests.
+	ConditionTypeReady = "Ready"
+)
+
+// Reasons for Accepted condition.
+const (
+	ReasonValid   = "Valid"
+	ReasonInvalid = "Invalid"
+	ReasonUnknown = "Unknown"
+)
+
+// Reasons for Ready condition.
+const (
+	ReasonAvailable             = "Available"
+	ReasonConfigurationInvalid  = "ConfigurationInvalid"
+	ReasonDeploymentUnavailable = "DeploymentUnavailable"
+	ReasonServiceUnavailable    = "ServiceUnavailable"
+	ReasonScaledToZero          = "ScaledToZero"
+	ReasonInitializing          = "Initializing"
+)
+
+// Reconciliation constants.
+const (
+	// requeueDelayDeploymentUnavailable is the delay before requeuing when a deployment is not yet available.
+	requeueDelayDeploymentUnavailable = 15 * time.Second
 )
 
 // MCPServerReconciler reconciles a MCPServer object
@@ -86,136 +114,271 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
 
-	// Reconcile Deployment
+	// Validate configuration and set Accepted condition
+	acceptedCondition, configValid := r.setAcceptedCondition(ctx, mcpServer)
+	preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
+
+	// If configuration is not valid, update status and stop
+	if !configValid {
+		readyCondition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionFalse,
+			ReasonConfigurationInvalid,
+			"Configuration must be fixed before server can start",
+			mcpServer.Generation,
+		)
+		preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+		status := acv1alpha1.MCPServerStatus().
+			WithObservedGeneration(mcpServer.Generation).
+			WithServiceName(mcpServer.Name).
+			WithConditions(
+				conditionToAC(acceptedCondition),
+				conditionToAC(readyCondition),
+			)
+
+		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
+			logger.Error(err, "Failed to update MCPServer status")
+			return ctrl.Result{}, err
+		}
+
+		logger.Info("MCPServer configuration is invalid", "reason", acceptedCondition.Reason)
+		return ctrl.Result{}, nil
+	}
+
+	// Configuration is valid, proceed with deployment reconciliation
 	existingDeployment, err := r.reconcileDeployment(ctx, mcpServer)
 	if err != nil {
-		r.updateStatusFailed(ctx, mcpServer, "Failed to reconcile Deployment")
+		// Deployment reconciliation failed - update status
+		readyCondition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionFalse,
+			ReasonDeploymentUnavailable,
+			fmt.Sprintf("Failed to reconcile Deployment: %v", err),
+			mcpServer.Generation,
+		)
+		preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+		status := acv1alpha1.MCPServerStatus().
+			WithObservedGeneration(mcpServer.Generation).
+			WithServiceName(mcpServer.Name).
+			WithConditions(
+				conditionToAC(acceptedCondition),
+				conditionToAC(readyCondition),
+			)
+
+		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
+			logger.Error(err, "Failed to update MCPServer status")
+		}
 		return ctrl.Result{}, err
 	}
 
 	// Reconcile Service
 	if err := r.reconcileService(ctx, mcpServer); err != nil {
-		r.updateStatusFailed(ctx, mcpServer, "Failed to reconcile Service")
+		// Service reconciliation failed - update status
+		readyCondition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionFalse,
+			ReasonServiceUnavailable,
+			fmt.Sprintf("Failed to reconcile Service: %v", err),
+			mcpServer.Generation,
+		)
+		preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+		status := acv1alpha1.MCPServerStatus().
+			WithObservedGeneration(mcpServer.Generation).
+			WithDeploymentName(existingDeployment.Name).
+			WithServiceName(mcpServer.Name).
+			WithConditions(
+				conditionToAC(acceptedCondition),
+				conditionToAC(readyCondition),
+			)
+
+		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
+			logger.Error(err, "Failed to update MCPServer status")
+		}
 		return ctrl.Result{}, err
 	}
 
-	phase, condition := determinePhase(existingDeployment, mcpServer.Generation, mcpServer.Status.Conditions)
+	// Determine Ready condition based on deployment status
+	readyCondition := determineReadyCondition(
+		existingDeployment,
+		acceptedCondition,
+		mcpServer.Generation,
+		mcpServer.Status.Conditions,
+	)
 
+	// Build status
 	path := mcpServer.Spec.Config.Path
 	if path == "" {
 		path = "/mcp"
 	}
 
 	status := acv1alpha1.MCPServerStatus().
-		WithPhase(phase).
+		WithObservedGeneration(mcpServer.Generation).
 		WithDeploymentName(existingDeployment.Name).
 		WithServiceName(mcpServer.Name).
-		WithAddress(acv1alpha1.MCPServerAddress().WithURL(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", mcpServer.Name, mcpServer.Namespace, mcpServer.Spec.Config.Port, path))).
-		WithConditions(conditionToAC(condition))
+		WithAddress(acv1alpha1.MCPServerAddress().
+			WithURL(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s",
+				mcpServer.Name, mcpServer.Namespace, mcpServer.Spec.Config.Port, path))).
+		WithConditions(
+			conditionToAC(acceptedCondition),
+			conditionToAC(readyCondition),
+		)
 
 	if err := r.applyStatus(ctx, mcpServer, status); err != nil {
-		logger.Error(err, "Failed to apply new MCPServer status")
+		logger.Error(err, "Failed to apply MCPServer status")
 		return ctrl.Result{}, err
 	}
 
-	logger.Info("Successfully reconciled MCPServer", "phase", mcpServer.Status.Phase)
+	logger.Info("Successfully reconciled MCPServer",
+		"accepted", acceptedCondition.Status,
+		"ready", readyCondition.Status)
+
+	// If Deployment is not yet available, requeue to check again later
+	if readyCondition.Status == metav1.ConditionFalse && readyCondition.Reason == ReasonDeploymentUnavailable {
+		logger.Info("Deployment not yet available, requeuing to check again",
+			"requeueAfter", requeueDelayDeploymentUnavailable)
+		return ctrl.Result{RequeueAfter: requeueDelayDeploymentUnavailable}, nil
+	}
+
 	return ctrl.Result{}, nil
 }
 
-// determinePhase maps deployment status to an MCPServer phase and condition.
-func determinePhase(
+// determineReadyCondition analyzes deployment status and accepted condition to determine
+// the Ready condition.
+func determineReadyCondition(
 	deployment *appsv1.Deployment,
+	acceptedCondition metav1.Condition,
 	generation int64,
 	existingConditions []metav1.Condition,
-) (string, metav1.Condition) {
+) metav1.Condition {
+	// If configuration is not accepted, Ready=False
+	if acceptedCondition.Status == metav1.ConditionFalse {
+		condition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionFalse,
+			ReasonConfigurationInvalid,
+			"Configuration must be fixed before server can start",
+			generation,
+		)
+		preserveLastTransitionTime(&condition, existingConditions)
+		return condition
+	}
+
+	// Check if scaled to zero
+	// Note: Following Kubernetes Deployment semantics, we set Ready=True when scaled to 0.
+	// Scaling to zero is an intentional, valid desired state (not a failure).
+	// This prevents false alerts and aligns with core K8s resource conventions where
+	// conditions indicate "is the system in its desired state?" rather than "is it doing work?".
+	// Users can check the ScaledToZero reason or status.replicas for operational state.
+	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {
+		condition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionTrue,
+			ReasonScaledToZero,
+			"Server is ready (scaled to 0 replicas)",
+			generation,
+		)
+		preserveLastTransitionTime(&condition, existingConditions)
+		return condition
+	}
+
+	// Extract deployment conditions
 	deploymentAvailable := false
 	deploymentProgressing := false
 	deploymentReplicaFailure := false
 	var deploymentMessage string
 
-	for _, condition := range deployment.Status.Conditions {
-		switch condition.Type {
+	for _, cond := range deployment.Status.Conditions {
+		switch cond.Type {
 		case appsv1.DeploymentAvailable:
-			if condition.Status == corev1.ConditionTrue {
+			if cond.Status == corev1.ConditionTrue {
 				deploymentAvailable = true
 			}
 		case appsv1.DeploymentProgressing:
-			if condition.Status == corev1.ConditionTrue {
+			if cond.Status == corev1.ConditionTrue {
 				deploymentProgressing = true
 			}
-			if condition.Status == corev1.ConditionFalse {
-				deploymentMessage = condition.Message
+			if cond.Status == corev1.ConditionFalse {
+				deploymentMessage = cond.Message
 			}
 		case appsv1.DeploymentReplicaFailure:
-			if condition.Status == corev1.ConditionTrue {
+			if cond.Status == corev1.ConditionTrue {
 				deploymentReplicaFailure = true
-				deploymentMessage = condition.Message
+				deploymentMessage = cond.Message
 			}
 		}
 	}
 
+	// Deployment has no status yet
 	if len(deployment.Status.Conditions) == 0 && deployment.Status.ReadyReplicas == 0 {
-		condition := metav1.Condition{
-			Type:               "Ready",
-			Status:             metav1.ConditionFalse,
-			Reason:             "DeploymentPending",
-			Message:            "Waiting for Deployment to report status",
-			ObservedGeneration: generation,
-			LastTransitionTime: metav1.Now(),
-		}
-
+		condition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionUnknown,
+			ReasonInitializing,
+			"Waiting for Deployment to report status",
+			generation,
+		)
 		preserveLastTransitionTime(&condition, existingConditions)
-
-		return PhasePending, condition
+		return condition
 	}
 
+	// Deployment hasn't processed the latest spec yet
+	// Only check if ObservedGeneration is non-zero (0 is the initial state)
+	if deployment.Status.ObservedGeneration > 0 && deployment.Status.ObservedGeneration < deployment.Generation {
+		condition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionFalse,
+			ReasonDeploymentUnavailable,
+			"Deployment is processing spec update",
+			generation,
+		)
+		preserveLastTransitionTime(&condition, existingConditions)
+		return condition
+	}
+
+	// At least one replica is ready - SUCCESS
 	if deploymentAvailable && deployment.Status.ReadyReplicas > 0 {
-		condition := metav1.Condition{
-			Type:               "Ready",
-			Status:             metav1.ConditionTrue,
-			Reason:             "DeploymentAvailable",
-			Message:            "Deployment is available and ready",
-			ObservedGeneration: generation,
-			LastTransitionTime: metav1.Now(),
-		}
-
+		message := fmt.Sprintf("MCP server is ready (%d of %d instances healthy)",
+			deployment.Status.ReadyReplicas,
+			ptr.Deref(deployment.Spec.Replicas, 1))
+		condition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionTrue,
+			ReasonAvailable,
+			message,
+			generation,
+		)
 		preserveLastTransitionTime(&condition, existingConditions)
-
-		return PhaseRunning, condition
+		return condition
 	}
 
+	// Deployment exists but no replicas ready - FAILURE
+	// This covers: ImagePullBackOff, CrashLoop, OOM, Security errors, Probe failures, etc.
 	if deploymentReplicaFailure || (!deploymentProgressing && !deploymentAvailable) {
-		message := "Deployment failed"
-		if deploymentMessage != "" {
-			message = deploymentMessage
-		}
-
-		condition := metav1.Condition{
-			Type:               "Ready",
-			Status:             metav1.ConditionFalse,
-			Reason:             "DeploymentFailed",
-			Message:            message,
-			ObservedGeneration: generation,
-			LastTransitionTime: metav1.Now(),
-		}
-
+		message := analyzeDeploymentFailure(deploymentMessage)
+		condition := newCondition(
+			ConditionTypeReady,
+			metav1.ConditionFalse,
+			ReasonDeploymentUnavailable,
+			message,
+			generation,
+		)
 		preserveLastTransitionTime(&condition, existingConditions)
-
-		return PhaseFailed, condition
+		return condition
 	}
 
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             "DeploymentProgressing",
-		Message:            "Deployment is progressing",
-		ObservedGeneration: generation,
-		LastTransitionTime: metav1.Now(),
-	}
-
+	// Still progressing (no replicas ready yet)
+	condition := newCondition(
+		ConditionTypeReady,
+		metav1.ConditionFalse,
+		ReasonDeploymentUnavailable,
+		"Waiting for instances to become healthy",
+		generation,
+	)
 	preserveLastTransitionTime(&condition, existingConditions)
-
-	return PhasePending, condition
+	return condition
 }
 
 // reconcileDeployment creates or updates the Deployment for the MCPServer
@@ -226,10 +389,9 @@ func (r *MCPServerReconciler) reconcileDeployment(
 ) (*appsv1.Deployment, error) {
 	logger := log.FromContext(ctx)
 
-	deployment, err := r.createDeployment(ctx, mcpServer)
+	deployment, err := r.createDeployment(mcpServer)
 	if err != nil {
 		logger.Error(err, "Failed to create Deployment")
-		r.updateStatusFailed(ctx, mcpServer, "Failed to create Deployment")
 		return nil, err
 	}
 	if err := controllerutil.SetControllerReference(mcpServer, deployment, r.Scheme); err != nil {
@@ -245,13 +407,12 @@ func (r *MCPServerReconciler) reconcileDeployment(
 			logger.Error(err, "Failed to create Deployment")
 			return nil, err
 		}
-		if err := r.Get(ctx, client.ObjectKey{
-			Name: deployment.Name, Namespace: deployment.Namespace,
-		}, existingDeployment); err != nil {
-			logger.Error(err, "Failed to get newly created Deployment")
-			return nil, err
-		}
-		return existingDeployment, nil
+		// Return the deployment object we just created.
+		// Don't try to Get it immediately - this can cause a race condition
+		// where the API server hasn't fully processed the creation yet.
+		// The deployment status will be empty, which is fine - the Ready condition
+		// will be set to Unknown/Initializing, and we'll requeue to check again.
+		return deployment, nil
 	} else if err != nil {
 		logger.Error(err, "Failed to get Deployment")
 		return nil, err
@@ -289,6 +450,13 @@ func (r *MCPServerReconciler) reconcileDeployment(
 			logger.Error(err, "Failed to update Deployment")
 			return nil, err
 		}
+		// Re-fetch deployment to get current status after update
+		if err := r.Get(ctx, client.ObjectKey{
+			Name: existingDeployment.Name, Namespace: existingDeployment.Namespace,
+		}, existingDeployment); err != nil {
+			logger.Error(err, "Failed to get updated Deployment")
+			return nil, err
+		}
 	} else {
 		logger.Info("Deployment already exists and is up to date", "name", deployment.Name)
 	}
@@ -297,7 +465,7 @@ func (r *MCPServerReconciler) reconcileDeployment(
 }
 
 // createDeployment creates a Deployment for the MCPServer
-func (r *MCPServerReconciler) createDeployment(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer) (*appsv1.Deployment, error) {
+func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer) (*appsv1.Deployment, error) {
 	// Validate source type and extract image reference
 	var imageRef string
 	switch mcpServer.Spec.Source.Type {
@@ -342,9 +510,6 @@ func (r *MCPServerReconciler) createDeployment(ctx context.Context, mcpServer *m
 		container.Env = mcpServer.Spec.Config.Env
 	}
 	if len(mcpServer.Spec.Config.EnvFrom) > 0 {
-		if err := r.validateEnvFrom(ctx, mcpServer); err != nil {
-			return nil, err
-		}
 		container.EnvFrom = mcpServer.Spec.Config.EnvFrom
 	}
 
@@ -373,10 +538,7 @@ func (r *MCPServerReconciler) createDeployment(ctx context.Context, mcpServer *m
 	}
 
 	// Process storage mounts
-	volumes, volumeMounts, err := r.processStorageMounts(ctx, mcpServer)
-	if err != nil {
-		return nil, err
-	}
+	volumes, volumeMounts := r.processStorageMounts(mcpServer)
 	container.VolumeMounts = volumeMounts
 
 	deployment := &appsv1.Deployment{
@@ -414,41 +576,11 @@ func (r *MCPServerReconciler) createDeployment(ctx context.Context, mcpServer *m
 	return deployment, nil
 }
 
-// validateEnvFrom verifies that referenced ConfigMaps and Secrets exist for non-optional envFrom entries.
-func (r *MCPServerReconciler) validateEnvFrom(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer) error {
-	for i, envFrom := range mcpServer.Spec.Config.EnvFrom {
-		if ref := envFrom.ConfigMapRef; ref != nil {
-			if ref.Optional == nil || !*ref.Optional {
-				configMap := &corev1.ConfigMap{}
-				if err := r.Get(ctx, client.ObjectKey{
-					Name:      ref.Name,
-					Namespace: mcpServer.Namespace,
-				}, configMap); err != nil {
-					return fmt.Errorf("failed to get ConfigMap %s for envFrom at index %d: %w", ref.Name, i, err)
-				}
-			}
-		}
-		if ref := envFrom.SecretRef; ref != nil {
-			if ref.Optional == nil || !*ref.Optional {
-				secret := &corev1.Secret{}
-				if err := r.Get(ctx, client.ObjectKey{
-					Name:      ref.Name,
-					Namespace: mcpServer.Namespace,
-				}, secret); err != nil {
-					return fmt.Errorf("failed to get Secret %s for envFrom at index %d: %w", ref.Name, i, err)
-				}
-			}
-		}
-	}
-	return nil
-}
-
-// processStorageMounts builds volumes and volume mounts from the MCPServer storage configuration,
-// validating that referenced ConfigMaps and Secrets exist for non-optional entries.
+// processStorageMounts builds volumes and volume mounts from the MCPServer storage configuration.
+// Validation of referenced ConfigMaps and Secrets is done in setAcceptedCondition.
 func (r *MCPServerReconciler) processStorageMounts(
-	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
-) ([]corev1.Volume, []corev1.VolumeMount, error) {
+) ([]corev1.Volume, []corev1.VolumeMount) {
 	volumes := make([]corev1.Volume, 0, len(mcpServer.Spec.Config.Storage))
 	volumeMounts := make([]corev1.VolumeMount, 0, len(mcpServer.Spec.Config.Storage))
 
@@ -484,53 +616,20 @@ func (r *MCPServerReconciler) processStorageMounts(
 
 		switch storage.Source.Type {
 		case mcpv1alpha1.StorageTypeConfigMap:
-			if storage.Source.ConfigMap == nil {
-				return nil, nil, fmt.Errorf("configMap must be set when type is ConfigMap for storage mount at index %d", i)
-			}
-			if storage.Source.ConfigMap.Name == "" {
-				return nil, nil, fmt.Errorf("configMap name must not be empty for storage mount at index %d", i)
-			}
-			if storage.Source.ConfigMap.Optional == nil || !*storage.Source.ConfigMap.Optional {
-				configMap := &corev1.ConfigMap{}
-				if err := r.Get(ctx, client.ObjectKey{
-					Name:      storage.Source.ConfigMap.Name,
-					Namespace: mcpServer.Namespace,
-				}, configMap); err != nil {
-					return nil, nil, fmt.Errorf("failed to get ConfigMap %s for storage mount at index %d: %w", storage.Source.ConfigMap.Name, i, err)
-				}
-			}
+			// Validation already done in setAcceptedCondition
 			volume.ConfigMap = storage.Source.ConfigMap
 		case mcpv1alpha1.StorageTypeSecret:
-			if storage.Source.Secret == nil {
-				return nil, nil, fmt.Errorf("secret must be set when type is Secret for storage mount at index %d", i)
-			}
-			if storage.Source.Secret.SecretName == "" {
-				return nil, nil, fmt.Errorf("secret name must not be empty for storage mount at index %d", i)
-			}
-			if storage.Source.Secret.Optional == nil || !*storage.Source.Secret.Optional {
-				secret := &corev1.Secret{}
-				if err := r.Get(ctx, client.ObjectKey{
-					Name:      storage.Source.Secret.SecretName,
-					Namespace: mcpServer.Namespace,
-				}, secret); err != nil {
-					return nil, nil, fmt.Errorf("failed to get Secret %s for storage mount at index %d: %w", storage.Source.Secret.SecretName, i, err)
-				}
-			}
+			// Validation already done in setAcceptedCondition
 			volume.Secret = storage.Source.Secret
 		case mcpv1alpha1.StorageTypeEmptyDir:
-			if storage.Source.EmptyDir == nil {
-				return nil, nil, fmt.Errorf("emptyDir must be set when type is EmptyDir for storage mount at index %d", i)
-			}
-			// No existence validation needed - EmptyDir is created by Kubernetes
+			// No validation needed - EmptyDir is created by Kubernetes
 			volume.EmptyDir = storage.Source.EmptyDir
-		default:
-			return nil, nil, fmt.Errorf("unsupported storage type %s at index %d", storage.Source.Type, i)
 		}
 
 		volumes = append(volumes, volume)
 	}
 
-	return volumes, volumeMounts, nil
+	return volumes, volumeMounts
 }
 
 // reconcileService creates or updates the Service for the MCPServer.
@@ -603,37 +702,6 @@ func (r *MCPServerReconciler) createService(mcpServer *mcpv1alpha1.MCPServer) *c
 	return service
 }
 
-// updateStatusFailed updates the MCPServer status to Failed
-func (r *MCPServerReconciler) updateStatusFailed(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, message string) {
-	condition := metav1.Condition{
-		Type:               "Ready",
-		Status:             metav1.ConditionFalse,
-		Reason:             "ReconciliationFailed",
-		Message:            message,
-		ObservedGeneration: mcpServer.Generation,
-		LastTransitionTime: metav1.Now(),
-	}
-
-	preserveLastTransitionTime(&condition, mcpServer.Status.Conditions)
-
-	status := acv1alpha1.MCPServerStatus().
-		WithPhase(PhaseFailed).
-		WithServiceName(mcpServer.Name).
-		WithConditions(conditionToAC(condition))
-
-	if mcpServer.Status.DeploymentName != "" {
-		status = status.WithDeploymentName(mcpServer.Status.DeploymentName)
-	}
-
-	if mcpServer.Status.Address != nil {
-		status = status.WithAddress(acv1alpha1.MCPServerAddress().WithURL(mcpServer.Status.Address.URL))
-	}
-
-	if err := r.applyStatus(ctx, mcpServer, status); err != nil {
-		log.FromContext(ctx).Error(err, "Failed to update MCPServer status to Failed")
-	}
-}
-
 func (r *MCPServerReconciler) applyStatus(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
@@ -674,6 +742,283 @@ func defaultContainerSecurityContext() *corev1.SecurityContext {
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}
+}
+
+// newCondition creates a new metav1.Condition with the current timestamp.
+func newCondition(
+	condType string,
+	status metav1.ConditionStatus,
+	reason string,
+	message string,
+	observedGeneration int64,
+) metav1.Condition {
+	return metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: metav1.Now(),
+	}
+}
+
+// analyzeDeploymentFailure examines the deployment message to build a detailed message
+// about why pods are not healthy. Returns a message with specifics.
+func analyzeDeploymentFailure(deploymentMessage string) string {
+	if deploymentMessage == "" {
+		return "No healthy instances available"
+	}
+
+	// Extract the most relevant error information
+	msg := deploymentMessage
+
+	// Common patterns - extract the key info
+	if strings.Contains(msg, "ImagePullBackOff") || strings.Contains(msg, "ErrImagePull") {
+		return fmt.Sprintf("No healthy instances: ImagePullBackOff - %s", msg)
+	}
+	if strings.Contains(msg, "runAsNonRoot") || strings.Contains(msg, "CreateContainerConfigError") {
+		return fmt.Sprintf("No healthy instances: CreateContainerConfigError - %s", msg)
+	}
+	if strings.Contains(msg, "OOMKilled") {
+		return fmt.Sprintf("No healthy instances: OOMKilled - %s", msg)
+	}
+	if strings.Contains(msg, "CrashLoopBackOff") {
+		return fmt.Sprintf("No healthy instances: CrashLoopBackOff - %s", msg)
+	}
+	if strings.Contains(msg, "Liveness probe failed") || strings.Contains(msg, "Readiness probe failed") {
+		return fmt.Sprintf("No healthy instances: Probe failed - %s", msg)
+	}
+
+	// Generic failure
+	return fmt.Sprintf("No healthy instances: %s", msg)
+}
+
+// validateStorageMount validates a single storage mount configuration.
+// Returns an error condition and false if validation fails, otherwise returns zero condition and true.
+func (r *MCPServerReconciler) validateStorageMount(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+	storage mcpv1alpha1.StorageMount,
+	index int,
+) (metav1.Condition, bool) {
+	switch storage.Source.Type {
+	case mcpv1alpha1.StorageTypeConfigMap:
+		if storage.Source.ConfigMap == nil {
+			return newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				ReasonInvalid,
+				fmt.Sprintf("ConfigMap must be set for storage mount at index %d", index),
+				mcpServer.Generation,
+			), false
+		}
+		if storage.Source.ConfigMap.Name == "" {
+			return newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				ReasonInvalid,
+				fmt.Sprintf("ConfigMap name must not be empty for storage mount at index %d", index),
+				mcpServer.Generation,
+			), false
+		}
+		// Skip validation if optional
+		if storage.Source.ConfigMap.Optional != nil && *storage.Source.ConfigMap.Optional {
+			return metav1.Condition{}, true
+		}
+		// Validate ConfigMap exists
+		configMap := &corev1.ConfigMap{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Name:      storage.Source.ConfigMap.Name,
+			Namespace: mcpServer.Namespace,
+		}, configMap); err != nil {
+			if apierrors.IsNotFound(err) {
+				return newCondition(
+					ConditionTypeAccepted,
+					metav1.ConditionFalse,
+					ReasonInvalid,
+					fmt.Sprintf("ConfigMap '%s' not found in namespace '%s'",
+						storage.Source.ConfigMap.Name, mcpServer.Namespace),
+					mcpServer.Generation,
+				), false
+			}
+			// Other errors (permissions, etc.) - still mark as not accepted
+			return newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				ReasonInvalid,
+				fmt.Sprintf("Failed to validate ConfigMap '%s': %v",
+					storage.Source.ConfigMap.Name, err),
+				mcpServer.Generation,
+			), false
+		}
+
+	case mcpv1alpha1.StorageTypeSecret:
+		if storage.Source.Secret == nil {
+			return newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				ReasonInvalid,
+				fmt.Sprintf("Secret must be set for storage mount at index %d", index),
+				mcpServer.Generation,
+			), false
+		}
+		if storage.Source.Secret.SecretName == "" {
+			return newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				ReasonInvalid,
+				fmt.Sprintf("Secret name must not be empty for storage mount at index %d", index),
+				mcpServer.Generation,
+			), false
+		}
+		// Skip validation if optional
+		if storage.Source.Secret.Optional != nil && *storage.Source.Secret.Optional {
+			return metav1.Condition{}, true
+		}
+		// Validate Secret exists
+		secret := &corev1.Secret{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Name:      storage.Source.Secret.SecretName,
+			Namespace: mcpServer.Namespace,
+		}, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				return newCondition(
+					ConditionTypeAccepted,
+					metav1.ConditionFalse,
+					ReasonInvalid,
+					fmt.Sprintf("Secret '%s' not found in namespace '%s'",
+						storage.Source.Secret.SecretName, mcpServer.Namespace),
+					mcpServer.Generation,
+				), false
+			}
+			return newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				ReasonInvalid,
+				fmt.Sprintf("Failed to validate Secret '%s': %v",
+					storage.Source.Secret.SecretName, err),
+				mcpServer.Generation,
+			), false
+		}
+
+	case mcpv1alpha1.StorageTypeEmptyDir:
+		// Validate EmptyDir configuration is present
+		if storage.Source.EmptyDir == nil {
+			return newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				ReasonInvalid,
+				fmt.Sprintf("EmptyDir must be set for storage mount at index %d", index),
+				mcpServer.Generation,
+			), false
+		}
+
+	default:
+		// Unknown/unsupported storage type
+		return newCondition(
+			ConditionTypeAccepted,
+			metav1.ConditionFalse,
+			ReasonInvalid,
+			fmt.Sprintf("Unsupported storage type '%s' at index %d", storage.Source.Type, index),
+			mcpServer.Generation,
+		), false
+	}
+	return metav1.Condition{}, true
+}
+
+// validateEnvFrom validates a single envFrom configuration.
+// Returns an error condition and false if validation fails, otherwise returns zero condition and true.
+func (r *MCPServerReconciler) validateEnvFrom(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+	envFrom corev1.EnvFromSource,
+	index int,
+) (metav1.Condition, bool) {
+	if ref := envFrom.ConfigMapRef; ref != nil {
+		if ref.Optional == nil || !*ref.Optional {
+			configMap := &corev1.ConfigMap{}
+			if err := r.Get(ctx, client.ObjectKey{
+				Name:      ref.Name,
+				Namespace: mcpServer.Namespace,
+			}, configMap); err != nil {
+				if apierrors.IsNotFound(err) {
+					return newCondition(
+						ConditionTypeAccepted,
+						metav1.ConditionFalse,
+						ReasonInvalid,
+						fmt.Sprintf("ConfigMap '%s' (envFrom index %d) not found in namespace '%s'",
+							ref.Name, index, mcpServer.Namespace),
+						mcpServer.Generation,
+					), false
+				}
+				return newCondition(
+					ConditionTypeAccepted,
+					metav1.ConditionFalse,
+					ReasonInvalid,
+					fmt.Sprintf("Failed to validate ConfigMap '%s': %v", ref.Name, err),
+					mcpServer.Generation,
+				), false
+			}
+		}
+	}
+	if ref := envFrom.SecretRef; ref != nil {
+		if ref.Optional == nil || !*ref.Optional {
+			secret := &corev1.Secret{}
+			if err := r.Get(ctx, client.ObjectKey{
+				Name:      ref.Name,
+				Namespace: mcpServer.Namespace,
+			}, secret); err != nil {
+				if apierrors.IsNotFound(err) {
+					return newCondition(
+						ConditionTypeAccepted,
+						metav1.ConditionFalse,
+						ReasonInvalid,
+						fmt.Sprintf("Secret '%s' (envFrom index %d) not found in namespace '%s'",
+							ref.Name, index, mcpServer.Namespace),
+						mcpServer.Generation,
+					), false
+				}
+				return newCondition(
+					ConditionTypeAccepted,
+					metav1.ConditionFalse,
+					ReasonInvalid,
+					fmt.Sprintf("Failed to validate Secret '%s': %v", ref.Name, err),
+					mcpServer.Generation,
+				), false
+			}
+		}
+	}
+	return metav1.Condition{}, true
+}
+
+// setAcceptedCondition validates the MCPServer configuration and sets the Accepted condition.
+// Returns the condition and a boolean indicating if configuration is valid.
+func (r *MCPServerReconciler) setAcceptedCondition(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+) (metav1.Condition, bool) {
+	// Validate storage mounts
+	for i, storage := range mcpServer.Spec.Config.Storage {
+		if condition, valid := r.validateStorageMount(ctx, mcpServer, storage, i); !valid {
+			return condition, false
+		}
+	}
+
+	// Validate envFrom references
+	for i, envFrom := range mcpServer.Spec.Config.EnvFrom {
+		if condition, valid := r.validateEnvFrom(ctx, mcpServer, envFrom, i); !valid {
+			return condition, false
+		}
+	}
+
+	// All validation passed
+	return newCondition(
+		ConditionTypeAccepted,
+		metav1.ConditionTrue,
+		ReasonValid,
+		"Configuration is valid",
+		mcpServer.Generation,
+	), true
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -653,6 +653,7 @@ func (r *MCPServerReconciler) reconcileService(
 			logger.Error(err, "Failed to create Service")
 			return err
 		}
+		return nil
 	} else if err != nil {
 		logger.Error(err, "Failed to get Service")
 		return err

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -22,6 +22,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -885,6 +886,322 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
 		})
+
+		It("should correctly handle MCPServer status after spec update", func() {
+			resource := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+					Runtime: mcpv1alpha1.RuntimeConfig{
+						Replicas: ptr.To(int32(1)),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Initial reconciliation creates deployment with 1 replica")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+
+			By("Simulating deployment becoming available")
+			deployment.Status.Replicas = 1
+			deployment.Status.ReadyReplicas = 1
+			deployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   appsv1.DeploymentProgressing,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+			By("Reconciling to update MCPServer status to Ready=True")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+
+			By("Updating replicas to 3")
+			mcpServer.Spec.Runtime.Replicas = ptr.To(int32(3))
+			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+			By("Reconciling after spec update")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying deployment spec was updated")
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(3)))
+
+			By("Verifying MCPServer status reflects current deployment state")
+			// This is the critical test that would have caught the bug:
+			// Without the fix, reconcileDeployment would return deployment with stale status,
+			// causing determineReadyCondition to incorrectly report DeploymentUnavailable
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			// The deployment is still available (we haven't changed its status),
+			// so Ready should remain True, not incorrectly flip to False
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+		})
+	})
+
+	Context("When Deployment is unavailable", func() {
+		const resourceName = "test-resource-requeue"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			resource := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should requeue reconciliation when Deployment is unavailable", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Initial reconciliation creates deployment")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Simulating deployment being unavailable (progressing but not ready)")
+			deployment.Status.Replicas = 1
+			deployment.Status.ReadyReplicas = 0
+			deployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentProgressing,
+					Status: corev1.ConditionTrue,
+					Reason: "NewReplicaSetCreated",
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+			By("Reconciling should set Ready=False and requeue")
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCondition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		})
+
+		It("should NOT requeue when Deployment becomes available", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Initial reconciliation creates deployment")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Simulating deployment becoming available")
+			deployment.Status.Replicas = 1
+			deployment.Status.ReadyReplicas = 1
+			deployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   appsv1.DeploymentProgressing,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+			By("Reconciling should set Ready=True and NOT requeue")
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should NOT requeue when available
+			Expect(result.RequeueAfter).To(BeZero())
+
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+		})
+
+		It("should eventually reach Ready=True after Deployment becomes available", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Initial reconciliation creates deployment")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deployment starts unavailable")
+			deployment.Status.Replicas = 1
+			deployment.Status.ReadyReplicas = 0
+			deployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentProgressing,
+					Status: corev1.ConditionTrue,
+					Reason: "NewReplicaSetCreated",
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+			By("First reconciliation: unavailable, requeue")
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+
+			By("Deployment becomes available")
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment.Status.ReadyReplicas = 1
+			deployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   appsv1.DeploymentProgressing,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+			By("Second reconciliation: available, no requeue, Ready=True")
+			result, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+		})
 	})
 
 	Context("When reconciling a resource with envFrom", func() {
@@ -1064,7 +1381,7 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 		})
 
-		It("should fail reconciliation and set status to Failed when envFrom references a missing ConfigMap", func() {
+		It("should set Accepted=False when envFrom references a missing ConfigMap", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -1073,8 +1390,8 @@ var _ = Describe("MCPServer Controller", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get ConfigMap nonexistent-configmap for envFrom"))
+			// No error should be returned - configuration issues are reported via status conditions
+			Expect(err).NotTo(HaveOccurred())
 
 			// Verify no Deployment was created
 			deployment := &appsv1.Deployment{}
@@ -1084,14 +1401,20 @@ var _ = Describe("MCPServer Controller", func() {
 			}, deployment)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 
-			// Verify MCPServer status is Failed with the correct condition
+			// Verify MCPServer status has correct conditions
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Failed"))
+
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal(ReasonInvalid))
+			Expect(acceptedCondition.Message).To(ContainSubstring("nonexistent-configmap"))
+
 			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCondition.Reason).To(Equal("ReconciliationFailed"))
+			Expect(readyCondition.Reason).To(Equal(ReasonConfigurationInvalid))
 		})
 
 		It("should skip validation when envFrom reference is optional", func() {
@@ -1163,7 +1486,7 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 		})
 
-		It("should fail reconciliation and set status to Failed when envFrom references a missing Secret", func() {
+		It("should set Accepted=False when envFrom references a missing Secret", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -1172,8 +1495,8 @@ var _ = Describe("MCPServer Controller", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get Secret nonexistent-secret for envFrom"))
+			// No error should be returned - configuration issues are reported via status conditions
+			Expect(err).NotTo(HaveOccurred())
 
 			// Verify no Deployment was created
 			deployment := &appsv1.Deployment{}
@@ -1183,14 +1506,20 @@ var _ = Describe("MCPServer Controller", func() {
 			}, deployment)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 
-			// Verify MCPServer status is Failed with the correct condition
+			// Verify MCPServer status has correct conditions
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Failed"))
+
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal(ReasonInvalid))
+			Expect(acceptedCondition.Message).To(ContainSubstring("nonexistent-secret"))
+
 			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCondition.Reason).To(Equal("ReconciliationFailed"))
+			Expect(readyCondition.Reason).To(Equal(ReasonConfigurationInvalid))
 		})
 
 		It("should skip validation when envFrom Secret reference is optional", func() {
@@ -1215,6 +1544,42 @@ var _ = Describe("MCPServer Controller", func() {
 				Name:      resourceName,
 				Namespace: "default",
 			}, deployment)).To(Succeed())
+		})
+
+		It("should preserve Accepted condition LastTransitionTime across reconciliations", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// First reconciliation - should set Accepted condition
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Get the initial Accepted condition timestamp
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			initialTimestamp := acceptedCondition.LastTransitionTime
+
+			// Wait a bit to ensure time difference would be detectable
+			time.Sleep(100 * time.Millisecond)
+
+			// Second reconciliation - Accepted status hasn't changed, timestamp should be preserved
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the LastTransitionTime was preserved
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			acceptedCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.LastTransitionTime).To(Equal(initialTimestamp),
+				"Accepted condition LastTransitionTime should be preserved when status doesn't change")
 		})
 	})
 })
@@ -1474,14 +1839,6 @@ var _ = Describe("MCPServer Controller - Service Update", func() {
 	})
 })
 
-var _ = Describe("Phase Constants", func() {
-	It("should define expected phase values", func() {
-		Expect(PhasePending).To(Equal("Pending"))
-		Expect(PhaseRunning).To(Equal("Running"))
-		Expect(PhaseFailed).To(Equal("Failed"))
-	})
-})
-
 var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 	const resourceName = "test-reconcile-deployment"
 
@@ -1615,6 +1972,154 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 	})
 })
 
+var _ = Describe("MCPServer Controller - Deployment Reconciliation Failures", func() {
+	const resourceName = "test-deployment-failure"
+
+	ctx := context.Background()
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	BeforeEach(func() {
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: "default",
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{
+					Port: 8080,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("should update status with DeploymentUnavailable when deployment creation fails", func() {
+		By("Creating interceptor that returns error on Deployment Create")
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return fmt.Errorf("simulated deployment creation failure")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+
+		deploymentFailureReconciler := &MCPServerReconciler{
+			Client: interceptedClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		By("Reconciling with deployment creation failure")
+		_, err = deploymentFailureReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated deployment creation failure"))
+
+		By("Verifying status is updated with DeploymentUnavailable")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(acceptedCondition.Reason).To(Equal("Valid"))
+
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		Expect(readyCondition.Message).To(ContainSubstring("Failed to reconcile Deployment"))
+		Expect(readyCondition.Message).To(ContainSubstring("simulated deployment creation failure"))
+	})
+
+	It("should update status with DeploymentUnavailable when deployment update fails", func() {
+		By("Initial reconcile to create resources")
+		initialReconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying deployment was created")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      resourceName,
+			Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		By("Creating interceptor that returns error on Deployment Update")
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return fmt.Errorf("simulated deployment update failure")
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		})
+
+		deploymentFailureReconciler := &MCPServerReconciler{
+			Client: interceptedClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		By("Updating MCPServer spec to trigger deployment reconciliation")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		mcpServer.Spec.Config.Env = []corev1.EnvVar{{Name: "TEST_VAR", Value: "test_value"}}
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		By("Reconciling with deployment update failure")
+		_, err = deploymentFailureReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated deployment update failure"))
+
+		By("Verifying status is updated with DeploymentUnavailable")
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(acceptedCondition.Reason).To(Equal("Valid"))
+
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		Expect(readyCondition.Message).To(ContainSubstring("Failed to reconcile Deployment"))
+		Expect(readyCondition.Message).To(ContainSubstring("simulated deployment update failure"))
+	})
+})
+
 var _ = Describe("MCPServer Controller - reconcileService", func() {
 	const resourceName = "test-reconcile-service"
 
@@ -1688,21 +2193,185 @@ var _ = Describe("MCPServer Controller - reconcileService", func() {
 	})
 })
 
-var _ = Describe("determinePhase", func() {
-	var generation int64 = 1
+var _ = Describe("MCPServer Controller - Service Reconciliation Failures", func() {
+	const resourceName = "test-service-failure"
 
-	It("should return Pending when deployment has no conditions and no ready replicas", func() {
+	ctx := context.Background()
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	BeforeEach(func() {
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: "default",
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{
+					Port: 8080,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("should update status with ServiceUnavailable when service creation fails", func() {
+		By("Creating interceptor that returns error on Service Create")
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Service); ok {
+					return fmt.Errorf("simulated service creation failure")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+
+		serviceFailureReconciler := &MCPServerReconciler{
+			Client: interceptedClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		By("Reconciling with service creation failure")
+		_, err = serviceFailureReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated service creation failure"))
+
+		By("Verifying status is updated with ServiceUnavailable")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(acceptedCondition.Reason).To(Equal("Valid"))
+
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonServiceUnavailable))
+		Expect(readyCondition.Message).To(ContainSubstring("Failed to reconcile Service"))
+		Expect(readyCondition.Message).To(ContainSubstring("simulated service creation failure"))
+
+		Expect(mcpServer.Status.DeploymentName).To(Equal(resourceName))
+	})
+
+	It("should update status with ServiceUnavailable when service update fails", func() {
+		By("Initial reconcile to create resources")
+		initialReconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying service was created")
+		svc := &corev1.Service{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      resourceName,
+			Namespace: "default",
+		}, svc)).To(Succeed())
+
+		By("Creating interceptor that returns error on Service Update")
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*corev1.Service); ok {
+					return fmt.Errorf("simulated service update failure")
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		})
+
+		serviceFailureReconciler := &MCPServerReconciler{
+			Client: interceptedClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		By("Updating MCPServer spec to trigger service reconciliation")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		mcpServer.Spec.Config.Port = 9090
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		By("Reconciling with service update failure")
+		_, err = serviceFailureReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated service update failure"))
+
+		By("Verifying status is updated with ServiceUnavailable")
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(acceptedCondition.Reason).To(Equal("Valid"))
+
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonServiceUnavailable))
+		Expect(readyCondition.Message).To(ContainSubstring("Failed to reconcile Service"))
+		Expect(readyCondition.Message).To(ContainSubstring("simulated service update failure"))
+
+		Expect(mcpServer.Status.DeploymentName).To(Equal(resourceName))
+	})
+})
+
+var _ = Describe("determineReadyCondition", func() {
+	var generation int64 = 1
+	var acceptedCondition metav1.Condition
+
+	BeforeEach(func() {
+		// Default to valid configuration
+		acceptedCondition = metav1.Condition{
+			Type:   ConditionTypeAccepted,
+			Status: metav1.ConditionTrue,
+			Reason: ReasonValid,
+		}
+	})
+
+	It("should return Initializing when deployment has no conditions and no ready replicas", func() {
 		deployment := &appsv1.Deployment{
 			Status: appsv1.DeploymentStatus{},
 		}
-		phase, condition := determinePhase(deployment, generation, make([]metav1.Condition, 0))
-		Expect(phase).To(Equal(PhasePending))
-		Expect(condition.Reason).To(Equal("DeploymentPending"))
-		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		Expect(condition.Reason).To(Equal(ReasonInitializing))
+		Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
 	})
 
-	It("should return Running when deployment is available with ready replicas", func() {
+	It("should return Available when deployment is available with ready replicas", func() {
 		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](1),
+			},
 			Status: appsv1.DeploymentStatus{
 				ReadyReplicas: 1,
 				Conditions: []appsv1.DeploymentCondition{
@@ -1713,13 +2382,12 @@ var _ = Describe("determinePhase", func() {
 				},
 			},
 		}
-		phase, condition := determinePhase(deployment, generation, make([]metav1.Condition, 0))
-		Expect(phase).To(Equal(PhaseRunning))
-		Expect(condition.Reason).To(Equal("DeploymentAvailable"))
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		Expect(condition.Reason).To(Equal(ReasonAvailable))
 		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 	})
 
-	It("should return Failed when deployment has replica failure", func() {
+	It("should return DeploymentUnavailable when deployment has replica failure", func() {
 		deployment := &appsv1.Deployment{
 			Status: appsv1.DeploymentStatus{
 				Conditions: []appsv1.DeploymentCondition{
@@ -1731,13 +2399,12 @@ var _ = Describe("determinePhase", func() {
 				},
 			},
 		}
-		phase, condition := determinePhase(deployment, generation, make([]metav1.Condition, 0))
-		Expect(phase).To(Equal(PhaseFailed))
-		Expect(condition.Reason).To(Equal("DeploymentFailed"))
-		Expect(condition.Message).To(Equal("replica failed"))
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		Expect(condition.Message).To(ContainSubstring("replica failed"))
 	})
 
-	It("should return Pending when deployment is progressing", func() {
+	It("should return DeploymentUnavailable when deployment is progressing", func() {
 		deployment := &appsv1.Deployment{
 			Status: appsv1.DeploymentStatus{
 				Conditions: []appsv1.DeploymentCondition{
@@ -1748,9 +2415,177 @@ var _ = Describe("determinePhase", func() {
 				},
 			},
 		}
-		phase, condition := determinePhase(deployment, generation, make([]metav1.Condition, 0))
-		Expect(phase).To(Equal(PhasePending))
-		Expect(condition.Reason).To(Equal("DeploymentProgressing"))
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
+	})
+
+	It("should return ConfigurationInvalid when configuration is not accepted", func() {
+		invalidAcceptedCondition := metav1.Condition{
+			Type:   ConditionTypeAccepted,
+			Status: metav1.ConditionFalse,
+			Reason: ReasonInvalid,
+		}
+		deployment := &appsv1.Deployment{}
+		condition := determineReadyCondition(deployment, invalidAcceptedCondition, generation, make([]metav1.Condition, 0))
+		Expect(condition.Reason).To(Equal(ReasonConfigurationInvalid))
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+	})
+
+	It("should return Ready=True with ScaledToZero reason when deployment is scaled to 0 replicas", func() {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](0),
+			},
+			Status: appsv1.DeploymentStatus{
+				ReadyReplicas: 0,
+			},
+		}
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		Expect(condition.Reason).To(Equal(ReasonScaledToZero))
+		// Ready=True following Kubernetes Deployment semantics: replicas=0 is a valid desired state
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Message).To(ContainSubstring("scaled to 0 replicas"))
+	})
+
+	It("should preserve LastTransitionTime when condition status hasn't changed", func() {
+		// Create an existing condition with a specific timestamp
+		pastTime := metav1.NewTime(metav1.Now().Add(-5 * time.Minute))
+		existingConditions := []metav1.Condition{
+			{
+				Type:               ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             ReasonDeploymentUnavailable,
+				LastTransitionTime: pastTime,
+			},
+		}
+
+		// Create a deployment that would result in the same condition
+		deployment := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, existingConditions)
+
+		// The LastTransitionTime should be preserved from the existing condition
+		Expect(condition.LastTransitionTime).To(Equal(pastTime))
+	})
+
+	It("should update LastTransitionTime when condition status changes", func() {
+		// Create an existing condition with Status=False
+		pastTime := metav1.NewTime(metav1.Now().Add(-5 * time.Minute))
+		existingConditions := []metav1.Condition{
+			{
+				Type:               ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             ReasonInitializing,
+				LastTransitionTime: pastTime,
+			},
+		}
+
+		// Create a deployment that would result in Status=True (different status)
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](1),
+			},
+			Status: appsv1.DeploymentStatus{
+				ReadyReplicas: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, existingConditions)
+
+		// The LastTransitionTime should be NEW (not the past time)
+		Expect(condition.LastTransitionTime).NotTo(Equal(pastTime))
+	})
+
+	It("should handle nil replicas gracefully when deployment is available", func() {
+		// Create a deployment with nil replicas (tests the ptr.Deref fix)
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Replicas: nil, // nil replicas should default to 1 in the message
+			},
+			Status: appsv1.DeploymentStatus{
+				ReadyReplicas: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+
+		// Should succeed without panicking
+		Expect(condition.Reason).To(Equal(ReasonAvailable))
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		// Message should use default value of 1 for nil replicas
+		Expect(condition.Message).To(ContainSubstring("1 of 1 instances healthy"))
+	})
+})
+
+var _ = Describe("analyzeDeploymentFailure", func() {
+	It("should identify ImagePullBackOff errors", func() {
+		message := "Back-off pulling image \"nonexistent:latest\": ImagePullBackOff"
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(ContainSubstring("ImagePullBackOff"))
+	})
+
+	It("should identify ErrImagePull errors", func() {
+		message := "Failed to pull image: ErrImagePull"
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(ContainSubstring("ImagePullBackOff"))
+	})
+
+	It("should identify OOMKilled errors", func() {
+		message := "Container was OOMKilled"
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(ContainSubstring("OOMKilled"))
+	})
+
+	It("should identify CrashLoopBackOff errors", func() {
+		message := "Back-off restarting failed container: CrashLoopBackOff"
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(ContainSubstring("CrashLoopBackOff"))
+	})
+
+	It("should identify CreateContainerConfigError errors", func() {
+		message := "Error: container has runAsNonRoot and image will run as root: CreateContainerConfigError"
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(ContainSubstring("CreateContainerConfigError"))
+	})
+
+	It("should identify probe failures", func() {
+		message := "Liveness probe failed: HTTP probe failed"
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(ContainSubstring("Probe failed"))
+	})
+
+	It("should handle empty message", func() {
+		message := ""
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(Equal("No healthy instances available"))
+	})
+
+	It("should handle generic failures", func() {
+		message := "Some unknown error occurred"
+		result := analyzeDeploymentFailure(message)
+		Expect(result).To(ContainSubstring("No healthy instances"))
+		Expect(result).To(ContainSubstring("Some unknown error occurred"))
 	})
 })
 
@@ -2529,7 +3364,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			}
 		})
 
-		It("should fail with 'ConfigMap not found' error", func() {
+		It("should set Accepted=False with 'ConfigMap not found' message", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -2538,9 +3373,19 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get ConfigMap"))
-			Expect(err.Error()).To(ContainSubstring("nonexistent-configmap"))
+			// No error should be returned - configuration issues are reported via status conditions
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify MCPServer status has Accepted=False
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal(ReasonInvalid))
+			Expect(acceptedCondition.Message).To(ContainSubstring("nonexistent-configmap"))
+			Expect(acceptedCondition.Message).To(ContainSubstring("not found"))
 		})
 	})
 
@@ -2592,7 +3437,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			}
 		})
 
-		It("should fail with 'Secret not found' error", func() {
+		It("should set Accepted=False with 'Secret not found' message", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -2601,9 +3446,19 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get Secret"))
-			Expect(err.Error()).To(ContainSubstring("nonexistent-secret"))
+			// No error should be returned - configuration issues are reported via status conditions
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify MCPServer status has Accepted=False
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal(ReasonInvalid))
+			Expect(acceptedCondition.Message).To(ContainSubstring("nonexistent-secret"))
+			Expect(acceptedCondition.Message).To(ContainSubstring("not found"))
 		})
 	})
 
@@ -2817,7 +3672,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			}
 		})
 
-		It("should fail with 'empty ConfigMap name' error", func() {
+		It("should set Accepted=False when ConfigMap name is empty", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -2826,8 +3681,19 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("configMap name must not be empty"))
+			// No error should be returned - configuration issues are reported via status conditions
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify MCPServer status has Accepted=False
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal(ReasonInvalid))
+			Expect(acceptedCondition.Message).To(ContainSubstring("ConfigMap name must not be empty"))
+			Expect(acceptedCondition.Message).To(ContainSubstring("index 0"))
 		})
 	})
 
@@ -2879,7 +3745,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			}
 		})
 
-		It("should fail with 'empty Secret name' error", func() {
+		It("should set Accepted=False when Secret name is empty", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -2888,8 +3754,101 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("secret name must not be empty"))
+			// No error should be returned - configuration issues are reported via status conditions
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify MCPServer status has Accepted=False
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal(ReasonInvalid))
+			Expect(acceptedCondition.Message).To(ContainSubstring("Secret name must not be empty"))
+			Expect(acceptedCondition.Message).To(ContainSubstring("index 0"))
+		})
+	})
+
+	Context("setAcceptedCondition validation", func() {
+		ctx := context.Background()
+
+		It("should reject EmptyDir with nil EmptyDir configuration", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Storage: []mcpv1alpha1.StorageMount{
+							{
+								Path: "/data",
+								Source: mcpv1alpha1.StorageSource{
+									Type:     mcpv1alpha1.StorageTypeEmptyDir,
+									EmptyDir: nil, // Intentionally nil
+								},
+							},
+						},
+					},
+				},
+			}
+
+			condition, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(valid).To(BeFalse())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(ReasonInvalid))
+			Expect(condition.Message).To(ContainSubstring("EmptyDir must be set"))
+		})
+
+		It("should reject unknown storage type", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Storage: []mcpv1alpha1.StorageMount{
+							{
+								Path: "/data",
+								Source: mcpv1alpha1.StorageSource{
+									Type: "UnknownType", // Invalid storage type
+								},
+							},
+						},
+					},
+				},
+			}
+
+			condition, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(valid).To(BeFalse())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(ReasonInvalid))
+			Expect(condition.Message).To(ContainSubstring("Unsupported storage type"))
+			Expect(condition.Message).To(ContainSubstring("UnknownType"))
 		})
 	})
 
@@ -3912,17 +4871,20 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get ConfigMap recovery-configmap for envFrom"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying status is Failed")
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Failed"))
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal("Invalid"))
+			Expect(acceptedCondition.Message).To(ContainSubstring("recovery-configmap"))
 			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCondition.Reason).To(Equal("ReconciliationFailed"))
+			Expect(readyCondition.Reason).To(Equal("ConfigurationInvalid"))
 
 			By("Verifying no Deployment was created")
 			deployment := &appsv1.Deployment{}
@@ -3944,10 +4906,13 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 			By("Verifying status recovered to Pending")
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Pending"))
+			acceptedCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(acceptedCondition.Reason).To(Equal("Valid"))
 			readyCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
 			Expect(readyCondition).NotTo(BeNil())
-			Expect(readyCondition.Reason).To(Equal("DeploymentPending"))
+			Expect(readyCondition.Reason).To(Equal("Initializing"))
 
 			By("Verifying Deployment was created on recovery")
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
@@ -4014,17 +4979,20 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get Secret recovery-secret for envFrom"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying status is Failed")
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Failed"))
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal("Invalid"))
+			Expect(acceptedCondition.Message).To(ContainSubstring("recovery-secret"))
 			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(readyCondition.Reason).To(Equal("ReconciliationFailed"))
+			Expect(readyCondition.Reason).To(Equal("ConfigurationInvalid"))
 
 			By("Verifying no Deployment was created")
 			deployment := &appsv1.Deployment{}
@@ -4046,10 +5014,13 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 			By("Verifying status recovered to Pending")
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Pending"))
+			acceptedCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(acceptedCondition.Reason).To(Equal("Valid"))
 			readyCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
 			Expect(readyCondition).NotTo(BeNil())
-			Expect(readyCondition.Reason).To(Equal("DeploymentPending"))
+			Expect(readyCondition.Reason).To(Equal("Initializing"))
 
 			By("Verifying Deployment was created on recovery")
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
@@ -4120,13 +5091,20 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to get ConfigMap recovery-storage-cm for storage mount"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying status is Failed")
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Failed"))
+			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(acceptedCondition.Reason).To(Equal("Invalid"))
+			Expect(acceptedCondition.Message).To(ContainSubstring("recovery-storage-cm"))
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCondition.Reason).To(Equal("ConfigurationInvalid"))
 
 			By("Creating the missing ConfigMap")
 			configMap := &corev1.ConfigMap{
@@ -4143,7 +5121,13 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 			By("Verifying status recovered to Pending")
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			Expect(mcpServer.Status.Phase).To(Equal("Pending"))
+			acceptedCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+			Expect(acceptedCondition).NotTo(BeNil())
+			Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(acceptedCondition.Reason).To(Equal("Valid"))
+			readyCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Reason).To(Equal("Initializing"))
 
 			By("Verifying Deployment was created on recovery")
 			deployment := &appsv1.Deployment{}


### PR DESCRIPTION
Fixes #45 

Replaces the simple phase-based status (Pending, Running, Failed) with a Kubernetes-style conditions model using Accepted and Ready conditions for better observability and diagnostics.

API Changes:
- Removed Phase field ⚠️  BREAKING CHANGE
- Added ObservedGeneration field
- Added Accepted condition - validates configuration before creating resources
- Enhanced Ready condition with detailed reasons and error messages

Also changed the `kubectl` output:
- Before: Phase | Image | Age
- After: Ready | Accepted | Image | Port | Address | Age

Controller will now set proper conditions and reasons in these:
- Fail-fast configuration validation (missing ConfigMaps/Secrets)
- Detailed error categorization (ImagePullBackOff, OOMKilled, CrashLoop, probe failures, etc.)

Condition Reasons:
- Accepted: Valid, Invalid
- Ready: Available, ConfigurationInvalid, DeploymentUnavailable, ScaledToZero, Initializing