### PR TITLE
Distinguish transient API errors from config errors during validation

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -180,8 +180,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		// Transient error - log and return to trigger retry with exponential backoff
-		logger.Info("Transient error during configuration validation, will retry",
-			"error", err)
+		logger.Error(err, "Transient error during configuration validation, will retry")
 		// Don't update status - preserve existing Accepted condition
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -991,7 +991,9 @@ func (r *MCPServerReconciler) validateStorageMount(
 			Name:      storage.Source.ConfigMap.Name,
 			Namespace: mcpServer.Namespace,
 		}, configMap); err != nil {
-			// Permanent errors - configuration is invalid
+			// NotFound and BadRequest are permanent errors. NotFound is safe to treat as
+			// permanent because the controller watches ConfigMaps/Secrets and will
+			// re-reconcile when the missing resource is created.
 			if apierrors.IsNotFound(err) {
 				return &ValidationError{
 					Reason: ReasonInvalid,
@@ -1006,21 +1008,7 @@ func (r *MCPServerReconciler) validateStorageMount(
 						storage.Source.ConfigMap.Name, err),
 				}
 			}
-			if apierrors.IsForbidden(err) {
-				return &ValidationError{
-					Reason: ReasonInvalid,
-					Message: fmt.Sprintf("No permission to access ConfigMap '%s': %v",
-						storage.Source.ConfigMap.Name, err),
-				}
-			}
-			if apierrors.IsUnauthorized(err) {
-				return &ValidationError{
-					Reason: ReasonInvalid,
-					Message: fmt.Sprintf("Not authorized to access ConfigMap '%s': %v",
-						storage.Source.ConfigMap.Name, err),
-				}
-			}
-			// All other errors are transient - return wrapped error to trigger retry
+			// All other errors (Forbidden, Unauthorized, 500, 503, 429, timeouts...) are transient
 			return fmt.Errorf("transient error validating ConfigMap '%s': %w",
 				storage.Source.ConfigMap.Name, err)
 		}
@@ -1048,7 +1036,9 @@ func (r *MCPServerReconciler) validateStorageMount(
 			Name:      storage.Source.Secret.SecretName,
 			Namespace: mcpServer.Namespace,
 		}, secret); err != nil {
-			// Permanent errors - configuration is invalid
+			// NotFound and BadRequest are permanent errors. NotFound is safe to treat as
+			// permanent because the controller watches ConfigMaps/Secrets and will
+			// re-reconcile when the missing resource is created.
 			if apierrors.IsNotFound(err) {
 				return &ValidationError{
 					Reason: ReasonInvalid,
@@ -1063,21 +1053,7 @@ func (r *MCPServerReconciler) validateStorageMount(
 						storage.Source.Secret.SecretName, err),
 				}
 			}
-			if apierrors.IsForbidden(err) {
-				return &ValidationError{
-					Reason: ReasonInvalid,
-					Message: fmt.Sprintf("No permission to access Secret '%s': %v",
-						storage.Source.Secret.SecretName, err),
-				}
-			}
-			if apierrors.IsUnauthorized(err) {
-				return &ValidationError{
-					Reason: ReasonInvalid,
-					Message: fmt.Sprintf("Not authorized to access Secret '%s': %v",
-						storage.Source.Secret.SecretName, err),
-				}
-			}
-			// All other errors are transient - return wrapped error to trigger retry
+			// All other errors (Forbidden, Unauthorized, 500, 503, 429, timeouts...) are transient
 			return fmt.Errorf("transient error validating Secret '%s': %w",
 				storage.Source.Secret.SecretName, err)
 		}
@@ -1116,7 +1092,9 @@ func (r *MCPServerReconciler) validateEnvFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, configMap); err != nil {
-				// Permanent errors - configuration is invalid
+				// NotFound and BadRequest are permanent errors. NotFound is safe to treat as
+				// permanent because the controller watches ConfigMaps/Secrets and will
+				// re-reconcile when the missing resource is created.
 				if apierrors.IsNotFound(err) {
 					return &ValidationError{
 						Reason: ReasonInvalid,
@@ -1131,21 +1109,7 @@ func (r *MCPServerReconciler) validateEnvFrom(
 							ref.Name, index, err),
 					}
 				}
-				if apierrors.IsForbidden(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("No permission to access ConfigMap '%s' (envFrom index %d): %v",
-							ref.Name, index, err),
-					}
-				}
-				if apierrors.IsUnauthorized(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("Not authorized to access ConfigMap '%s' (envFrom index %d): %v",
-							ref.Name, index, err),
-					}
-				}
-				// All other errors are transient
+				// All other errors (Forbidden, Unauthorized, 500, 503, 429, timeouts...) are transient
 				return fmt.Errorf("transient error validating ConfigMap '%s' (envFrom index %d): %w",
 					ref.Name, index, err)
 			}
