### PR TITLE
Add ownership validation to reject foreign-owned and unowned resources

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserver.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserver.go
@@ -27,7 +27,31 @@ import (
 // MCPServerApplyConfiguration represents a declarative configuration of the MCPServer type for use
 // with apply.
 //
-// MCPServer is the Schema for the mcpservers API
+// MCPServer runs a Model Context Protocol (MCP) server in Kubernetes.
+//
+// MCPServer creates and manages a Deployment and Service to run an MCP server from a
+// container image. The MCP server exposes tools, resources, and prompts that AI applications
+// can use via the Model Context Protocol.
+//
+// Example:
+//
+// apiVersion: mcp.x-k8s.io/v1alpha1
+// kind: MCPServer
+// metadata:
+// name: example
+// spec:
+// source:
+// type: ContainerImage
+// containerImage:
+// ref: example-mcp-image
+// config:
+// port: 8080
+//
+// The controller manages Deployment and Service resources with the same name as the MCPServer,
+// using ownerReferences to establish ownership. The controller will reject updates to resources
+// owned by other controllers or resources with no controller owner (to prevent silent overwrites
+// of manually-created resources), but will adopt orphaned resources from a deleted MCPServer
+// with the same name to enable seamless recreation.
 type MCPServerApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:",inline"`
 	// metadata is a standard object metadata

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -42,3 +42,8 @@ var (
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+const (
+	// MCPServerKind is the kind name for MCPServer resources.
+	MCPServerKind = "MCPServer"
+)

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -415,7 +415,31 @@ type MCPServerStatus struct {
 // +kubebuilder:printcolumn:name="Address",type=string,JSONPath=`.status.address.url`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
-// MCPServer is the Schema for the mcpservers API
+// MCPServer runs a Model Context Protocol (MCP) server in Kubernetes.
+//
+// MCPServer creates and manages a Deployment and Service to run an MCP server from a
+// container image. The MCP server exposes tools, resources, and prompts that AI applications
+// can use via the Model Context Protocol.
+//
+// Example:
+//
+//	apiVersion: mcp.x-k8s.io/v1alpha1
+//	kind: MCPServer
+//	metadata:
+//	  name: example
+//	spec:
+//	  source:
+//	    type: ContainerImage
+//	    containerImage:
+//	      ref: example-mcp-image
+//	  config:
+//	    port: 8080
+//
+// The controller manages Deployment and Service resources with the same name as the MCPServer,
+// using ownerReferences to establish ownership. The controller will reject updates to resources
+// owned by other controllers or resources with no controller owner (to prevent silent overwrites
+// of manually-created resources), but will adopt orphaned resources from a deleted MCPServer
+// with the same name to enable seamless recreation.
 type MCPServer struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -36,7 +36,18 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MCPServer is the Schema for the mcpservers API
+        description: "MCPServer runs a Model Context Protocol (MCP) server in Kubernetes.\n\nMCPServer
+          creates and manages a Deployment and Service to run an MCP server from a\ncontainer
+          image. The MCP server exposes tools, resources, and prompts that AI applications\ncan
+          use via the Model Context Protocol.\n\nExample:\n\n\tapiVersion: mcp.x-k8s.io/v1alpha1\n\tkind:
+          MCPServer\n\tmetadata:\n\t  name: example\n\tspec:\n\t  source:\n\t    type:
+          ContainerImage\n\t    containerImage:\n\t      ref: example-mcp-image\n\t
+          \ config:\n\t    port: 8080\n\nThe controller manages Deployment and Service
+          resources with the same name as the MCPServer,\nusing ownerReferences to
+          establish ownership. The controller will reject updates to resources\nowned
+          by other controllers or resources with no controller owner (to prevent silent
+          overwrites\nof manually-created resources), but will adopt orphaned resources
+          from a deleted MCPServer\nwith the same name to enable seamless recreation."
         properties:
           apiVersion:
             description: |-

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -424,12 +424,24 @@ func (r *MCPServerReconciler) reconcileDeployment(
 		return nil, err
 	}
 
+	// Check if we need to adopt an orphaned resource by comparing owner UIDs before updating
+	oldOwnerUID := ""
+	if oldOwner := metav1.GetControllerOf(existingDeployment); oldOwner != nil {
+		oldOwnerUID = string(oldOwner.UID)
+	}
+
 	// Update ownerReferences to establish/refresh controller ownership.
 	// This is safe because validateOwnership has confirmed we can manage this resource.
 	// For orphaned resources, this adopts them by updating the stale UID.
 	if err := controllerutil.SetControllerReference(mcpServer, existingDeployment, r.Scheme); err != nil {
 		logger.Error(err, "Failed to set controller reference for existing Deployment")
 		return nil, err
+	}
+
+	// Check if we actually adopted an orphaned resource (owner UID changed)
+	ownershipChanged := false
+	if newOwner := metav1.GetControllerOf(existingDeployment); newOwner != nil {
+		ownershipChanged = oldOwnerUID != string(newOwner.UID)
 	}
 
 	oldPodSpec := existingDeployment.Spec.Template.Spec
@@ -454,7 +466,8 @@ func (r *MCPServerReconciler) reconcileDeployment(
 			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].LivenessProbe, newPodSpec.Containers[0].LivenessProbe) ||
 			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].ReadinessProbe, newPodSpec.Containers[0].ReadinessProbe) ||
 			oldPodSpec.ServiceAccountName != newPodSpec.ServiceAccountName ||
-			!equality.Semantic.DeepEqual(existingDeployment.Spec.Replicas, deployment.Spec.Replicas)
+			!equality.Semantic.DeepEqual(existingDeployment.Spec.Replicas, deployment.Spec.Replicas) ||
+			ownershipChanged
 	}
 	if needsUpdate {
 		logger.Info("Updating Deployment", "name", existingDeployment.Name)
@@ -679,6 +692,12 @@ func (r *MCPServerReconciler) reconcileService(
 		return err
 	}
 
+	// Check if we need to adopt an orphaned resource by comparing owner UIDs before updating
+	oldOwnerUID := ""
+	if oldOwner := metav1.GetControllerOf(existingService); oldOwner != nil {
+		oldOwnerUID = string(oldOwner.UID)
+	}
+
 	// Update ownerReferences to establish/refresh controller ownership.
 	// This is safe because validateOwnership has confirmed we can manage this resource.
 	// For orphaned resources, this adopts them by updating the stale UID.
@@ -687,7 +706,15 @@ func (r *MCPServerReconciler) reconcileService(
 		return err
 	}
 
-	if !equality.Semantic.DeepEqual(service.Spec.Ports, existingService.Spec.Ports) {
+	// Check if we actually adopted an orphaned resource (owner UID changed)
+	ownershipChanged := false
+	if newOwner := metav1.GetControllerOf(existingService); newOwner != nil {
+		ownershipChanged = oldOwnerUID != string(newOwner.UID)
+	}
+
+	// Update if ports changed OR if we adopted an orphaned resource
+	needsUpdate := !equality.Semantic.DeepEqual(service.Spec.Ports, existingService.Spec.Ports) || ownershipChanged
+	if needsUpdate {
 		logger.Info("Updating Service", "name", existingService.Name)
 		existingService.Spec.Ports = service.Spec.Ports
 		if err := r.Update(ctx, existingService); err != nil {

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -418,6 +418,20 @@ func (r *MCPServerReconciler) reconcileDeployment(
 		return nil, err
 	}
 
+	// Validate ownership before updating
+	if err := r.validateOwnership(existingDeployment, mcpServer); err != nil {
+		logger.Error(err, "Deployment ownership validation failed")
+		return nil, err
+	}
+
+	// Update ownerReferences to establish/refresh controller ownership.
+	// This is safe because validateOwnership has confirmed we can manage this resource.
+	// For orphaned resources, this adopts them by updating the stale UID.
+	if err := controllerutil.SetControllerReference(mcpServer, existingDeployment, r.Scheme); err != nil {
+		logger.Error(err, "Failed to set controller reference for existing Deployment")
+		return nil, err
+	}
+
 	oldPodSpec := existingDeployment.Spec.Template.Spec
 	newPodSpec := deployment.Spec.Template.Spec
 
@@ -657,7 +671,23 @@ func (r *MCPServerReconciler) reconcileService(
 	} else if err != nil {
 		logger.Error(err, "Failed to get Service")
 		return err
-	} else if !equality.Semantic.DeepEqual(service.Spec.Ports, existingService.Spec.Ports) {
+	}
+
+	// Validate ownership before updating
+	if err := r.validateOwnership(existingService, mcpServer); err != nil {
+		logger.Error(err, "Service ownership validation failed")
+		return err
+	}
+
+	// Update ownerReferences to establish/refresh controller ownership.
+	// This is safe because validateOwnership has confirmed we can manage this resource.
+	// For orphaned resources, this adopts them by updating the stale UID.
+	if err := controllerutil.SetControllerReference(mcpServer, existingService, r.Scheme); err != nil {
+		logger.Error(err, "Failed to set controller reference for existing Service")
+		return err
+	}
+
+	if !equality.Semantic.DeepEqual(service.Spec.Ports, existingService.Spec.Ports) {
 		logger.Info("Updating Service", "name", existingService.Name)
 		existingService.Spec.Ports = service.Spec.Ports
 		if err := r.Update(ctx, existingService); err != nil {
@@ -701,6 +731,48 @@ func (r *MCPServerReconciler) createService(mcpServer *mcpv1alpha1.MCPServer) *c
 	}
 
 	return service
+}
+
+// validateOwnership checks if a resource is owned by a different controller.
+// Returns an error if the resource has a controller owner that is not the given MCPServer,
+// or if the resource has no controller owner (preventing silent adoption of unowned resources).
+func (r *MCPServerReconciler) validateOwnership(
+	obj client.Object,
+	mcpServer *mcpv1alpha1.MCPServer,
+) error {
+	// Get the controller owner reference from the existing resource
+	controllerOwner := metav1.GetControllerOf(obj)
+	if controllerOwner == nil {
+		// No controller owner - reject to prevent silent adoption
+		// User must delete the existing resource or choose a different name for their MCPServer
+		return fmt.Errorf("resource %s/%s exists but has no controller owner; "+
+			"delete the resource first or choose a different name for the MCPServer",
+			obj.GetNamespace(), obj.GetName())
+	}
+
+	// Check if the controller owner is this MCPServer by UID
+	if controllerOwner.UID == mcpServer.UID {
+		// Owned by this exact MCPServer instance - safe to update
+		return nil
+	}
+
+	// Check if the owner is an MCPServer with the same name/namespace
+	// This handles the case where the MCPServer was deleted and recreated
+	// with the same name, and we want to adopt the orphaned resources.
+	if controllerOwner.Kind == "MCPServer" &&
+		controllerOwner.Name == mcpServer.Name &&
+		obj.GetNamespace() == mcpServer.Namespace {
+		// Owner is an MCPServer with same name/namespace but different UID
+		// This means the old MCPServer was deleted and this is a new one
+		// Safe to adopt the resources
+		return nil
+	}
+
+	// Resource is owned by a different controller
+	return fmt.Errorf("resource %s/%s is owned by %s/%s (UID: %s), cannot be managed by MCPServer %s/%s (UID: %s)",
+		obj.GetNamespace(), obj.GetName(),
+		controllerOwner.Kind, controllerOwner.Name, controllerOwner.UID,
+		mcpServer.Namespace, mcpServer.Name, mcpServer.UID)
 }
 
 func (r *MCPServerReconciler) applyStatus(

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	v1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/ptr"
@@ -760,6 +761,21 @@ func (r *MCPServerReconciler) createService(mcpServer *mcpv1alpha1.MCPServer) *c
 	return service
 }
 
+// isSameGroupKind checks if an owner reference matches the expected API group and kind,
+// ignoring the API version to support cross-version adoption scenarios.
+func isSameGroupKind(ownerRef *metav1.OwnerReference, expectedGroup, expectedKind string) bool {
+	if ownerRef.Kind != expectedKind {
+		return false
+	}
+
+	ownerGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	return ownerGV.Group == expectedGroup
+}
+
 // validateOwnership checks if a resource is owned by a different controller.
 // Returns an error if the resource has a controller owner that is not the given MCPServer,
 // or if the resource has no controller owner (preventing silent adoption of unowned resources).
@@ -783,15 +799,16 @@ func (r *MCPServerReconciler) validateOwnership(
 		return nil
 	}
 
-	// Check if the owner is an MCPServer with the same name/namespace
+	// Check if the owner is an MCPServer with the same name/namespace/group
 	// This handles the case where the MCPServer was deleted and recreated
 	// with the same name, and we want to adopt the orphaned resources.
-	if controllerOwner.Kind == "MCPServer" &&
+	// We validate the API group but allow different versions to support upgrades.
+	if isSameGroupKind(controllerOwner, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind) &&
 		controllerOwner.Name == mcpServer.Name &&
 		obj.GetNamespace() == mcpServer.Namespace {
-		// Owner is an MCPServer with same name/namespace but different UID
+		// Owner is an MCPServer with same group/name/namespace but different UID
 		// This means the old MCPServer was deleted and this is a new one
-		// Safe to adopt the resources
+		// Safe to adopt the resources (version may differ during upgrades)
 		return nil
 	}
 

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -1934,6 +1934,15 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-empty-containers",
 				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "mcp.x-k8s.io/v1alpha1",
+						Kind:       "MCPServer",
+						Name:       "test-empty-containers",
+						UID:        "fake-uid",
+						Controller: ptr.To(true),
+					},
+				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
@@ -5432,7 +5441,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			}
 		})
 
-		It("should update deployment spec even when owned by another controller", func() {
+		It("should reject updating deployment when owned by another controller", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -5441,12 +5450,14 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is owned by"))
+			Expect(err.Error()).To(ContainSubstring("cannot be managed by MCPServer"))
 
-			By("Verifying the deployment spec was overwritten")
+			By("Verifying the deployment spec was NOT overwritten")
 			deployment := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
-			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("docker.io/library/test-image:latest"))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("other-image:latest"))
 
 			By("Verifying the original foreign owner reference is still present")
 			Expect(deployment.OwnerReferences).To(HaveLen(1))
@@ -5527,7 +5538,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			}
 		})
 
-		It("should update service spec even when owned by another controller", func() {
+		It("should reject updating service when owned by another controller", func() {
 			controllerReconciler := &MCPServerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -5536,18 +5547,328 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is owned by"))
+			Expect(err.Error()).To(ContainSubstring("cannot be managed by MCPServer"))
 
-			By("Verifying the service port was updated to match MCPServer config")
+			By("Verifying the service port was NOT updated")
 			service := &corev1.Service{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
 			Expect(service.Spec.Ports).To(HaveLen(1))
-			Expect(service.Spec.Ports[0].Port).To(Equal(int32(8080)))
+			Expect(service.Spec.Ports[0].Port).To(Equal(int32(9999)))
 
 			By("Verifying the original foreign owner reference is still present")
 			Expect(service.OwnerReferences).To(HaveLen(1))
 			Expect(service.OwnerReferences[0].Name).To(Equal("foreign-svc-owner"))
 			Expect(*service.OwnerReferences[0].Controller).To(BeTrue())
+		})
+	})
+
+	Context("When a Deployment exists with no controller owner", func() {
+		const resourceName = "test-unowned-deploy"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			By("Pre-creating a Deployment with no owner")
+			unownedDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					// No ownerReferences - simulates manually created resource
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "manual"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "manual"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "manual", Image: "manual-image:latest"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, unownedDeployment)).To(Succeed())
+
+			By("Creating the MCPServer CR")
+			resource := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should reject updating unowned deployment", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+			Expect(err.Error()).To(ContainSubstring("delete the resource first or choose a different name"))
+
+			By("Verifying the deployment was NOT updated")
+			deployment := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
+			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("manual-image:latest"))
+
+			By("Verifying the deployment still has no owner")
+			Expect(deployment.OwnerReferences).To(BeEmpty())
+
+			By("Verifying the MCPServer status shows deployment unavailable with ownership error")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCondition.Reason).To(Equal("DeploymentUnavailable"))
+			Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
+		})
+	})
+
+	Context("When a Service exists with no controller owner", func() {
+		const resourceName = "test-unowned-svc"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			By("Creating MCPServer first to create Deployment")
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+
+			By("Pre-creating a Service with no owner")
+			unownedService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					// No ownerReferences
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "manual"},
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Port:     9999,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, unownedService)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			service := &corev1.Service{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, service)).To(Succeed())
+			}
+		})
+
+		It("should reject updating unowned service", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+
+			By("Verifying the service was NOT updated")
+			service := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
+			Expect(service.Spec.Ports[0].Port).To(Equal(int32(9999)))
+
+			By("Verifying the MCPServer status shows service unavailable with ownership error")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCondition.Reason).To(Equal("ServiceUnavailable"))
+		})
+	})
+
+	Context("When a Deployment is orphaned from a deleted MCPServer", func() {
+		const resourceName = "test-orphaned-deploy"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		It("should adopt deployment when MCPServer is recreated with same name", func() {
+			By("Creating first MCPServer")
+			oldMCPServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/old-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldMCPServer)).To(Succeed())
+
+			By("Reconciling to create deployment")
+			reconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying deployment was created with old MCPServer owner")
+			deployment := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
+			Expect(deployment.OwnerReferences).To(HaveLen(1))
+			oldUID := oldMCPServer.UID
+			Expect(deployment.OwnerReferences[0].UID).To(Equal(oldUID))
+
+			By("Deleting MCPServer but keeping deployment")
+			// Re-fetch to get latest version after reconciliation
+			Expect(k8sClient.Get(ctx, typeNamespacedName, oldMCPServer)).To(Succeed())
+			// Remove finalizers if any
+			oldMCPServer.Finalizers = nil
+			Expect(k8sClient.Update(ctx, oldMCPServer)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, oldMCPServer)).To(Succeed())
+
+			// Manually set owner reference to simulate orphaned deployment
+			// (with stale UID from deleted MCPServer)
+			deployment.OwnerReferences[0].UID = types.UID("old-deleted-uid")
+			Expect(k8sClient.Update(ctx, deployment)).To(Succeed())
+
+			By("Creating new MCPServer with same name")
+			newMCPServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/new-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, newMCPServer)).To(Succeed())
+
+			By("Reconciling new MCPServer")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying deployment was adopted by new MCPServer")
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
+			Expect(deployment.OwnerReferences).To(HaveLen(1))
+			Expect(deployment.OwnerReferences[0].UID).To(Equal(newMCPServer.UID))
+			Expect(deployment.OwnerReferences[0].Name).To(Equal(resourceName))
+			Expect(deployment.OwnerReferences[0].Kind).To(Equal("MCPServer"))
+
+			By("Verifying deployment spec was updated to new image")
+			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("docker.io/library/new-image:latest"))
+
+			By("Verifying MCPServer status shows successful reconciliation")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, typeNamespacedName, mcpServer)
+				if err != nil {
+					return ""
+				}
+				readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+				if readyCondition == nil {
+					return ""
+				}
+				return readyCondition.Reason
+			}).Should(Or(
+				Equal("Initializing"),          // Initial state after creation
+				Equal("DeploymentUnavailable"), // Deployment exists but not ready yet
+				Equal("Available"),             // Fully ready
+			), "MCPServer should be reconciling successfully after adopting orphaned deployment")
+
+			By("Cleanup")
+			Expect(k8sClient.Delete(ctx, newMCPServer)).To(Succeed())
 		})
 	})
 })

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -5753,242 +5753,242 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			Expect(readyCondition.Reason).To(Equal("ServiceUnavailable"))
 			Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
 		})
+	})
 
-		Context("When a Deployment has multiple owner references but no controller", func() {
-			const resourceName = "test-multi-owner-deploy"
+	Context("When a Deployment has multiple owner references but no controller", func() {
+		const resourceName = "test-multi-owner-deploy"
 
-			typeNamespacedName := types.NamespacedName{
-				Name:      resourceName,
-				Namespace: "default",
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			By("Creating MCPServer")
+			resource := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
 			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			BeforeEach(func() {
-				By("Creating MCPServer")
-				resource := &mcpv1alpha1.MCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: mcpv1alpha1.MCPServerSpec{
-						Source: mcpv1alpha1.Source{
-							Type: mcpv1alpha1.SourceTypeContainerImage,
-							ContainerImage: &mcpv1alpha1.ContainerImageSource{
-								Ref: "docker.io/library/test-image:latest",
-							},
+			By("Pre-creating a Deployment with multiple non-controller owners")
+			multiOwnerDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "mcp.x-k8s.io/v1alpha1",
+							Kind:       "MCPServer",
+							Name:       "some-other-server",
+							UID:        types.UID("other-mcpserver-uid"),
+							Controller: ptr.To(false), // Not a controller
 						},
-						Config: mcpv1alpha1.ServerConfig{
-							Port: 8080,
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-
-				By("Pre-creating a Deployment with multiple non-controller owners")
-				multiOwnerDeployment := &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "mcp.x-k8s.io/v1alpha1",
-								Kind:       "MCPServer",
-								Name:       "some-other-server",
-								UID:        types.UID("other-mcpserver-uid"),
-								Controller: ptr.To(false), // Not a controller
-							},
-							{
-								APIVersion: "apps/v1",
-								Kind:       "ReplicaSet",
-								Name:       "some-replicaset",
-								UID:        types.UID("replicaset-uid"),
-								Controller: ptr.To(false), // Also not a controller
-							},
+						{
+							APIVersion: "apps/v1",
+							Kind:       "ReplicaSet",
+							Name:       "some-replicaset",
+							UID:        types.UID("replicaset-uid"),
+							Controller: ptr.To(false), // Also not a controller
 						},
 					},
-					Spec: appsv1.DeploymentSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"mcp-server": resourceName},
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app":        "mcp-server",
-									"mcp-server": resourceName,
-								},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"mcp-server": resourceName},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app":        "mcp-server",
+								"mcp-server": resourceName,
 							},
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name:  "mcp-server",
-										Image: "manual-image:latest",
-									},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "mcp-server",
+									Image: "manual-image:latest",
 								},
 							},
 						},
 					},
-				}
-				Expect(k8sClient.Create(ctx, multiOwnerDeployment)).To(Succeed())
-			})
-
-			AfterEach(func() {
-				resource := &mcpv1alpha1.MCPServer{}
-				err := k8sClient.Get(ctx, typeNamespacedName, resource)
-				if err == nil {
-					Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-				}
-				deployment := &appsv1.Deployment{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
-				if err == nil {
-					Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
-				}
-			})
-
-			It("should reject updating deployment with multiple non-controller owners", func() {
-				controllerReconciler := &MCPServerReconciler{
-					Client: k8sClient,
-					Scheme: k8sClient.Scheme(),
-				}
-
-				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: typeNamespacedName,
-				})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("has no controller owner"))
-
-				By("Verifying the deployment was NOT updated")
-				deployment := &appsv1.Deployment{}
-				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
-				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("manual-image:latest"))
-
-				By("Verifying all original owner references are still present")
-				Expect(deployment.OwnerReferences).To(HaveLen(2))
-				Expect(deployment.OwnerReferences[0].Name).To(Equal("some-other-server"))
-				Expect(*deployment.OwnerReferences[0].Controller).To(BeFalse())
-				Expect(deployment.OwnerReferences[1].Name).To(Equal("some-replicaset"))
-				Expect(*deployment.OwnerReferences[1].Controller).To(BeFalse())
-
-				By("Verifying the MCPServer status shows deployment unavailable with ownership error")
-				mcpServer := &mcpv1alpha1.MCPServer{}
-				Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-				readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
-				Expect(readyCondition).NotTo(BeNil())
-				Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-				Expect(readyCondition.Reason).To(Equal("DeploymentUnavailable"))
-				Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
-			})
+				},
+			}
+			Expect(k8sClient.Create(ctx, multiOwnerDeployment)).To(Succeed())
 		})
 
-		Context("When a Service has multiple owner references but no controller", func() {
-			const resourceName = "test-multi-owner-svc"
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
 
-			typeNamespacedName := types.NamespacedName{
-				Name:      resourceName,
-				Namespace: "default",
+		It("should reject updating deployment with multiple non-controller owners", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
 			}
 
-			BeforeEach(func() {
-				By("Creating MCPServer first to create Deployment")
-				mcpServer := &mcpv1alpha1.MCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: mcpv1alpha1.MCPServerSpec{
-						Source: mcpv1alpha1.Source{
-							Type: mcpv1alpha1.SourceTypeContainerImage,
-							ContainerImage: &mcpv1alpha1.ContainerImageSource{
-								Ref: "docker.io/library/test-image:latest",
-							},
-						},
-						Config: mcpv1alpha1.ServerConfig{
-							Port: 8080,
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
-
-				By("Pre-creating a Service with multiple non-controller owners")
-				multiOwnerService := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								APIVersion: "mcp.x-k8s.io/v1alpha1",
-								Kind:       "MCPServer",
-								Name:       "some-other-server",
-								UID:        types.UID("other-mcpserver-uid"),
-								Controller: ptr.To(false), // Not a controller
-							},
-							{
-								APIVersion: "v1",
-								Kind:       "ConfigMap",
-								Name:       "some-config",
-								UID:        types.UID("config-uid"),
-								Controller: ptr.To(false), // Also not a controller
-							},
-						},
-					},
-					Spec: corev1.ServiceSpec{
-						Selector: map[string]string{"app": "manual"},
-						Ports: []corev1.ServicePort{
-							{
-								Name:     "http",
-								Port:     9999,
-								Protocol: corev1.ProtocolTCP,
-							},
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, multiOwnerService)).To(Succeed())
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
 			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
 
-			AfterEach(func() {
-				resource := &mcpv1alpha1.MCPServer{}
-				err := k8sClient.Get(ctx, typeNamespacedName, resource)
-				if err == nil {
-					Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-				}
-				service := &corev1.Service{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)
-				if err == nil {
-					Expect(k8sClient.Delete(ctx, service)).To(Succeed())
-				}
+			By("Verifying the deployment was NOT updated")
+			deployment := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
+			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("manual-image:latest"))
+
+			By("Verifying all original owner references are still present")
+			Expect(deployment.OwnerReferences).To(HaveLen(2))
+			Expect(deployment.OwnerReferences[0].Name).To(Equal("some-other-server"))
+			Expect(*deployment.OwnerReferences[0].Controller).To(BeFalse())
+			Expect(deployment.OwnerReferences[1].Name).To(Equal("some-replicaset"))
+			Expect(*deployment.OwnerReferences[1].Controller).To(BeFalse())
+
+			By("Verifying the MCPServer status shows deployment unavailable with ownership error")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCondition.Reason).To(Equal("DeploymentUnavailable"))
+			Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
+		})
+	})
+
+	Context("When a Service has multiple owner references but no controller", func() {
+		const resourceName = "test-multi-owner-svc"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			By("Creating MCPServer first to create Deployment")
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+
+			By("Pre-creating a Service with multiple non-controller owners")
+			multiOwnerService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "mcp.x-k8s.io/v1alpha1",
+							Kind:       "MCPServer",
+							Name:       "some-other-server",
+							UID:        types.UID("other-mcpserver-uid"),
+							Controller: ptr.To(false), // Not a controller
+						},
+						{
+							APIVersion: "v1",
+							Kind:       "ConfigMap",
+							Name:       "some-config",
+							UID:        types.UID("config-uid"),
+							Controller: ptr.To(false), // Also not a controller
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "manual"},
+					Ports: []corev1.ServicePort{
+						{
+							Name:     "http",
+							Port:     9999,
+							Protocol: corev1.ProtocolTCP,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, multiOwnerService)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			service := &corev1.Service{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, service)).To(Succeed())
+			}
+		})
+
+		It("should reject updating service with multiple non-controller owners", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
 			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
 
-			It("should reject updating service with multiple non-controller owners", func() {
-				controllerReconciler := &MCPServerReconciler{
-					Client: k8sClient,
-					Scheme: k8sClient.Scheme(),
-				}
+			By("Verifying the service was NOT updated")
+			service := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
+			Expect(service.Spec.Ports[0].Port).To(Equal(int32(9999)))
 
-				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-					NamespacedName: typeNamespacedName,
-				})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+			By("Verifying all original owner references are still present")
+			Expect(service.OwnerReferences).To(HaveLen(2))
+			Expect(service.OwnerReferences[0].Name).To(Equal("some-other-server"))
+			Expect(*service.OwnerReferences[0].Controller).To(BeFalse())
+			Expect(service.OwnerReferences[1].Name).To(Equal("some-config"))
+			Expect(*service.OwnerReferences[1].Controller).To(BeFalse())
 
-				By("Verifying the service was NOT updated")
-				service := &corev1.Service{}
-				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
-				Expect(service.Spec.Ports[0].Port).To(Equal(int32(9999)))
-
-				By("Verifying all original owner references are still present")
-				Expect(service.OwnerReferences).To(HaveLen(2))
-				Expect(service.OwnerReferences[0].Name).To(Equal("some-other-server"))
-				Expect(*service.OwnerReferences[0].Controller).To(BeFalse())
-				Expect(service.OwnerReferences[1].Name).To(Equal("some-config"))
-				Expect(*service.OwnerReferences[1].Controller).To(BeFalse())
-
-				By("Verifying the MCPServer status shows service unavailable with ownership error")
-				mcpServer := &mcpv1alpha1.MCPServer{}
-				Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-				readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
-				Expect(readyCondition).NotTo(BeNil())
-				Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
-				Expect(readyCondition.Reason).To(Equal("ServiceUnavailable"))
-				Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
-			})
+			By("Verifying the MCPServer status shows service unavailable with ownership error")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCondition.Reason).To(Equal("ServiceUnavailable"))
+			Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
 		})
 	})
 

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -5753,6 +5753,243 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			Expect(readyCondition.Reason).To(Equal("ServiceUnavailable"))
 			Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
 		})
+
+		Context("When a Deployment has multiple owner references but no controller", func() {
+			const resourceName = "test-multi-owner-deploy"
+
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			BeforeEach(func() {
+				By("Creating MCPServer")
+				resource := &mcpv1alpha1.MCPServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					Spec: mcpv1alpha1.MCPServerSpec{
+						Source: mcpv1alpha1.Source{
+							Type: mcpv1alpha1.SourceTypeContainerImage,
+							ContainerImage: &mcpv1alpha1.ContainerImageSource{
+								Ref: "docker.io/library/test-image:latest",
+							},
+						},
+						Config: mcpv1alpha1.ServerConfig{
+							Port: 8080,
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+				By("Pre-creating a Deployment with multiple non-controller owners")
+				multiOwnerDeployment := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "mcp.x-k8s.io/v1alpha1",
+								Kind:       "MCPServer",
+								Name:       "some-other-server",
+								UID:        types.UID("other-mcpserver-uid"),
+								Controller: ptr.To(false), // Not a controller
+							},
+							{
+								APIVersion: "apps/v1",
+								Kind:       "ReplicaSet",
+								Name:       "some-replicaset",
+								UID:        types.UID("replicaset-uid"),
+								Controller: ptr.To(false), // Also not a controller
+							},
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"mcp-server": resourceName},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"app":        "mcp-server",
+									"mcp-server": resourceName,
+								},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "mcp-server",
+										Image: "manual-image:latest",
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, multiOwnerDeployment)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				resource := &mcpv1alpha1.MCPServer{}
+				err := k8sClient.Get(ctx, typeNamespacedName, resource)
+				if err == nil {
+					Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+				}
+				deployment := &appsv1.Deployment{}
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+				if err == nil {
+					Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+				}
+			})
+
+			It("should reject updating deployment with multiple non-controller owners", func() {
+				controllerReconciler := &MCPServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+
+				By("Verifying the deployment was NOT updated")
+				deployment := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("manual-image:latest"))
+
+				By("Verifying all original owner references are still present")
+				Expect(deployment.OwnerReferences).To(HaveLen(2))
+				Expect(deployment.OwnerReferences[0].Name).To(Equal("some-other-server"))
+				Expect(*deployment.OwnerReferences[0].Controller).To(BeFalse())
+				Expect(deployment.OwnerReferences[1].Name).To(Equal("some-replicaset"))
+				Expect(*deployment.OwnerReferences[1].Controller).To(BeFalse())
+
+				By("Verifying the MCPServer status shows deployment unavailable with ownership error")
+				mcpServer := &mcpv1alpha1.MCPServer{}
+				Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+				readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+				Expect(readyCondition).NotTo(BeNil())
+				Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(readyCondition.Reason).To(Equal("DeploymentUnavailable"))
+				Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
+			})
+		})
+
+		Context("When a Service has multiple owner references but no controller", func() {
+			const resourceName = "test-multi-owner-svc"
+
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			BeforeEach(func() {
+				By("Creating MCPServer first to create Deployment")
+				mcpServer := &mcpv1alpha1.MCPServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					Spec: mcpv1alpha1.MCPServerSpec{
+						Source: mcpv1alpha1.Source{
+							Type: mcpv1alpha1.SourceTypeContainerImage,
+							ContainerImage: &mcpv1alpha1.ContainerImageSource{
+								Ref: "docker.io/library/test-image:latest",
+							},
+						},
+						Config: mcpv1alpha1.ServerConfig{
+							Port: 8080,
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+
+				By("Pre-creating a Service with multiple non-controller owners")
+				multiOwnerService := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "mcp.x-k8s.io/v1alpha1",
+								Kind:       "MCPServer",
+								Name:       "some-other-server",
+								UID:        types.UID("other-mcpserver-uid"),
+								Controller: ptr.To(false), // Not a controller
+							},
+							{
+								APIVersion: "v1",
+								Kind:       "ConfigMap",
+								Name:       "some-config",
+								UID:        types.UID("config-uid"),
+								Controller: ptr.To(false), // Also not a controller
+							},
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{"app": "manual"},
+						Ports: []corev1.ServicePort{
+							{
+								Name:     "http",
+								Port:     9999,
+								Protocol: corev1.ProtocolTCP,
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, multiOwnerService)).To(Succeed())
+			})
+
+			AfterEach(func() {
+				resource := &mcpv1alpha1.MCPServer{}
+				err := k8sClient.Get(ctx, typeNamespacedName, resource)
+				if err == nil {
+					Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+				}
+				service := &corev1.Service{}
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)
+				if err == nil {
+					Expect(k8sClient.Delete(ctx, service)).To(Succeed())
+				}
+			})
+
+			It("should reject updating service with multiple non-controller owners", func() {
+				controllerReconciler := &MCPServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+
+				By("Verifying the service was NOT updated")
+				service := &corev1.Service{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
+				Expect(service.Spec.Ports[0].Port).To(Equal(int32(9999)))
+
+				By("Verifying all original owner references are still present")
+				Expect(service.OwnerReferences).To(HaveLen(2))
+				Expect(service.OwnerReferences[0].Name).To(Equal("some-other-server"))
+				Expect(*service.OwnerReferences[0].Controller).To(BeFalse())
+				Expect(service.OwnerReferences[1].Name).To(Equal("some-config"))
+				Expect(*service.OwnerReferences[1].Controller).To(BeFalse())
+
+				By("Verifying the MCPServer status shows service unavailable with ownership error")
+				mcpServer := &mcpv1alpha1.MCPServer{}
+				Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+				readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+				Expect(readyCondition).NotTo(BeNil())
+				Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+				Expect(readyCondition.Reason).To(Equal("ServiceUnavailable"))
+				Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
+			})
+		})
 	})
 
 	Context("When a Deployment is orphaned from a deleted MCPServer", func() {

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -6421,3 +6421,84 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 		})
 	})
 })
+var _ = Describe("isSameGroupKind", func() {
+	It("should return true for same group and kind with v1alpha1", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: mcpv1alpha1.GroupVersion.String(),
+			Kind:       mcpv1alpha1.MCPServerKind,
+			Name:       "test-server",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind)).To(BeTrue())
+	})
+
+	It("should return true for same group and kind with different version (v1alpha2)", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: mcpv1alpha1.GroupVersion.Group + "/v1alpha2",
+			Kind:       mcpv1alpha1.MCPServerKind,
+			Name:       "test-server",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind)).To(BeTrue())
+	})
+
+	It("should return true for same group and kind with stable version (v1)", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: mcpv1alpha1.GroupVersion.Group + "/v1",
+			Kind:       mcpv1alpha1.MCPServerKind,
+			Name:       "test-server",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind)).To(BeTrue())
+	})
+
+	It("should return false for different group with same kind", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: "evil.io/v1",
+			Kind:       mcpv1alpha1.MCPServerKind,
+			Name:       "test-server",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind)).To(BeFalse())
+	})
+
+	It("should return false for different kind with same group", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: mcpv1alpha1.GroupVersion.String(),
+			Kind:       "OtherResource",
+			Name:       "test-server",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind)).To(BeFalse())
+	})
+
+	It("should return false for both different group and kind", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: "other.io/v1",
+			Kind:       "OtherResource",
+			Name:       "test-server",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind)).To(BeFalse())
+	})
+
+	It("should return false for invalid APIVersion format", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: "invalid/format/extra",
+			Kind:       mcpv1alpha1.MCPServerKind,
+			Name:       "test-server",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, mcpv1alpha1.GroupVersion.Group, mcpv1alpha1.MCPServerKind)).To(BeFalse())
+	})
+
+	It("should return true for core API resource with empty group", func() {
+		ownerRef := &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       "test-pod",
+			UID:        types.UID("test-uid"),
+		}
+		Expect(isSameGroupKind(ownerRef, "", "Pod")).To(BeTrue())
+	})
+})

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -6226,5 +6226,198 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			By("Cleanup")
 			Expect(k8sClient.Delete(ctx, newMCPServer)).To(Succeed())
 		})
+		It("should adopt service when MCPServer is recreated with same name and same port", func() {
+			const resourceName = "test-orphaned-svc-same-port"
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+			samePort := int32(8080)
+
+			By("Creating first MCPServer")
+			oldMCPServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: samePort,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldMCPServer)).To(Succeed())
+
+			By("Reconciling to create service")
+			reconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying service was created with old MCPServer owner")
+			service := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
+			Expect(service.OwnerReferences).To(HaveLen(1))
+			oldUID := oldMCPServer.UID
+			Expect(service.OwnerReferences[0].UID).To(Equal(oldUID))
+
+			By("Deleting MCPServer but keeping service")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, oldMCPServer)).To(Succeed())
+			oldMCPServer.Finalizers = nil
+			Expect(k8sClient.Update(ctx, oldMCPServer)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, oldMCPServer)).To(Succeed())
+
+			// Manually set owner reference to simulate orphaned service
+			service.OwnerReferences[0].UID = types.UID("old-deleted-uid")
+			Expect(k8sClient.Update(ctx, service)).To(Succeed())
+
+			By("Creating new MCPServer with same name and SAME port")
+			newMCPServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/test-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: samePort, // Same port as before
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, newMCPServer)).To(Succeed())
+
+			By("Reconciling new MCPServer")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying service was adopted by new MCPServer despite same port")
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
+			Expect(service.OwnerReferences).To(HaveLen(1))
+			Expect(service.OwnerReferences[0].UID).To(Equal(newMCPServer.UID), "Owner UID should be updated even when port is the same")
+			Expect(service.OwnerReferences[0].Name).To(Equal(resourceName))
+			Expect(service.OwnerReferences[0].Kind).To(Equal("MCPServer"))
+
+			By("Verifying service port is still the same")
+			Expect(service.Spec.Ports[0].Port).To(Equal(samePort))
+
+			By("Cleanup")
+			Expect(k8sClient.Delete(ctx, newMCPServer)).To(Succeed())
+		})
+
+		Context("When a Deployment is orphaned and MCPServer recreated with same image", func() {
+			const resourceName = "test-orphaned-deploy-same-img"
+
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			It("should adopt deployment when MCPServer is recreated with same image", func() {
+				sameImage := "docker.io/library/same-image:v1.0"
+
+				By("Creating first MCPServer")
+				oldMCPServer := &mcpv1alpha1.MCPServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					Spec: mcpv1alpha1.MCPServerSpec{
+						Source: mcpv1alpha1.Source{
+							Type: mcpv1alpha1.SourceTypeContainerImage,
+							ContainerImage: &mcpv1alpha1.ContainerImageSource{
+								Ref: sameImage,
+							},
+						},
+						Config: mcpv1alpha1.ServerConfig{
+							Port: 8080,
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, oldMCPServer)).To(Succeed())
+
+				By("Reconciling to create deployment")
+				reconciler := &MCPServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying deployment was created with old MCPServer owner")
+				deployment := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
+				Expect(deployment.OwnerReferences).To(HaveLen(1))
+				oldUID := oldMCPServer.UID
+				Expect(deployment.OwnerReferences[0].UID).To(Equal(oldUID))
+
+				By("Deleting MCPServer but keeping deployment")
+				Expect(k8sClient.Get(ctx, typeNamespacedName, oldMCPServer)).To(Succeed())
+				oldMCPServer.Finalizers = nil
+				Expect(k8sClient.Update(ctx, oldMCPServer)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, oldMCPServer)).To(Succeed())
+
+				// Manually set owner reference to simulate orphaned deployment
+				deployment.OwnerReferences[0].UID = types.UID("old-deleted-uid")
+				Expect(k8sClient.Update(ctx, deployment)).To(Succeed())
+
+				By("Creating new MCPServer with same image")
+				newMCPServer := &mcpv1alpha1.MCPServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					Spec: mcpv1alpha1.MCPServerSpec{
+						Source: mcpv1alpha1.Source{
+							Type: mcpv1alpha1.SourceTypeContainerImage,
+							ContainerImage: &mcpv1alpha1.ContainerImageSource{
+								Ref: sameImage, // Same image as before
+							},
+						},
+						Config: mcpv1alpha1.ServerConfig{
+							Port: 8080,
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, newMCPServer)).To(Succeed())
+
+				By("Reconciling new MCPServer")
+				_, err = reconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying deployment was adopted despite same image")
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)).To(Succeed())
+				Expect(deployment.OwnerReferences).To(HaveLen(1))
+				Expect(deployment.OwnerReferences[0].UID).To(Equal(newMCPServer.UID), "Owner UID should be updated even when image is the same")
+				Expect(deployment.OwnerReferences[0].Name).To(Equal(resourceName))
+				Expect(deployment.OwnerReferences[0].Kind).To(Equal("MCPServer"))
+
+				By("Verifying deployment image is still the same")
+				Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(sameImage))
+
+				By("Cleanup")
+				Expect(k8sClient.Delete(ctx, newMCPServer)).To(Succeed())
+			})
+		})
 	})
 })

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -5751,6 +5751,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(readyCondition.Reason).To(Equal("ServiceUnavailable"))
+			Expect(readyCondition.Message).To(ContainSubstring("has no controller owner"))
 		})
 	})
 
@@ -5866,6 +5867,124 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 				Equal("DeploymentUnavailable"), // Deployment exists but not ready yet
 				Equal("Available"),             // Fully ready
 			), "MCPServer should be reconciling successfully after adopting orphaned deployment")
+
+			By("Cleanup")
+			Expect(k8sClient.Delete(ctx, newMCPServer)).To(Succeed())
+		})
+	})
+
+	Context("When a Service is orphaned from a deleted MCPServer", func() {
+		const resourceName = "test-orphaned-svc"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		It("should adopt service when MCPServer is recreated with same name", func() {
+			By("Creating first MCPServer")
+			oldMCPServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/old-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 8080,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldMCPServer)).To(Succeed())
+
+			By("Reconciling to create service")
+			reconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying service was created with old MCPServer owner")
+			service := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
+			Expect(service.OwnerReferences).To(HaveLen(1))
+			oldUID := oldMCPServer.UID
+			Expect(service.OwnerReferences[0].UID).To(Equal(oldUID))
+
+			By("Deleting MCPServer but keeping service")
+			// Re-fetch to get latest version after reconciliation
+			Expect(k8sClient.Get(ctx, typeNamespacedName, oldMCPServer)).To(Succeed())
+			// Remove finalizers if any
+			oldMCPServer.Finalizers = nil
+			Expect(k8sClient.Update(ctx, oldMCPServer)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, oldMCPServer)).To(Succeed())
+
+			// Manually set owner reference to simulate orphaned service
+			// (with stale UID from deleted MCPServer)
+			service.OwnerReferences[0].UID = types.UID("old-deleted-uid")
+			Expect(k8sClient.Update(ctx, service)).To(Succeed())
+
+			By("Creating new MCPServer with same name")
+			newMCPServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: "docker.io/library/new-image:latest",
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port: 9090,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, newMCPServer)).To(Succeed())
+
+			By("Reconciling new MCPServer")
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying service was adopted by new MCPServer")
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)).To(Succeed())
+			Expect(service.OwnerReferences).To(HaveLen(1))
+			Expect(service.OwnerReferences[0].UID).To(Equal(newMCPServer.UID))
+			Expect(service.OwnerReferences[0].Name).To(Equal(resourceName))
+			Expect(service.OwnerReferences[0].Kind).To(Equal("MCPServer"))
+
+			By("Verifying service spec was updated to new port")
+			Expect(service.Spec.Ports[0].Port).To(Equal(int32(9090)))
+
+			By("Verifying MCPServer status shows successful reconciliation")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, typeNamespacedName, mcpServer)
+				if err != nil {
+					return ""
+				}
+				readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+				if readyCondition == nil {
+					return ""
+				}
+				return readyCondition.Reason
+			}).Should(Or(
+				Equal("Initializing"),          // Initial state after creation
+				Equal("DeploymentUnavailable"), // Deployment exists but not ready yet
+				Equal("Available"),             // Fully ready
+			), "MCPServer should be reconciling successfully after adopting orphaned service")
 
 			By("Cleanup")
 			Expect(k8sClient.Delete(ctx, newMCPServer)).To(Succeed())


### PR DESCRIPTION
Fixes #85 

Prevents the controller from silently overwriting resources owned by other controllers or adopting unowned resources, while properly handling legitimate orphaned resource adoption scenarios.

- Reject resources owned by other controllers with clear error messages
- Reject resources with no controller owner to prevent silent adoption
- Allow adoption of orphaned resources from deleted MCPServers with matching names
- Applied to both Deployments and Services