### PR TITLE
Add default MCP readiness probe and controller-level MCP handshake validation

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -23,9 +23,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -52,7 +54,17 @@ import (
 
 const (
 	fieldManager = "mcpserver-controller"
+
+	// defaultMCPPath is the default HTTP path for MCP endpoints, matching the
+	// kubebuilder default on ServerConfig.Path.
+	defaultMCPPath = "/mcp"
+
+	// mcpClientName is the client name sent during MCP handshake.
+	mcpClientName = "mcp-lifecycle-operator"
 )
+
+// MCPClientVersion is the version sent during MCP handshake. Bump with releases.
+var MCPClientVersion = "v0.1.0"
 
 // ValidationError represents a permanent configuration validation error.
 // These errors indicate the MCPServer configuration is invalid and should not be retried.
@@ -82,18 +94,29 @@ const (
 
 // Reasons for Ready condition.
 const (
-	ReasonAvailable             = "Available"
-	ReasonConfigurationInvalid  = "ConfigurationInvalid"
-	ReasonDeploymentUnavailable = "DeploymentUnavailable"
-	ReasonServiceUnavailable    = "ServiceUnavailable"
-	ReasonScaledToZero          = "ScaledToZero"
-	ReasonInitializing          = "Initializing"
+	ReasonAvailable              = "Available"
+	ReasonConfigurationInvalid   = "ConfigurationInvalid"
+	ReasonDeploymentUnavailable  = "DeploymentUnavailable"
+	ReasonServiceUnavailable     = "ServiceUnavailable"
+	ReasonScaledToZero           = "ScaledToZero"
+	ReasonInitializing           = "Initializing"
+	ReasonMCPEndpointUnavailable = "MCPEndpointUnavailable"
 )
 
 // Reconciliation constants.
 const (
 	// requeueDelayDeploymentUnavailable is the delay before requeuing when a deployment is not yet available.
 	requeueDelayDeploymentUnavailable = 15 * time.Second
+	// requeueDelayMCPHandshake is the initial delay before requeuing when an MCP handshake fails.
+	requeueDelayMCPHandshake = 10 * time.Second
+	// maxRequeueDelayMCPHandshake is the maximum requeue delay after exponential backoff.
+	maxRequeueDelayMCPHandshake = 2 * time.Minute
+	// mcpHandshakeTimeout is the context timeout for a single MCP handshake attempt.
+	mcpHandshakeTimeout = 15 * time.Second
+	// maxMCPHandshakeRetries is the maximum number of MCP handshake failures before
+	// the controller stops requeuing. The status will remain MCPEndpointUnavailable
+	// until the next spec change triggers a new reconciliation.
+	maxMCPHandshakeRetries = 10
 )
 
 // Index keys for field indexing.
@@ -107,7 +130,8 @@ const (
 // MCPServerReconciler reconciles a MCPServer object
 type MCPServerReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	MCPDialer func(ctx context.Context, url string) error // nil = use real MCP handshake
 }
 
 // +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers,verbs=get;list;watch;create;update;patch;delete
@@ -260,7 +284,54 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Build status
 	path := mcpServer.Spec.Config.Path
 	if path == "" {
-		path = "/mcp"
+		path = defaultMCPPath
+	}
+
+	mcpURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s",
+		mcpServer.Name, mcpServer.Namespace, mcpServer.Spec.Config.Port, path)
+
+	// If deployment-level readiness reports Available, verify the MCP endpoint.
+	// Only perform the handshake on transitions: skip if the endpoint was already
+	// verified for this generation (Ready=True, reason=Available, matching generation).
+	if readyCondition.Status == metav1.ConditionTrue && readyCondition.Reason == ReasonAvailable {
+		existingReady := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeReady)
+		alreadyVerified := existingReady != nil &&
+			existingReady.Status == metav1.ConditionTrue &&
+			existingReady.Reason == ReasonAvailable &&
+			mcpServer.Status.ObservedGeneration == mcpServer.Generation
+
+		if !alreadyVerified {
+			dialer := r.MCPDialer
+			if dialer == nil {
+				dialer = r.verifyMCPEndpoint
+			}
+			dialCtx, dialCancel := context.WithTimeout(ctx, mcpHandshakeTimeout)
+			defer dialCancel()
+			if err := dialer(dialCtx, mcpURL); err != nil {
+				// An auth rejection (401/403) proves the server is running and
+				// listening for MCP requests - treat it as reachable.
+				if isHTTPAuthError(err) {
+					logger.Info("MCP endpoint returned auth error, treating as reachable", "url", mcpURL, "error", err)
+				} else {
+					logger.Info("MCP endpoint handshake failed", "url", mcpURL, "error", err)
+					readyCondition = newCondition(
+						ConditionTypeReady,
+						metav1.ConditionFalse,
+						ReasonMCPEndpointUnavailable,
+						fmt.Sprintf("MCP endpoint is not serving a valid MCP protocol: %v", err),
+						mcpServer.Generation,
+					)
+					// Only preserve LastTransitionTime on False -> False (steady state).
+					// A True -> False transition must record a new timestamp so the
+					// backoff retry counter starts from the correct point.
+					if existingReady == nil || existingReady.Status != metav1.ConditionTrue {
+						preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+					}
+				}
+			} else {
+				logger.Info("MCP endpoint verified successfully", "url", mcpURL)
+			}
+		}
 	}
 
 	status := acv1alpha1.MCPServerStatus().