@@ -1158,7 +1122,9 @@ func (r *MCPServerReconciler) validateEnvFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, secret); err != nil {
-				// Permanent errors - configuration is invalid
+				// NotFound and BadRequest are permanent errors. NotFound is safe to treat as
+				// permanent because the controller watches ConfigMaps/Secrets and will
+				// re-reconcile when the missing resource is created.
 				if apierrors.IsNotFound(err) {
 					return &ValidationError{
 						Reason: ReasonInvalid,
@@ -1173,21 +1139,7 @@ func (r *MCPServerReconciler) validateEnvFrom(
 							ref.Name, index, err),
 					}
 				}
-				if apierrors.IsForbidden(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("No permission to access Secret '%s' (envFrom index %d): %v",
-							ref.Name, index, err),
-					}
-				}
-				if apierrors.IsUnauthorized(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("Not authorized to access Secret '%s' (envFrom index %d): %v",
-							ref.Name, index, err),
-					}
-				}
-				// All other errors are transient
+				// All other errors (Forbidden, Unauthorized, 500, 503, 429, timeouts...) are transient
 				return fmt.Errorf("transient error validating Secret '%s' (envFrom index %d): %w",
 					ref.Name, index, err)
 			}
@@ -1214,7 +1166,9 @@ func (r *MCPServerReconciler) validateEnvValueFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, configMap); err != nil {
-				// Permanent errors - configuration is invalid
+				// NotFound and BadRequest are permanent errors. NotFound is safe to treat as
+				// permanent because the controller watches ConfigMaps/Secrets and will
+				// re-reconcile when the missing resource is created.
 				if apierrors.IsNotFound(err) {
 					return &ValidationError{
 						Reason: ReasonInvalid,
@@ -1229,21 +1183,7 @@ func (r *MCPServerReconciler) validateEnvValueFrom(
 							ref.Name, env.Name, index, err),
 					}
 				}
-				if apierrors.IsForbidden(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("No permission to access ConfigMap '%s' referenced by env var '%s' (env index %d): %v",
-							ref.Name, env.Name, index, err),
-					}
-				}
-				if apierrors.IsUnauthorized(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("Not authorized to access ConfigMap '%s' referenced by env var '%s' (env index %d): %v",
-							ref.Name, env.Name, index, err),
-					}
-				}
-				// All other errors are transient
+				// All other errors (Forbidden, Unauthorized, 500, 503, 429, timeouts...) are transient
 				return fmt.Errorf("transient error validating ConfigMap '%s' referenced by env var '%s' (env index %d): %w",
 					ref.Name, env.Name, index, err)
 			}
