### PR TITLE
Add release process issue templates and v0.1.0 release issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-patch-release.md
+++ b/.github/ISSUE_TEMPLATE/new-patch-release.md
@@ -1,0 +1,49 @@
+---
+name: New patch release
+about: Propose a new patch release
+title: "Release v0.MINOR.PATCH"
+labels: release
+assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
+---
+
+# Release v0.MINOR.PATCH
+
+<!-- Update MINOR and PATCH throughout before submitting -->
+
+**Release branch:** `release-0.MINOR`
+
+## Changelog
+
+<!-- Summarize user-facing changes since the last patch -->
+
+## Checklist
+
+- [ ] All OWNERS must LGTM the release proposal
+- [ ] Verify the changelog above is up-to-date
+- [ ] Verify all intended cherry-picks are merged to `release-0.MINOR`
+- [ ] Update `config/manager/kustomization.yaml` on the release branch: pin
+  `newTag` to `v0.MINOR.PATCH`
+  - [ ] Submit PR against `release-0.MINOR`
+- [ ] Ensure all CI (lint, unit tests, e2e) passes on the release branch
+- [ ] An OWNER creates a signed tag:
+  ```bash
+  git tag -s -m "mcp-lifecycle-operator release v0.MINOR.PATCH" v0.MINOR.PATCH
+  ```
+- [ ] An OWNER pushes the tag:
+  ```bash
+  git push upstream v0.MINOR.PATCH
+  ```
+  This triggers Cloud Build to build and publish the staging image.
+- [ ] Submit PR to
+  [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) updating
+  `registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/images.yaml`
+  to promote the container image to production
+  - [ ] Wait for merge and verify image availability:
+    ```bash
+    crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.PATCH
+    ```
+- [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
+  with the changelog above
+- [ ] Send announcement email to `dev@kubernetes.io` with subject:
+  `[ANNOUNCE] mcp-lifecycle-operator v0.MINOR.PATCH is released`
+- [ ] Close this issue

--- a/.github/ISSUE_TEMPLATE/new-patch-release.md
+++ b/.github/ISSUE_TEMPLATE/new-patch-release.md
@@ -42,8 +42,12 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
     ```bash
     crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.PATCH
     ```
+- [ ] Generate the install manifest and include it among the release assets:
+  ```bash
+  IMG=registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.PATCH make build-installer
+  ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
-  with the changelog above
+  with the changelog above; attach `dist/install.yaml` as a release asset
 - [ ] Send announcement email to `dev@kubernetes.io` with subject:
   `[ANNOUNCE] mcp-lifecycle-operator v0.MINOR.PATCH is released`
 - [ ] Close this issue

--- a/.github/ISSUE_TEMPLATE/new-patch-release.md
+++ b/.github/ISSUE_TEMPLATE/new-patch-release.md
@@ -40,11 +40,11 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
   to promote the container image to production
   - [ ] Wait for merge and verify image availability:
     ```bash
-    crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.PATCH
+    crane manifest registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:v0.MINOR.PATCH
     ```
 - [ ] Generate the install manifest and include it among the release assets:
   ```bash
-  IMG=registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.PATCH make build-installer
+  IMG=registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:v0.MINOR.PATCH make build-installer
   ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
   with the changelog above; attach `dist/install.yaml` as a release asset

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -47,11 +47,11 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
   to promote the container image to production
   - [ ] Wait for merge and verify image availability:
     ```bash
-    crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.0
+    crane manifest registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:v0.MINOR.0
     ```
 - [ ] Generate the install manifest and include it among the release assets:
   ```bash
-  IMG=registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.0 make build-installer
+  IMG=registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:v0.MINOR.0 make build-installer
   ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
   with the changelog above; attach `dist/install.yaml` as a release asset

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -1,0 +1,57 @@
+---
+name: New release
+about: Propose a new major or minor release
+title: "Release v0.MINOR.0"
+labels: release
+assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
+---
+
+# Release v0.MINOR.0
+
+<!-- Update MINOR throughout before submitting -->
+
+**Release branch:** `release-0.MINOR`
+
+## Changelog
+
+<!-- Summarize user-facing changes since the last release -->
+
+## Checklist
+
+- [ ] All OWNERS must LGTM the release proposal
+- [ ] Verify the changelog above is up-to-date
+- [ ] Create the release branch
+  ```bash
+  git branch release-0.MINOR main
+  git push upstream release-0.MINOR
+  ```
+- [ ] Create Prow presubmit/postsubmit jobs for `release-0.MINOR` in
+  [kubernetes/test-infra](https://github.com/kubernetes/test-infra) and submit PR
+  - [ ] Wait for test-infra PR to merge
+- [ ] Verify Go version in Prow job image matches `go.mod`
+- [ ] Update `config/manager/kustomization.yaml` on the release branch: pin
+  `newTag` to `v0.MINOR.0`
+  - [ ] Submit PR against `release-0.MINOR`
+- [ ] Ensure all CI (lint, unit tests, e2e) passes on the release branch
+- [ ] An OWNER creates a signed tag:
+  ```bash
+  git tag -s -m "mcp-lifecycle-operator release v0.MINOR.0" v0.MINOR.0
+  ```
+- [ ] An OWNER pushes the tag:
+  ```bash
+  git push upstream v0.MINOR.0
+  ```
+  This triggers Cloud Build to build and publish the staging image.
+- [ ] Submit PR to
+  [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) updating
+  `registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/images.yaml`
+  to promote the container image to production
+  - [ ] Wait for merge and verify image availability:
+    ```bash
+    crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.0
+    ```
+- [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
+  with the changelog above
+- [ ] Send announcement email to `dev@kubernetes.io` with subject:
+  `[ANNOUNCE] mcp-lifecycle-operator v0.MINOR.0 is released`
+- [ ] Close this issue

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -25,9 +25,8 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
   git branch release-0.MINOR main
   git push upstream release-0.MINOR
   ```
-- [ ] Create Prow presubmit/postsubmit jobs for `release-0.MINOR` in
-  [kubernetes/test-infra](https://github.com/kubernetes/test-infra) and submit PR
-  - [ ] Wait for test-infra PR to merge
+- [ ] Verify the [postsubmit image-pushing job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-mcp-lifecycle-operator.yaml)
+  covers `release-0.MINOR` (the existing `^release-` pattern should match)
 - [ ] Verify Go version in Prow job image matches `go.mod`
 - [ ] Update `config/manager/kustomization.yaml` on the release branch: pin
   `newTag` to `v0.MINOR.0`
@@ -50,8 +49,12 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
     ```bash
     crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.0
     ```
+- [ ] Generate the install manifest and include it among the release assets:
+  ```bash
+  IMG=registry.k8s.io/mcp-lifecycle-operator:v0.MINOR.0 make build-installer
+  ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
-  with the changelog above
+  with the changelog above; attach `dist/install.yaml` as a release asset
 - [ ] Send announcement email to `dev@kubernetes.io` with subject:
   `[ANNOUNCE] mcp-lifecycle-operator v0.MINOR.0 is released`
 - [ ] Close this issue

--- a/docs/release-v0.1.0-issue.md
+++ b/docs/release-v0.1.0-issue.md
@@ -70,11 +70,11 @@ First release. Key features:
   point to the final branch tip after pinning + tagging.
   - [ ] Wait for merge and verify image availability:
     ```bash
-    crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.1.0
+    crane manifest registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:v0.1.0
     ```
 - [ ] Generate the install manifest and include it among the release assets:
   ```bash
-  IMG=registry.k8s.io/mcp-lifecycle-operator:v0.1.0 make build-installer
+  IMG=registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:v0.1.0 make build-installer
   ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
   with the changelog above; attach `dist/install.yaml` as a release asset

--- a/docs/release-v0.1.0-issue.md
+++ b/docs/release-v0.1.0-issue.md
@@ -43,10 +43,8 @@ First release. Key features:
 - [ ] Verify the changelog above is up-to-date
 - [x] Create the release branch
   `release-0.1` exists (branched at `1c39a19`), cherry-pick PR #78 merged.
-- [ ] Create Prow presubmit/postsubmit jobs for `release-0.1` in
-  [kubernetes/test-infra](https://github.com/kubernetes/test-infra) and submit PR
-  (copy from main config, adjust branch to `release-0.1`)
-  - [ ] Wait for test-infra PR to merge
+- [x] Verify the [postsubmit image-pushing job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-mcp-lifecycle-operator.yaml)
+  covers `release-0.1` — the existing `^release-` pattern matches; presubmits run on all branches
 - [ ] Verify Go version in Prow job image matches `go.mod`
   **Note:** Prow config currently uses `golang:1.24`, but `go.mod` declares `go 1.25.8`.
   This must be aligned before proceeding.
@@ -74,8 +72,12 @@ First release. Key features:
     ```bash
     crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.1.0
     ```
+- [ ] Generate the install manifest and include it among the release assets:
+  ```bash
+  IMG=registry.k8s.io/mcp-lifecycle-operator:v0.1.0 make build-installer
+  ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
-  with the changelog above
+  with the changelog above; attach `dist/install.yaml` as a release asset
 - [ ] Send announcement email to `dev@kubernetes.io` with subject:
   `[ANNOUNCE] mcp-lifecycle-operator v0.1.0 is released`
 - [ ] Close this issue

--- a/docs/release-v0.1.0-issue.md
+++ b/docs/release-v0.1.0-issue.md
@@ -1,0 +1,81 @@
+# Release v0.1.0
+
+**Release branch:** `release-0.1`
+
+## Changelog
+
+First release. Key features:
+
+**Core:**
+- Initial MCP Lifecycle Operator implementation — declarative API (`MCPServer` CRD, `v1alpha1`)
+  to deploy, manage, and roll out MCP Servers on Kubernetes
+- Reconciler manages Deployments and Services for MCPServer resources
+- Server-side apply (SSA) for all status updates
+
+**API Features:**
+- Container image, port, and args configuration
+- ConfigMap mounting with configurable path and volume name
+- Secret mounting with secretKey field support
+- Environment variables and envFrom (with secret/configmap reference validation)
+- Resource requirements and limits
+- Liveness and readiness probes
+- Storage mounts with EmptyDir support and duplicate path validation
+- Security context at pod and container level (restricted Pod Security Standard defaults)
+- Configurable replicas (including scale-to-zero)
+- Path configuration with detailed validation for routing
+- Status address URL with configurable path
+
+**Operational:**
+- Production logging by default
+- Aggregation labels on clusterroles (admin, editor, viewer)
+- CloudBuild configuration for k8s-staging image publishing
+- CI: lint, unit tests, e2e tests (pinned to commit SHAs)
+- Dependabot for automated dependency updates
+
+**Dependencies:**
+- Go 1.25.8
+- controller-runtime v0.23.3
+- Kubernetes API v0.35.2
+
+## Checklist
+
+- [ ] All OWNERS must LGTM the release proposal
+- [ ] Verify the changelog above is up-to-date
+- [x] Create the release branch
+  `release-0.1` exists (branched at `1c39a19`), cherry-pick PR #78 merged.
+- [ ] Create Prow presubmit/postsubmit jobs for `release-0.1` in
+  [kubernetes/test-infra](https://github.com/kubernetes/test-infra) and submit PR
+  (copy from main config, adjust branch to `release-0.1`)
+  - [ ] Wait for test-infra PR to merge
+- [ ] Verify Go version in Prow job image matches `go.mod`
+  **Note:** Prow config currently uses `golang:1.24`, but `go.mod` declares `go 1.25.8`.
+  This must be aligned before proceeding.
+- [ ] Update `config/manager/kustomization.yaml` on the release branch: pin
+  `newTag` to `v0.1.0`
+  - [ ] Submit PR against `release-0.1`
+- [x] Ensure all CI (lint, unit tests, e2e) passes on the release branch
+  Lint: 0 issues. Unit tests: pass (controller 81.6% coverage). Generated manifests up to date.
+- [ ] An OWNER creates a signed tag:
+  ```bash
+  git tag -s -m "mcp-lifecycle-operator release v0.1.0" v0.1.0
+  ```
+- [ ] An OWNER pushes the tag:
+  ```bash
+  git push upstream v0.1.0
+  ```
+  This triggers Cloud Build to build and publish the staging image.
+- [ ] Submit PR to
+  [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) updating
+  `registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/images.yaml`
+  to promote the container image to production
+  **Note:** An image promotion entry already exists but targets `1c39a19`. Update to
+  point to the final branch tip after pinning + tagging.
+  - [ ] Wait for merge and verify image availability:
+    ```bash
+    crane manifest registry.k8s.io/mcp-lifecycle-operator:v0.1.0
+    ```
+- [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
+  with the changelog above
+- [ ] Send announcement email to `dev@kubernetes.io` with subject:
+  `[ANNOUNCE] mcp-lifecycle-operator v0.1.0 is released`
+- [ ] Close this issue


### PR DESCRIPTION
## What

Add GitHub issue templates for the release process, adapted from kubernetes-sigs/node-feature-discovery, and prepare the v0.1.0 release issue.

## Deliverables

1. **`.github/ISSUE_TEMPLATE/new-release.md`** — Major/minor release checklist template
2. **`.github/ISSUE_TEMPLATE/new-patch-release.md`** — Patch release checklist template
3. **`docs/release-v0.1.0-issue.md`** — Pre-filled v0.1.0 release issue with current status

## Details

Templates cover the full release lifecycle:
- Owner approval and changelog verification
- Release branch creation (major/minor only)
- Prow job setup in kubernetes/test-infra
- Go version alignment check
- Version pinning in kustomization.yaml
- CI verification
- Signed git tags
- Image promotion via kubernetes/k8s.io
- GitHub release creation
- Announcement email to dev@kubernetes.io

The v0.1.0 issue document reflects current state: release branch exists, CI passes, but Prow jobs, Go version alignment, version pinning, and image promotion still need work.

See: `docs/plans/2026-04-08-v0.1-release-process-design.md`