@@ -268,8 +339,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		WithDeploymentName(existingDeployment.Name).
 		WithServiceName(mcpServer.Name).
 		WithAddress(acv1alpha1.MCPServerAddress().
-			WithURL(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s",
-				mcpServer.Name, mcpServer.Namespace, mcpServer.Spec.Config.Port, path))).
+			WithURL(mcpURL)).
 		WithConditions(
 			conditionToAC(acceptedCondition),
 			conditionToAC(readyCondition),
@@ -291,7 +361,100 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{RequeueAfter: requeueDelayDeploymentUnavailable}, nil
 	}
 
+	// If MCP endpoint is not yet reachable, requeue with exponential backoff up to a max retry count.
+	if readyCondition.Status == metav1.ConditionFalse && readyCondition.Reason == ReasonMCPEndpointUnavailable {
+		retryCount := mcpHandshakeRetryCount(mcpServer.Status.Conditions)
+		if retryCount >= maxMCPHandshakeRetries {
+			logger.Info("MCP handshake retries exhausted, not requeuing",
+				"retries", retryCount, "max", maxMCPHandshakeRetries)
+			return ctrl.Result{}, nil
+		}
+		delay := mcpHandshakeBackoff(retryCount)
+		logger.Info("MCP endpoint not yet reachable, requeuing with backoff",
+			"requeueAfter", delay, "retry", retryCount+1, "maxRetries", maxMCPHandshakeRetries)
+		return ctrl.Result{RequeueAfter: delay}, nil
+	}
+
 	return ctrl.Result{}, nil