@@ -1256,7 +1196,9 @@ func (r *MCPServerReconciler) validateEnvValueFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, secret); err != nil {
-				// Permanent errors - configuration is invalid
+				// NotFound and BadRequest are permanent errors. NotFound is safe to treat as
+				// permanent because the controller watches ConfigMaps/Secrets and will
+				// re-reconcile when the missing resource is created.
 				if apierrors.IsNotFound(err) {
 					return &ValidationError{
 						Reason: ReasonInvalid,
@@ -1271,21 +1213,7 @@ func (r *MCPServerReconciler) validateEnvValueFrom(
 							ref.Name, env.Name, index, err),
 					}
 				}
-				if apierrors.IsForbidden(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("No permission to access Secret '%s' referenced by env var '%s' (env index %d): %v",
-							ref.Name, env.Name, index, err),
-					}
-				}
-				if apierrors.IsUnauthorized(err) {
-					return &ValidationError{
-						Reason: ReasonInvalid,
-						Message: fmt.Sprintf("Not authorized to access Secret '%s' referenced by env var '%s' (env index %d): %v",
-							ref.Name, env.Name, index, err),
-					}
-				}
-				// All other errors are transient
+				// All other errors (Forbidden, Unauthorized, 500, 503, 429, timeouts...) are transient
 				return fmt.Errorf("transient error validating Secret '%s' referenced by env var '%s' (env index %d): %w",
 					ref.Name, env.Name, index, err)
 			}

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -52,6 +53,17 @@ import (
 const (
 	fieldManager = "mcpserver-controller"
 )
+
+// ValidationError represents a permanent configuration validation error.
+// These errors indicate the MCPServer configuration is invalid and should not be retried.
+type ValidationError struct {
+	Reason  string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return e.Message
+}
 
 // Condition types for MCPServer status.
 const (
@@ -127,37 +139,62 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
 
-	// Validate configuration and set Accepted condition
-	acceptedCondition, configValid := r.setAcceptedCondition(ctx, mcpServer)
-	preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
-
-	// If configuration is not valid, update status and stop
-	if !configValid {
-		readyCondition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionFalse,
-			ReasonConfigurationInvalid,
-			"Configuration must be fixed before server can start",
-			mcpServer.Generation,
-		)
-		preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
-
-		status := acv1alpha1.MCPServerStatus().
-			WithObservedGeneration(mcpServer.Generation).
-			WithServiceName(mcpServer.Name).
-			WithConditions(
-				conditionToAC(acceptedCondition),
-				conditionToAC(readyCondition),
+	// Validate configuration
+	if err := r.setAcceptedCondition(ctx, mcpServer); err != nil {
+		var validationErr *ValidationError
+		if errors.As(err, &validationErr) {
+			// Permanent validation error - mark configuration as invalid
+			acceptedCondition := newCondition(
+				ConditionTypeAccepted,
+				metav1.ConditionFalse,
+				validationErr.Reason,
+				validationErr.Message,
+				mcpServer.Generation,
 			)
+			preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
 
-		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
-			logger.Error(err, "Failed to update MCPServer status")
-			return ctrl.Result{}, err
+			readyCondition := newCondition(
+				ConditionTypeReady,
+				metav1.ConditionFalse,
+				ReasonConfigurationInvalid,
+				"Configuration must be fixed before server can start",
+				mcpServer.Generation,
+			)
+			preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+			status := acv1alpha1.MCPServerStatus().
+				WithObservedGeneration(mcpServer.Generation).
+				WithServiceName(mcpServer.Name).
+				WithConditions(
+					conditionToAC(acceptedCondition),
+					conditionToAC(readyCondition),
+				)
+
+			if err := r.applyStatus(ctx, mcpServer, status); err != nil {
+				logger.Error(err, "Failed to update MCPServer status")
+				return ctrl.Result{}, err
+			}
+
+			logger.Info("MCPServer configuration is invalid", "reason", validationErr.Reason)
+			return ctrl.Result{}, nil
 		}
 
-		logger.Info("MCPServer configuration is invalid", "reason", acceptedCondition.Reason)
-		return ctrl.Result{}, nil
+		// Transient error - log and return to trigger retry with exponential backoff
+		logger.Info("Transient error during configuration validation, will retry",
+			"error", err)
+		// Don't update status - preserve existing Accepted condition
+		return ctrl.Result{}, err
 	}
+
+	// Configuration is valid - create Accepted=True condition
+	acceptedCondition := newCondition(
+		ConditionTypeAccepted,
+		metav1.ConditionTrue,
+		ReasonValid,
+		"Configuration is valid",
+		mcpServer.Generation,
+	)
+	preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
 
 	// Configuration is valid, proceed with deployment reconciliation
 	existingDeployment, err := r.reconcileDeployment(ctx, mcpServer)
@@ -923,36 +960,30 @@ func analyzeDeploymentFailure(deploymentMessage string) string {
 }
 
 // validateStorageMount validates a single storage mount configuration.
-// Returns an error condition and false if validation fails, otherwise returns zero condition and true.
+// Returns ValidationError for permanent configuration errors, wrapped error for transient errors, or nil for success.
 func (r *MCPServerReconciler) validateStorageMount(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
 	storage mcpv1alpha1.StorageMount,
 	index int,
-) (metav1.Condition, bool) {
+) error {
 	switch storage.Source.Type {
 	case mcpv1alpha1.StorageTypeConfigMap:
 		if storage.Source.ConfigMap == nil {
-			return newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				ReasonInvalid,
-				fmt.Sprintf("ConfigMap must be set for storage mount at index %d", index),
-				mcpServer.Generation,
-			), false
+			return &ValidationError{
+				Reason:  ReasonInvalid,
+				Message: fmt.Sprintf("ConfigMap must be set for storage mount at index %d", index),
+			}
 		}
 		if storage.Source.ConfigMap.Name == "" {
-			return newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				ReasonInvalid,
-				fmt.Sprintf("ConfigMap name must not be empty for storage mount at index %d", index),
-				mcpServer.Generation,
-			), false
+			return &ValidationError{
+				Reason:  ReasonInvalid,
+				Message: fmt.Sprintf("ConfigMap name must not be empty for storage mount at index %d", index),
+			}
 		}
 		// Skip validation if optional
 		if storage.Source.ConfigMap.Optional != nil && *storage.Source.ConfigMap.Optional {
-			return metav1.Condition{}, true
+			return nil
 		}
 		// Validate ConfigMap exists
 		configMap := &corev1.ConfigMap{}
@@ -960,49 +991,56 @@ func (r *MCPServerReconciler) validateStorageMount(
 			Name:      storage.Source.ConfigMap.Name,
 			Namespace: mcpServer.Namespace,
 		}, configMap); err != nil {
+			// Permanent errors - configuration is invalid
 			if apierrors.IsNotFound(err) {
-				return newCondition(
-					ConditionTypeAccepted,
-					metav1.ConditionFalse,
-					ReasonInvalid,
-					fmt.Sprintf("ConfigMap '%s' not found in namespace '%s'",
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("ConfigMap '%s' not found in namespace '%s'",
 						storage.Source.ConfigMap.Name, mcpServer.Namespace),
-					mcpServer.Generation,
-				), false
+				}
 			}
-			// Other errors (permissions, etc.) - still mark as not accepted
-			return newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				ReasonInvalid,
-				fmt.Sprintf("Failed to validate ConfigMap '%s': %v",
-					storage.Source.ConfigMap.Name, err),
-				mcpServer.Generation,
-			), false
+			if apierrors.IsBadRequest(err) {
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("Invalid ConfigMap reference '%s': %v",
+						storage.Source.ConfigMap.Name, err),
+				}
+			}
+			if apierrors.IsForbidden(err) {
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("No permission to access ConfigMap '%s': %v",
+						storage.Source.ConfigMap.Name, err),
+				}
+			}
+			if apierrors.IsUnauthorized(err) {
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("Not authorized to access ConfigMap '%s': %v",
+						storage.Source.ConfigMap.Name, err),
+				}
+			}
+			// All other errors are transient - return wrapped error to trigger retry
+			return fmt.Errorf("transient error validating ConfigMap '%s': %w",
+				storage.Source.ConfigMap.Name, err)
 		}
 
 	case mcpv1alpha1.StorageTypeSecret:
 		if storage.Source.Secret == nil {
-			return newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				ReasonInvalid,
-				fmt.Sprintf("Secret must be set for storage mount at index %d", index),
-				mcpServer.Generation,
-			), false
+			return &ValidationError{
+				Reason:  ReasonInvalid,
+				Message: fmt.Sprintf("Secret must be set for storage mount at index %d", index),
+			}
 		}
 		if storage.Source.Secret.SecretName == "" {
-			return newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				ReasonInvalid,
-				fmt.Sprintf("Secret name must not be empty for storage mount at index %d", index),
-				mcpServer.Generation,
-			), false
+			return &ValidationError{
+				Reason:  ReasonInvalid,
+				Message: fmt.Sprintf("Secret name must not be empty for storage mount at index %d", index),
+			}
 		}
 		// Skip validation if optional
 		if storage.Source.Secret.Optional != nil && *storage.Source.Secret.Optional {
-			return metav1.Condition{}, true
+			return nil
 		}
 		// Validate Secret exists
 		secret := &corev1.Secret{}
