### PR TITLE
feat(makefile): add local Go coverage report targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ Dockerfile.cross
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Coverage reports from `make test-cover`
+out/coverage.html
+out/coverage.txt
+
 # Go workspace file
 go.work
 

--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,36 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# Coverage profile written by `make test` (same default as kubebuilder scaffold).
+COVER_PROFILE ?= cover.out
+# Human-readable reports (not used by CI; see kubernetes-sigs/cluster-api `test-cover` pattern).
+COVER_OUTPUT_DIR ?= out
+
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" \
-		go test $$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v /e2e) -coverprofile cover.out
+		go test $$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v /e2e) -coverprofile $(COVER_PROFILE)
+
+.PHONY: test-cover
+test-cover: test ## Run unit tests and write text + HTML coverage reports under out/ (informational).
+	mkdir -p $(COVER_OUTPUT_DIR)
+	go tool cover -func=$(COVER_PROFILE) -o $(COVER_OUTPUT_DIR)/coverage.txt
+	go tool cover -html=$(COVER_PROFILE) -o $(COVER_OUTPUT_DIR)/coverage.html
+	@echo "Wrote $(COVER_OUTPUT_DIR)/coverage.html and $(COVER_OUTPUT_DIR)/coverage.txt"
+
+.PHONY: cover-func
+cover-func: ## Print per-function coverage to stdout (requires cover.out; run make test first).
+	@test -f $(COVER_PROFILE) || { echo "missing $(COVER_PROFILE); run make test first" >&2; exit 1; }
+	go tool cover -func=$(COVER_PROFILE)
+
+.PHONY: cover-html
+cover-html: ## Open HTML coverage in a browser (requires cover.out; run make test first).
+	@test -f $(COVER_PROFILE) || { echo "missing $(COVER_PROFILE); run make test first" >&2; exit 1; }
+	go tool cover -html=$(COVER_PROFILE)
+
+.PHONY: cover-clean
+cover-clean: ## Remove cover.out and out/coverage.{txt,html} from test-cover.
+	rm -f $(COVER_PROFILE) $(COVER_OUTPUT_DIR)/coverage.txt $(COVER_OUTPUT_DIR)/coverage.html
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'test/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.

--- a/site-src/contributing/index.md
+++ b/site-src/contributing/index.md
@@ -19,7 +19,8 @@ From the repository root:
 - **Build:** `make build`
 - **Format:** `make fmt`
 - **Lint / vet:** `make lint`
-- **Tests:** `make test`
+- **Tests:** `make test` (writes `cover.out` for coverage)
+- **Test coverage:** `make test` writes `cover.out`. Run `make test-cover` to refresh tests and emit `out/coverage.html` and `out/coverage.txt` (`go tool cover`). With `cover.out` present, `make cover-func` prints a per-function summary and `make cover-html` opens the interactive HTML report in a browser (local). Remove generated artifacts with `make cover-clean`.
 - **Generate manifests:** `make manifests generate`
 
 After making changes, open a pull request on GitHub. Ensure CI passes and address any review feedback.


### PR DESCRIPTION
Add optional Makefile targets so contributors can turn the existing Go coverage profile (cover.out from make test) into text and HTML reports under out/, without memorizing go tool cover flags. Document the workflow on the contributing page and ignore generated report files.

References (patterns this follows)
These are examples, not copies—other kubernetes-sigs projects use the same building blocks (go test -coverprofile, go tool cover -func, go tool cover -html) and similar Make targets:

kubernetes-sigs/cluster-api — test-cover runs tests with a profile, then writes -func and -html outputs under out/

Makefile: https://github.com/kubernetes-sigs/cluster-api/blob/main/Makefile (search for test-cover)
kubernetes-sigs/external-dns — cover / cover-html and go-test using go tool cover

Makefile: https://github.com/kubernetes-sigs/external-dns/blob/master/Makefile (see cover, cover-html, go-test)
kubernetes-sigs/cluster-api (historical discussion) — PR adding / discussing Makefile coverage reporting

https://github.com/kubernetes-sigs/cluster-api/pull/3310
kubernetes-sigs/kustomize (older example) — Makefile cover target

https://github.com/kubernetes-sigs/kustomize/pull/1474

**Related issue**
https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/105

**How to try it**

```
make test          # writes cover.out
make cover-func    # summary to stdout (needs cover.out)
make test-cover    # writes out/coverage.txt and out/coverage.html
make cover-clean   # removes cover.out and out/coverage.
```

- <img width="2158" height="1760" alt="image" src="https://github.com/user-attachments/assets/44932327-0d89-4b16-9c8a-fbd63a4a60d0" />
- <img width="3436" height="1910" alt="image" src="https://github.com/user-attachments/assets/2590fef5-7fc9-4384-bac9-96ba31a343de" />
- <img width="2194" height="602" alt="image" src="https://github.com/user-attachments/assets/6119be30-ee8d-45c7-8e8c-397082f11a4a" />