+}
+
+// verifyMCPEndpoint performs an MCP initialize handshake against the given URL
+// to verify the endpoint actually speaks the MCP protocol.
+// It uses a dedicated context for the connection so that cancelling it tears
+// down the transport without sending an HTTP DELETE to the server (which some
+// MCP servers do not handle gracefully).
+func (r *MCPServerReconciler) verifyMCPEndpoint(ctx context.Context, url string) error {
+	// Use a child context so we can cancel the connection without affecting
+	// the caller's context. Cancelling instead of calling session.Close()
+	// avoids sending an HTTP DELETE that can destabilize some MCP servers.
+	connCtx, connCancel := context.WithCancel(ctx)
+	defer connCancel()
+
+	mcpClient := mcp.NewClient(
+		&mcp.Implementation{
+			Name:    mcpClientName,
+			Version: MCPClientVersion,
+		},
+		nil,
+	)
+
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:             url,
+		HTTPClient:           &http.Client{Timeout: 10 * time.Second},
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1, // disable retries; the controller handles requeue
+	}
+
+	_, err := mcpClient.Connect(connCtx, transport, nil)
+	return err
+}
+
+// mcpHandshakeBackoff computes an exponential backoff delay for MCP handshake
+// retries: 10s, 20s, 40s, 80s, capped at maxRequeueDelayMCPHandshake.
+func mcpHandshakeBackoff(retryCount int) time.Duration {
+	delay := requeueDelayMCPHandshake
+	for range retryCount {
+		delay *= 2
+		if delay > maxRequeueDelayMCPHandshake {
+			return maxRequeueDelayMCPHandshake
+		}
+	}
+	return delay
+}
+
+// mcpHandshakeRetryCount estimates how many consecutive MCP handshake failures
+// have occurred by computing elapsed time since the Ready condition last
+// transitioned to MCPEndpointUnavailable.
+func mcpHandshakeRetryCount(conditions []metav1.Condition) int {
+	existing := meta.FindStatusCondition(conditions, ConditionTypeReady)
+	if existing == nil || existing.Reason != ReasonMCPEndpointUnavailable {
+		return 0
+	}
+	elapsed := time.Since(existing.LastTransitionTime.Time)
+	// Walk the backoff schedule to count how many retries fit in the elapsed time.
+	total := time.Duration(0)
+	count := 0
+	for count < maxMCPHandshakeRetries {
+		total += mcpHandshakeBackoff(count)
+		if total > elapsed {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+// isHTTPAuthError checks whether the error from the MCP SDK indicates an HTTP
+// 401 Unauthorized or 403 Forbidden response. The SDK does not wrap these with
+// a sentinel error type; it returns a plain error whose message ends with the
+// status text from net/http (e.g. "POST http://...: Unauthorized").
+func isHTTPAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.HasSuffix(msg, ": "+http.StatusText(http.StatusUnauthorized)) ||
+		strings.HasSuffix(msg, ": "+http.StatusText(http.StatusForbidden))
 }
 
 // determineReadyCondition analyzes deployment status and accepted condition to determine
@@ -601,16 +764,24 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 		container.Resources = *mcpServer.Spec.Runtime.Resources
 	}
 
-	// Apply health probes if specified.
-	// The probes are passed directly to the container spec without any transformation,
-	// providing full compatibility with the Kubernetes Probe API. This allows users to
-	// configure all probe types (httpGet, tcpSocket, exec, grpc) and all parameters
-	// (delays, periods, thresholds) using standard Kubernetes probe configuration.
+	// Apply health probes.
+	// User-specified probes are passed directly to the container spec without any
+	// transformation, providing full compatibility with the Kubernetes Probe API.
+	// This allows users to configure all probe types (httpGet, tcpSocket, exec, grpc)
+	// and all parameters (delays, periods, thresholds) using standard Kubernetes
+	// probe configuration.
+	//
+	// When no readiness probe is specified, a default TCP socket probe is injected
+	// targeting the configured MCP port. This ensures that containers not listening
+	// on the expected port will not report as Ready. The controller-level MCP
+	// handshake provides the semantic protocol validation.
 	if mcpServer.Spec.Runtime.Health.LivenessProbe != nil {
 		container.LivenessProbe = mcpServer.Spec.Runtime.Health.LivenessProbe
 	}
 	if mcpServer.Spec.Runtime.Health.ReadinessProbe != nil {
 		container.ReadinessProbe = mcpServer.Spec.Runtime.Health.ReadinessProbe
+	} else {
+		container.ReadinessProbe = defaultMCPReadinessProbe(mcpServer.Spec.Config.Port)
 	}
 
 	// Process storage mounts
@@ -906,6 +1077,23 @@ func defaultContainerSecurityContext() *corev1.SecurityContext {
 		RunAsNonRoot:             ptr.To(true),
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}
+
+// defaultMCPReadinessProbe returns a TCP socket readiness probe targeting the
+// configured MCP port. This is injected when the user does not specify a custom
+// readiness probe, ensuring that containers not listening on the expected port
+// will not report as Ready. A TCP probe is used instead of HTTP GET because
+// the MCP Streamable HTTP spec only requires POST support on the endpoint path;
+// a GET probe would reject valid MCP servers that do not serve GET.
+// The controller-level MCP handshake provides the semantic protocol validation.
+func defaultMCPReadinessProbe(port int32) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Port: intstr.FromInt32(port),
+			},
+		},
 	}
 }
 

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -929,7 +929,10 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		}, deployment)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
-		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
+		// With no user-specified readiness probe, the default TCP socket readiness probe is injected
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(8080)))
 	})
 
 	It("should handle only liveness probe (no readiness)", func() {
@@ -969,7 +972,10 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).NotTo(BeNil())
 		Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet).NotTo(BeNil())