@@ -1010,59 +1048,67 @@ func (r *MCPServerReconciler) validateStorageMount(
 			Name:      storage.Source.Secret.SecretName,
 			Namespace: mcpServer.Namespace,
 		}, secret); err != nil {
+			// Permanent errors - configuration is invalid
 			if apierrors.IsNotFound(err) {
-				return newCondition(
-					ConditionTypeAccepted,
-					metav1.ConditionFalse,
-					ReasonInvalid,
-					fmt.Sprintf("Secret '%s' not found in namespace '%s'",
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("Secret '%s' not found in namespace '%s'",
 						storage.Source.Secret.SecretName, mcpServer.Namespace),
-					mcpServer.Generation,
-				), false
+				}
 			}
-			return newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				ReasonInvalid,
-				fmt.Sprintf("Failed to validate Secret '%s': %v",
-					storage.Source.Secret.SecretName, err),
-				mcpServer.Generation,
-			), false
+			if apierrors.IsBadRequest(err) {
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("Invalid Secret reference '%s': %v",
+						storage.Source.Secret.SecretName, err),
+				}
+			}
+			if apierrors.IsForbidden(err) {
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("No permission to access Secret '%s': %v",
+						storage.Source.Secret.SecretName, err),
+				}
+			}
+			if apierrors.IsUnauthorized(err) {
+				return &ValidationError{
+					Reason: ReasonInvalid,
+					Message: fmt.Sprintf("Not authorized to access Secret '%s': %v",
+						storage.Source.Secret.SecretName, err),
+				}
+			}
+			// All other errors are transient - return wrapped error to trigger retry
+			return fmt.Errorf("transient error validating Secret '%s': %w",
+				storage.Source.Secret.SecretName, err)
 		}
 
 	case mcpv1alpha1.StorageTypeEmptyDir:
 		// Validate EmptyDir configuration is present
 		if storage.Source.EmptyDir == nil {
-			return newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				ReasonInvalid,
-				fmt.Sprintf("EmptyDir must be set for storage mount at index %d", index),
-				mcpServer.Generation,
-			), false
+			return &ValidationError{
+				Reason:  ReasonInvalid,
+				Message: fmt.Sprintf("EmptyDir must be set for storage mount at index %d", index),
+			}
 		}
 
 	default:
 		// Unknown/unsupported storage type
-		return newCondition(
-			ConditionTypeAccepted,
-			metav1.ConditionFalse,
-			ReasonInvalid,
-			fmt.Sprintf("Unsupported storage type '%s' at index %d", storage.Source.Type, index),
-			mcpServer.Generation,
-		), false
+		return &ValidationError{
+			Reason:  ReasonInvalid,
+			Message: fmt.Sprintf("Unsupported storage type '%s' at index %d", storage.Source.Type, index),
+		}
 	}
-	return metav1.Condition{}, true
+	return nil
 }
 
 // validateEnvFrom validates a single envFrom configuration.
-// Returns an error condition and false if validation fails, otherwise returns zero condition and true.
+// Returns ValidationError for permanent configuration errors, wrapped error for transient errors, or nil for success.
 func (r *MCPServerReconciler) validateEnvFrom(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
 	envFrom corev1.EnvFromSource,
 	index int,
-) (metav1.Condition, bool) {
+) error {
 	if ref := envFrom.ConfigMapRef; ref != nil {
 		if ref.Optional == nil || !*ref.Optional {
 			configMap := &corev1.ConfigMap{}
@@ -1070,23 +1116,38 @@ func (r *MCPServerReconciler) validateEnvFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, configMap); err != nil {
+				// Permanent errors - configuration is invalid
 				if apierrors.IsNotFound(err) {
-					return newCondition(
-						ConditionTypeAccepted,
-						metav1.ConditionFalse,
-						ReasonInvalid,
-						fmt.Sprintf("ConfigMap '%s' (envFrom index %d) not found in namespace '%s'",
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("ConfigMap '%s' (envFrom index %d) not found in namespace '%s'",
 							ref.Name, index, mcpServer.Namespace),
-						mcpServer.Generation,
-					), false
+					}
 				}
-				return newCondition(
-					ConditionTypeAccepted,
-					metav1.ConditionFalse,
-					ReasonInvalid,
-					fmt.Sprintf("Failed to validate ConfigMap '%s': %v", ref.Name, err),
-					mcpServer.Generation,
-				), false
+				if apierrors.IsBadRequest(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Invalid ConfigMap reference '%s' (envFrom index %d): %v",
+							ref.Name, index, err),
+					}
+				}
+				if apierrors.IsForbidden(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("No permission to access ConfigMap '%s' (envFrom index %d): %v",
+							ref.Name, index, err),
+					}
+				}
+				if apierrors.IsUnauthorized(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Not authorized to access ConfigMap '%s' (envFrom index %d): %v",
+							ref.Name, index, err),
+					}
+				}
+				// All other errors are transient
+				return fmt.Errorf("transient error validating ConfigMap '%s' (envFrom index %d): %w",
+					ref.Name, index, err)
 			}
 		}
 	}
@@ -1097,39 +1158,54 @@ func (r *MCPServerReconciler) validateEnvFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, secret); err != nil {
+				// Permanent errors - configuration is invalid
 				if apierrors.IsNotFound(err) {
-					return newCondition(
-						ConditionTypeAccepted,
-						metav1.ConditionFalse,
-						ReasonInvalid,
-						fmt.Sprintf("Secret '%s' (envFrom index %d) not found in namespace '%s'",
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Secret '%s' (envFrom index %d) not found in namespace '%s'",
 							ref.Name, index, mcpServer.Namespace),
-						mcpServer.Generation,
-					), false
+					}
 				}
-				return newCondition(
-					ConditionTypeAccepted,
-					metav1.ConditionFalse,
-					ReasonInvalid,
-					fmt.Sprintf("Failed to validate Secret '%s': %v", ref.Name, err),
-					mcpServer.Generation,
-				), false
+				if apierrors.IsBadRequest(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Invalid Secret reference '%s' (envFrom index %d): %v",
+							ref.Name, index, err),
+					}
+				}
+				if apierrors.IsForbidden(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("No permission to access Secret '%s' (envFrom index %d): %v",
+							ref.Name, index, err),
+					}
+				}
+				if apierrors.IsUnauthorized(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Not authorized to access Secret '%s' (envFrom index %d): %v",
+							ref.Name, index, err),
+					}
+				}
+				// All other errors are transient
+				return fmt.Errorf("transient error validating Secret '%s' (envFrom index %d): %w",
+					ref.Name, index, err)
 			}
 		}
 	}
-	return metav1.Condition{}, true
+	return nil
 }
 
 // validateEnvValueFrom validates a single env var's valueFrom configuration.
-// Returns an error condition and false if validation fails, otherwise returns zero condition and true.
+// Returns ValidationError for permanent configuration errors, wrapped error for transient errors, or nil for success.
 func (r *MCPServerReconciler) validateEnvValueFrom(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
 	env corev1.EnvVar,
 	index int,
-) (metav1.Condition, bool) {
+) error {
 	if env.ValueFrom == nil {
-		return metav1.Condition{}, true
+		return nil
 	}
 	if ref := env.ValueFrom.ConfigMapKeyRef; ref != nil {
 		if ref.Optional == nil || !*ref.Optional {
@@ -1138,23 +1214,38 @@ func (r *MCPServerReconciler) validateEnvValueFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, configMap); err != nil {
+				// Permanent errors - configuration is invalid
 				if apierrors.IsNotFound(err) {
-					return newCondition(
-						ConditionTypeAccepted,
-						metav1.ConditionFalse,
-						ReasonInvalid,
-						fmt.Sprintf("ConfigMap '%s' referenced by env var '%s' (env index %d) not found in namespace '%s'",
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("ConfigMap '%s' referenced by env var '%s' (env index %d) not found in namespace '%s'",
 							ref.Name, env.Name, index, mcpServer.Namespace),
-						mcpServer.Generation,
-					), false
+					}
 				}
-				return newCondition(
-					ConditionTypeAccepted,
-					metav1.ConditionFalse,
-					ReasonInvalid,
-					fmt.Sprintf("Failed to validate ConfigMap '%s' referenced by env var '%s': %v", ref.Name, env.Name, err),
-					mcpServer.Generation,
-				), false
+				if apierrors.IsBadRequest(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Invalid ConfigMap reference '%s' referenced by env var '%s' (env index %d): %v",
+							ref.Name, env.Name, index, err),
+					}
+				}
+				if apierrors.IsForbidden(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("No permission to access ConfigMap '%s' referenced by env var '%s' (env index %d): %v",
+							ref.Name, env.Name, index, err),
+					}
+				}
+				if apierrors.IsUnauthorized(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Not authorized to access ConfigMap '%s' referenced by env var '%s' (env index %d): %v",
+							ref.Name, env.Name, index, err),
+					}
+				}
+				// All other errors are transient
+				return fmt.Errorf("transient error validating ConfigMap '%s' referenced by env var '%s' (env index %d): %w",
+					ref.Name, env.Name, index, err)
 			}
 		}
 	}
@@ -1165,64 +1256,73 @@ func (r *MCPServerReconciler) validateEnvValueFrom(
 				Name:      ref.Name,
 				Namespace: mcpServer.Namespace,
 			}, secret); err != nil {
+				// Permanent errors - configuration is invalid
 				if apierrors.IsNotFound(err) {
-					return newCondition(
-						ConditionTypeAccepted,
-						metav1.ConditionFalse,
-						ReasonInvalid,
-						fmt.Sprintf("Secret '%s' referenced by env var '%s' (env index %d) not found in namespace '%s'",
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Secret '%s' referenced by env var '%s' (env index %d) not found in namespace '%s'",
 							ref.Name, env.Name, index, mcpServer.Namespace),
-						mcpServer.Generation,
-					), false
+					}
 				}