-		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).To(BeNil())
+		// With no user-specified readiness probe, the default TCP socket readiness probe is injected
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(8080)))
 	})
 
 	It("should handle only readiness probe (no liveness)", func() {
@@ -1009,5 +1015,134 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
 		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil())
 		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket).NotTo(BeNil())
+	})
+
+	It("should inject default MCP readiness probe when no health config is specified", func() {
+		mcpServer := newTestMCPServer("test-default-probe")
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-default-probe", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		controllerReconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "test-default-probe", Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := &appsv1.Deployment{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-default-probe",
+			Namespace: "default",
+		}, deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Default readiness probe should be a TCP socket probe on port 8080
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(8080)))
+		// No liveness probe should be set
+		Expect(deployment.Spec.Template.Spec.Containers[0].LivenessProbe).To(BeNil())
+	})
+
+	It("should use custom port in default readiness probe", func() {
+		mcpServer := newTestMCPServer("test-default-probe-custom-port")
+		mcpServer.Spec.Config.Port = 9090
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-default-probe-custom-port", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		controllerReconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "test-default-probe-custom-port", Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := &appsv1.Deployment{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-default-probe-custom-port",
+			Namespace: "default",
+		}, deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Default readiness probe should use the custom port
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(9090)))
+	})
+
+	It("should create TCP socket probe with given port using Kubernetes default timing", func() {
+		probe := defaultMCPReadinessProbe(8080)
+		Expect(probe).NotTo(BeNil())
+		Expect(probe.TCPSocket).NotTo(BeNil())
+		Expect(probe.TCPSocket.Port.IntVal).To(Equal(int32(8080)))
+		Expect(probe.InitialDelaySeconds).To(BeZero(), "should use Kubernetes default")
+		Expect(probe.PeriodSeconds).To(BeZero(), "should use Kubernetes default")
+	})
+
+	It("should use provided port in default readiness probe", func() {
+		probe := defaultMCPReadinessProbe(9090)
+		Expect(probe).NotTo(BeNil())
+		Expect(probe.TCPSocket).NotTo(BeNil())
+		Expect(probe.TCPSocket.Port.IntVal).To(Equal(int32(9090)))
+	})
+
+	It("should not inject default readiness probe when custom readiness probe is specified", func() {
+		mcpServer := newTestMCPServer("test-custom-overrides-default")
+		mcpServer.Spec.Runtime.Health.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(3000),
+				},
+			},
+			InitialDelaySeconds: 15,
+			PeriodSeconds:       20,
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-custom-overrides-default", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		controllerReconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "test-custom-overrides-default", Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := &appsv1.Deployment{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-custom-overrides-default",
+			Namespace: "default",
+		}, deployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Custom readiness probe should be used, not the default
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket).NotTo(BeNil())
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(3000)))
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds).To(Equal(int32(15)))
+		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds).To(Equal(int32(20)))
 	})
 })

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -1,0 +1,623 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
+	const resourceName = "test-handshake"
+
+	ctx := context.Background()
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	BeforeEach(func() {
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: "default",
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{
+					Port: 8080,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("should set MCPEndpointUnavailable when handshake fails", func() {
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				return fmt.Errorf("connection refused")
+			},
+		}
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("Reconciling with MCP handshake failure")
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Ready=False with reason MCPEndpointUnavailable")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonMCPEndpointUnavailable))
+		Expect(readyCondition.Message).To(ContainSubstring("MCP endpoint is not serving a valid MCP protocol"))
+		Expect(readyCondition.Message).To(ContainSubstring("connection refused"))
+
+		By("Verifying requeue is set")
+		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+	})
+
+	It("should keep Ready=True when handshake succeeds", func() {
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				return nil
+			},
+		}
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("Reconciling with MCP handshake success")
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Ready=True with reason Available")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+
+		By("Verifying no requeue")
+		Expect(result.RequeueAfter).To(BeZero())
+	})
+
+	It("should not attempt handshake when deployment is unavailable", func() {
+		dialerCalled := false
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				dialerCalled = true
+				return nil
+			},
+		}
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment being unavailable (no ready replicas)")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 0
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionTrue,
+				Reason: "NewReplicaSetCreated",
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("Resetting dialer call tracking before unavailable reconcile")
+		dialerCalled = false
+
+		By("Reconciling with unavailable deployment")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying MCPDialer was not called during unavailable reconcile")
+		Expect(dialerCalled).To(BeFalse())
+	})
+
+	It("should not attempt handshake when scaled to zero", func() {
+		dialerCalled := false
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				dialerCalled = true
+				return nil
+			},
+		}
+
+		By("Setting replicas to 0")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		mcpServer.Spec.Runtime.Replicas = ptr.To(int32(0))
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Reconciling again")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying MCPDialer was not called")
+		Expect(dialerCalled).To(BeFalse())
+
+		By("Verifying Ready=True with ScaledToZero reason")
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(readyCondition.Reason).To(Equal(ReasonScaledToZero))
+	})
+
+	It("should requeue on handshake failure", func() {
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				return fmt.Errorf("MCP protocol error")
+			},
+		}
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("Reconciling with MCP handshake failure")
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying RequeueAfter is set to 10 seconds")
+		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+	})
+
+	It("should skip handshake when already verified for current generation", func() {
+		dialCount := 0
+		shouldFail := true
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				dialCount++
+				if shouldFail {
+					return fmt.Errorf("intentional failure")
+				}
+				return nil
+			},
+		}
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("Reconciling with handshake failure to ensure Ready!=Available")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonMCPEndpointUnavailable))
+
+		By("Switching to successful handshake - should run because Ready is not yet Available")
+		shouldFail = false
+		dialCount = 0
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dialCount).To(Equal(1))
+
+		By("Verifying Ready=True/Available is set")
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+
+		By("Second reconcile - handshake should be skipped (already verified)")
+		dialCount = 0
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dialCount).To(Equal(0))
+	})
+
+	It("should pass a context with timeout to the dialer", func() {
+		var receivedCtx context.Context
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				receivedCtx = ctx
+				return nil
+			},
+		}
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("Reconciling to trigger handshake")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the dialer received a context with a deadline")
+		Expect(receivedCtx).NotTo(BeNil())
+		_, ok := receivedCtx.Deadline()
+		Expect(ok).To(BeTrue(), "context should have a deadline")
+	})
+
+	It("should stop requeuing after max retries are exhausted", func() {
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				return fmt.Errorf("connection refused")
+			},
+		}
+
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("First reconciliation with handshake failure")
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).NotTo(BeZero(), "should requeue on first failure")
+
+		By("Simulating exhausted retries by backdating the condition's LastTransitionTime")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Reason).To(Equal(ReasonMCPEndpointUnavailable))
+		// Backdate to 20 minutes ago - well past the total backoff budget
+		readyCondition.LastTransitionTime = metav1.NewTime(time.Now().Add(-20 * time.Minute))
+		meta.SetStatusCondition(&mcpServer.Status.Conditions, *readyCondition)
+		Expect(k8sClient.Status().Update(ctx, mcpServer)).To(Succeed())
+
+		By("Reconciling after retries exhausted")
+		result, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying no requeue (retries exhausted)")
+		Expect(result.RequeueAfter).To(BeZero(), "should not requeue after max retries")
+
+		By("Verifying status is still MCPEndpointUnavailable")
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition = meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonMCPEndpointUnavailable))
+	})
+
+	It("should use exponential backoff for handshake requeue delays", func() {
+		By("Verifying backoff schedule")
+		Expect(mcpHandshakeBackoff(0)).To(Equal(10 * time.Second))
+		Expect(mcpHandshakeBackoff(1)).To(Equal(20 * time.Second))
+		Expect(mcpHandshakeBackoff(2)).To(Equal(40 * time.Second))
+		Expect(mcpHandshakeBackoff(3)).To(Equal(80 * time.Second))
+		Expect(mcpHandshakeBackoff(4)).To(Equal(2 * time.Minute))
+		Expect(mcpHandshakeBackoff(5)).To(Equal(2 * time.Minute))
+		Expect(mcpHandshakeBackoff(100)).To(Equal(2 * time.Minute))
+	})
+
+	It("should count retries from condition timestamp", func() {
+		By("No existing condition returns 0")
+		Expect(mcpHandshakeRetryCount(nil)).To(Equal(0))
+
+		By("Condition with different reason returns 0")
+		conditions := []metav1.Condition{
+			{
+				Type:               ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             ReasonDeploymentUnavailable,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+			},
+		}
+		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(0))
+
+		By("Recently transitioned condition returns 0")
+		conditions = []metav1.Condition{
+			{
+				Type:               ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             ReasonMCPEndpointUnavailable,
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(0))
+
+		By("Condition old enough for several retries returns correct count")
+		// After 75s (10+20+40=70s for 3 retries), count should be 3
+		conditions = []metav1.Condition{
+			{
+				Type:               ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             ReasonMCPEndpointUnavailable,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-75 * time.Second)),
+			},
+		}
+		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(3))
+
+		By("Very old condition returns max retries")
+		conditions = []metav1.Condition{
+			{
+				Type:               ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             ReasonMCPEndpointUnavailable,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+			},
+		}
+		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(maxMCPHandshakeRetries))
+	})
+
+	It("should treat 401 Unauthorized as a reachable endpoint", func() {
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				return fmt.Errorf("POST %s: Unauthorized", url)
+			},
+		}
+
+		By("Creating deployment and marking it available")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      resourceName,
+			Namespace: "default",
+		}, deployment)).To(Succeed())
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.AvailableReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+	})
+
+	It("should treat 403 Forbidden as a reachable endpoint", func() {
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) error {
+				return fmt.Errorf("POST %s: Forbidden", url)
+			},
+		}
+
+		By("Creating deployment and marking it available")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      resourceName,
+			Namespace: "default",
+		}, deployment)).To(Succeed())
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.AvailableReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+	})
+})

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -694,8 +694,9 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				MCPDialer: func(ctx context.Context, url string) error { return nil },
 			}
 
 			By("Initial reconciliation creates deployment with 1 replica")