-				return newCondition(
-					ConditionTypeAccepted,
-					metav1.ConditionFalse,
-					ReasonInvalid,
-					fmt.Sprintf("Failed to validate Secret '%s' referenced by env var '%s': %v", ref.Name, env.Name, err),
-					mcpServer.Generation,
-				), false
+				if apierrors.IsBadRequest(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Invalid Secret reference '%s' referenced by env var '%s' (env index %d): %v",
+							ref.Name, env.Name, index, err),
+					}
+				}
+				if apierrors.IsForbidden(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("No permission to access Secret '%s' referenced by env var '%s' (env index %d): %v",
+							ref.Name, env.Name, index, err),
+					}
+				}
+				if apierrors.IsUnauthorized(err) {
+					return &ValidationError{
+						Reason: ReasonInvalid,
+						Message: fmt.Sprintf("Not authorized to access Secret '%s' referenced by env var '%s' (env index %d): %v",
+							ref.Name, env.Name, index, err),
+					}
+				}
+				// All other errors are transient
+				return fmt.Errorf("transient error validating Secret '%s' referenced by env var '%s' (env index %d): %w",
+					ref.Name, env.Name, index, err)
 			}
 		}
 	}
-	return metav1.Condition{}, true
+	return nil
 }
 
-// setAcceptedCondition validates the MCPServer configuration and sets the Accepted condition.
-// Returns the condition and a boolean indicating if configuration is valid.
+// setAcceptedCondition validates the MCPServer configuration.
+// Returns ValidationError for permanent configuration errors, wrapped error for transient errors, or nil for success.
 func (r *MCPServerReconciler) setAcceptedCondition(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
-) (metav1.Condition, bool) {
+) error {
 	// Validate storage mounts
 	for i, storage := range mcpServer.Spec.Config.Storage {
-		if condition, valid := r.validateStorageMount(ctx, mcpServer, storage, i); !valid {
-			return condition, false
+		if err := r.validateStorageMount(ctx, mcpServer, storage, i); err != nil {
+			return err
 		}
 	}
 
 	// Validate envFrom references
 	for i, envFrom := range mcpServer.Spec.Config.EnvFrom {
-		if condition, valid := r.validateEnvFrom(ctx, mcpServer, envFrom, i); !valid {
-			return condition, false
+		if err := r.validateEnvFrom(ctx, mcpServer, envFrom, i); err != nil {
+			return err
 		}
 	}
 
 	// Validate env valueFrom references
 	for i, env := range mcpServer.Spec.Config.Env {
-		if condition, valid := r.validateEnvValueFrom(ctx, mcpServer, env, i); !valid {
-			return condition, false
+		if err := r.validateEnvValueFrom(ctx, mcpServer, env, i); err != nil {
+			return err
 		}
 	}
 
 	// All validation passed
-	return newCondition(
-		ConditionTypeAccepted,
-		metav1.ConditionTrue,
-		ReasonValid,
-		"Configuration is valid",
-		mcpServer.Generation,
-	), true
+	return nil
 }
 
 // extractConfigMapNames is an index extractor that returns all ConfigMap names

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -140,7 +140,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
 
 	// Validate configuration
-	if err := r.setAcceptedCondition(ctx, mcpServer); err != nil {
+	if err := r.validateConfig(ctx, mcpServer); err != nil {
 		var validationErr *ValidationError
 		if errors.As(err, &validationErr) {
 			// Permanent validation error - mark configuration as invalid
@@ -654,7 +654,7 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 }
 
 // processStorageMounts builds volumes and volume mounts from the MCPServer storage configuration.
-// Validation of referenced ConfigMaps and Secrets is done in setAcceptedCondition.
+// Validation of referenced ConfigMaps and Secrets is done in validateConfig.
 func (r *MCPServerReconciler) processStorageMounts(
 	mcpServer *mcpv1alpha1.MCPServer,
 ) ([]corev1.Volume, []corev1.VolumeMount) {
@@ -693,10 +693,10 @@ func (r *MCPServerReconciler) processStorageMounts(
 
 		switch storage.Source.Type {
 		case mcpv1alpha1.StorageTypeConfigMap:
-			// Validation already done in setAcceptedCondition
+			// Validation already done in validateConfig
 			volume.ConfigMap = storage.Source.ConfigMap
 		case mcpv1alpha1.StorageTypeSecret:
-			// Validation already done in setAcceptedCondition
+			// Validation already done in validateConfig
 			volume.Secret = storage.Source.Secret
 		case mcpv1alpha1.StorageTypeEmptyDir:
 			// No validation needed - EmptyDir is created by Kubernetes
@@ -1294,9 +1294,9 @@ func (r *MCPServerReconciler) validateEnvValueFrom(
 	return nil
 }
 
-// setAcceptedCondition validates the MCPServer configuration.
+// validateConfig validates the MCPServer configuration.
 // Returns ValidationError for permanent configuration errors, wrapped error for transient errors, or nil for success.
-func (r *MCPServerReconciler) setAcceptedCondition(
+func (r *MCPServerReconciler) validateConfig(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
 ) error {

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -4002,7 +4002,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 		})
 	})
 
-	Context("setAcceptedCondition validation", func() {
+	Context("validateConfig validation", func() {
 		ctx := context.Background()
 
 		It("should reject EmptyDir with nil EmptyDir configuration", func() {
@@ -4037,7 +4037,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			var validationErr *ValidationError
 			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
@@ -4076,7 +4076,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			var validationErr *ValidationError
 			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
@@ -4119,7 +4119,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			var validationErr *ValidationError
 			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
@@ -4162,7 +4162,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			var validationErr *ValidationError
 			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
@@ -4207,7 +4207,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -4247,7 +4247,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -4280,7 +4280,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -4337,7 +4337,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			// Should NOT be a ValidationError - should be a transient error
 			var validationErr *ValidationError
@@ -4396,7 +4396,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			// Should NOT be a ValidationError - should be a transient error
 			var validationErr *ValidationError
@@ -4452,7 +4452,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			var validationErr *ValidationError
 			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
@@ -4512,7 +4512,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			var validationErr *ValidationError
 			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
@@ -4572,7 +4572,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
 			// Should be a ValidationError - Forbidden is permanent
 			var validationErr *ValidationError

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
@@ -4036,11 +4037,12 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			condition, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
-			Expect(valid).To(BeFalse())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(ReasonInvalid))
-			Expect(condition.Message).To(ContainSubstring("EmptyDir must be set"))
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
+			Expect(validationErr.Reason).To(Equal(ReasonInvalid))
+			Expect(validationErr.Message).To(ContainSubstring("EmptyDir must be set"))
 		})
 
 		It("should reject unknown storage type", func() {
@@ -4074,12 +4076,13 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			condition, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
-			Expect(valid).To(BeFalse())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(ReasonInvalid))
-			Expect(condition.Message).To(ContainSubstring("Unsupported storage type"))
-			Expect(condition.Message).To(ContainSubstring("UnknownType"))
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
+			Expect(validationErr.Reason).To(Equal(ReasonInvalid))
+			Expect(validationErr.Message).To(ContainSubstring("Unsupported storage type"))
+			Expect(validationErr.Message).To(ContainSubstring("UnknownType"))
 		})
 
 		It("should reject env valueFrom with missing ConfigMap", func() {
@@ -4116,12 +4119,13 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			condition, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
-			Expect(valid).To(BeFalse())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(ReasonInvalid))
-			Expect(condition.Message).To(ContainSubstring("missing-cm"))
-			Expect(condition.Message).To(ContainSubstring("MY_VAR"))
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
+			Expect(validationErr.Reason).To(Equal(ReasonInvalid))
+			Expect(validationErr.Message).To(ContainSubstring("missing-cm"))
+			Expect(validationErr.Message).To(ContainSubstring("MY_VAR"))
 		})
 
 		It("should reject env valueFrom with missing Secret", func() {
@@ -4158,12 +4162,13 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			condition, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
-			Expect(valid).To(BeFalse())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(ReasonInvalid))
-			Expect(condition.Message).To(ContainSubstring("missing-secret"))
-			Expect(condition.Message).To(ContainSubstring("SECRET_VAR"))
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
+			Expect(validationErr.Reason).To(Equal(ReasonInvalid))
+			Expect(validationErr.Message).To(ContainSubstring("missing-secret"))
+			Expect(validationErr.Message).To(ContainSubstring("SECRET_VAR"))
 		})
 
 		It("should accept env valueFrom with optional missing ConfigMap", func() {
@@ -4202,8 +4207,8 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			_, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
-			Expect(valid).To(BeTrue())
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should accept env valueFrom with optional missing Secret", func() {
@@ -4242,8 +4247,8 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			_, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
-			Expect(valid).To(BeTrue())
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should accept env with literal value (no valueFrom)", func() {
@@ -4275,9 +4280,305 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				},
 			}
 
-			condition, valid := reconciler.setAcceptedCondition(ctx, mcpServer)
-			Expect(valid).To(BeTrue())
-			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return transient error for ConfigMap timeout without marking invalid", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			// Create a fake client that returns timeout error for ConfigMap Get
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.ConfigMap); ok {
+							return &errors.StatusError{
+								ErrStatus: metav1.Status{
+									Status:  metav1.StatusFailure,
+									Code:    500,
+									Reason:  metav1.StatusReasonInternalError,
+									Message: "the server has timed out",
+								},
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Storage: []mcpv1alpha1.StorageMount{
+							{
+								Path: "/data",
+								Source: mcpv1alpha1.StorageSource{
+									Type: mcpv1alpha1.StorageTypeConfigMap,
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "test-config",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			// Should NOT be a ValidationError - should be a transient error
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("transient error validating ConfigMap"))
+		})
+
+		It("should return transient error for Secret timeout without marking invalid", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			// Create a fake client that returns timeout error for Secret Get
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.Secret); ok {
+							return &errors.StatusError{
+								ErrStatus: metav1.Status{
+									Status:  metav1.StatusFailure,
+									Code:    503,
+									Reason:  metav1.StatusReasonServiceUnavailable,
+									Message: "the server is currently unable to handle the request",
+								},
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Storage: []mcpv1alpha1.StorageMount{
+							{
+								Path: "/secret",
+								Source: mcpv1alpha1.StorageSource{
+									Type: mcpv1alpha1.StorageTypeSecret,
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test-secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			// Should NOT be a ValidationError - should be a transient error
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("transient error validating Secret"))
+		})
+
+		It("should return transient error for envFrom ConfigMap timeout", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.ConfigMap); ok {
+							return &errors.StatusError{
+								ErrStatus: metav1.Status{
+									Status:  metav1.StatusFailure,
+									Code:    429,
+									Reason:  metav1.StatusReasonTooManyRequests,
+									Message: "rate limited",
+								},
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						EnvFrom: []corev1.EnvFromSource{
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "test-config",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("transient error validating ConfigMap"))
+			Expect(err.Error()).To(ContainSubstring("envFrom"))
+		})
+
+		It("should return transient error for env valueFrom Secret timeout", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.Secret); ok {
+							return &errors.StatusError{
+								ErrStatus: metav1.Status{
+									Status:  metav1.StatusFailure,
+									Code:    504,
+									Reason:  metav1.StatusReasonTimeout,
+									Message: "gateway timeout",
+								},
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Env: []corev1.EnvVar{
+							{
+								Name: "MY_SECRET",
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "test-secret",
+										},
+										Key: "key",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("transient error validating Secret"))
+			Expect(err.Error()).To(ContainSubstring("env"))
+		})
+
+		It("should return ValidationError for Forbidden (permanent error)", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.ConfigMap); ok {
+							return &errors.StatusError{
+								ErrStatus: metav1.Status{
+									Status:  metav1.StatusFailure,
+									Code:    403,
+									Reason:  metav1.StatusReasonForbidden,
+									Message: "forbidden: User cannot get configmaps",
+								},
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Storage: []mcpv1alpha1.StorageMount{
+							{
+								Path: "/data",
+								Source: mcpv1alpha1.StorageSource{
+									Type: mcpv1alpha1.StorageTypeConfigMap,
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "test-config",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := reconciler.setAcceptedCondition(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			// Should be a ValidationError - Forbidden is permanent
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
+			Expect(validationErr.Reason).To(Equal(ReasonInvalid))
+			Expect(validationErr.Message).To(ContainSubstring("No permission to access ConfigMap"))
 		})
 	})
 

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -4520,7 +4520,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			Expect(err.Error()).To(ContainSubstring("env"))
 		})
 
-		It("should return ValidationError for Forbidden (permanent error)", func() {
+		It("should return transient error for Forbidden", func() {
 			scheme := runtime.NewScheme()
 			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
@@ -4574,11 +4574,131 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			err := reconciler.validateConfig(ctx, mcpServer)
 			Expect(err).To(HaveOccurred())
-			// Should be a ValidationError - Forbidden is permanent
+			// Forbidden is transient - RBAC changes don't trigger reconciliation
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("transient error validating ConfigMap"))
+		})
+
+		It("should return transient error for Unauthorized", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.ConfigMap); ok {
+							return &errors.StatusError{
+								ErrStatus: metav1.Status{
+									Status:  metav1.StatusFailure,
+									Code:    401,
+									Reason:  metav1.StatusReasonUnauthorized,
+									Message: "unauthorized",
+								},
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Storage: []mcpv1alpha1.StorageMount{
+							{
+								Path: "/data",
+								Source: mcpv1alpha1.StorageSource{
+									Type: mcpv1alpha1.StorageTypeConfigMap,
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "test-config",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := reconciler.validateConfig(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			// Unauthorized is transient - RBAC changes don't trigger reconciliation
+			var validationErr *ValidationError
+			Expect(stderrors.As(err, &validationErr)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("transient error validating ConfigMap"))
+		})
+
+		It("should return ValidationError for BadRequest (permanent error)", func() {
+			scheme := runtime.NewScheme()
+			Expect(mcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*corev1.ConfigMap); ok {
+							return &errors.StatusError{
+								ErrStatus: metav1.Status{
+									Status:  metav1.StatusFailure,
+									Code:    400,
+									Reason:  metav1.StatusReasonBadRequest,
+									Message: "bad request",
+								},
+							}
+						}
+						return client.Get(ctx, key, obj, opts...)
+					},
+				}).Build()
+
+			reconciler := &MCPServerReconciler{
+				Client: fakeClient,
+				Scheme: scheme,
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-server",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						Storage: []mcpv1alpha1.StorageMount{
+							{
+								Path: "/data",
+								Source: mcpv1alpha1.StorageSource{
+									Type: mcpv1alpha1.StorageTypeConfigMap,
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "test-config",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err := reconciler.validateConfig(ctx, mcpServer)
+			Expect(err).To(HaveOccurred())
+			// BadRequest is a permanent ValidationError
 			var validationErr *ValidationError
 			Expect(stderrors.As(err, &validationErr)).To(BeTrue())
 			Expect(validationErr.Reason).To(Equal(ReasonInvalid))
-			Expect(validationErr.Message).To(ContainSubstring("No permission to access ConfigMap"))
+			Expect(validationErr.Message).To(ContainSubstring("Invalid ConfigMap reference"))
 		})
 	})
 


### PR DESCRIPTION
Fixes #86 

I know there are some duplicated code, when handling the errors.

I tried to create a structure which deduplicates this code, which resulted in too many changes. I will do that as a follow up.