@@ -844,8 +845,9 @@ var _ = Describe("MCPServer Controller", func() {
 
 		It("should NOT requeue when Deployment becomes available", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				MCPDialer: func(ctx context.Context, url string) error { return nil },
 			}
 
 			By("Initial reconciliation creates deployment")
@@ -895,8 +897,9 @@ var _ = Describe("MCPServer Controller", func() {
 
 		It("should eventually reach Ready=True after Deployment becomes available", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				MCPDialer: func(ctx context.Context, url string) error { return nil },
 			}
 
 			By("Initial reconciliation creates deployment")


### PR DESCRIPTION
Inject a default TCP socket readiness probe targeting the configured MCP port when no custom readiness probe is specified. A TCP probe is used instead of HTTP GET because the MCP Streamable HTTP spec only requires POST support on the endpoint path - a GET probe would reject valid MCP servers that do not serve GET. This prevents containers that do not listen on the expected port (e.g. nginx on port 80) from reporting as Ready.

Additionally, gate the Ready condition on a successful MCP initialize handshake using the official Go SDK's StreamableClientTransport. After the deployment reports Available, the controller performs an MCP protocol handshake against the service endpoint. If the handshake fails, Ready is set to False with reason MCPEndpointUnavailable and the reconciliation requeues after 10s.

The handshake is only performed on transitions - it is skipped when the endpoint was already verified for the current generation, avoiding unnecessary network calls on every reconcile loop.

The handshake function is injectable via the MCPDialer field on the reconciler to keep unit tests fast and deterministic without needing a real MCP server.

Fixes https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/110