### PR TITLE
Wire EventRecorder into MCPServer reconciler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -180,8 +180,9 @@ func main() {
 	}
 
 	if err := (&controller.MCPServerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorder("mcpserver-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MCPServer")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,6 +26,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -176,13 +176,6 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
 
 	pendingAcceptedEvent := !acceptedConditionIsTrue(mcpServer.Status.Conditions)
-	maybeEmitAccepted := func() {
-		if !pendingAcceptedEvent {
-			return
-		}
-		r.emitConfigurationAccepted(mcpServer)
-		pendingAcceptedEvent = false
-	}
 
 	// Validate configuration
 	validationStart := time.Now()
@@ -214,6 +207,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Record Accepted condition metric
 	recordCondition(mcpServer.Name, mcpServer.Namespace,
 		acceptedCondition.Type, string(acceptedCondition.Status), acceptedCondition.Reason)
+
+	// Normal Event once per Accepted transition (single site); not transactional with applyStatus — PR #118.
+	if pendingAcceptedEvent {
+		r.emitConfigurationAccepted(mcpServer)
+	}
 
 	// Configuration is valid, proceed with deployment reconciliation
 	deploymentStart := time.Now()
@@ -248,8 +246,6 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
 			logger.Error(err, "Failed to update MCPServer status")
-		} else {
-			maybeEmitAccepted()
 		}
 		return ctrl.Result{}, err
 	}
@@ -287,8 +283,6 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
 			logger.Error(err, "Failed to update MCPServer status")
-		} else {
-			maybeEmitAccepted()
 		}
 		return ctrl.Result{}, err
 	}
@@ -375,7 +369,6 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Error(err, "Failed to apply MCPServer status")
 		return ctrl.Result{}, err
 	}
-	maybeEmitAccepted()
 
 	logger.Info("Successfully reconciled MCPServer",
 		"accepted", acceptedCondition.Status,

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	v1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -107,6 +108,12 @@ const (
 const (
 	// requeueDelayDeploymentUnavailable is the delay before requeuing when a deployment is not yet available.
 	requeueDelayDeploymentUnavailable = 15 * time.Second
+
+	// eventActionConfigurationValidation is the reporting action for configuration validation outcomes.
+	eventActionConfigurationValidation = "ConfigurationValidation"
+	// eventActionConfigurationAccepted is the reporting action when Accepted becomes True.
+	eventActionConfigurationAccepted = "ConfigurationAccepted"
+
 	// requeueDelayMCPHandshake is the initial delay before requeuing when an MCP handshake fails.
 	requeueDelayMCPHandshake = 10 * time.Second
 	// maxRequeueDelayMCPHandshake is the maximum requeue delay after exponential backoff.
@@ -131,6 +138,7 @@ const (
 type MCPServerReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
 	MCPDialer func(ctx context.Context, url string) error // nil = use real MCP handshake
 }
 
@@ -141,6 +149,8 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -163,44 +173,20 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
 
+	pendingAcceptedEvent := !acceptedConditionIsTrue(mcpServer.Status.Conditions)
+	maybeEmitAccepted := func() {
+		if !pendingAcceptedEvent {
+			return
+		}
+		r.emitConfigurationAccepted(mcpServer)
+		pendingAcceptedEvent = false
+	}
+
 	// Validate configuration
 	if err := r.validateConfig(ctx, mcpServer); err != nil {
 		var validationErr *ValidationError
 		if errors.As(err, &validationErr) {
-			// Permanent validation error - mark configuration as invalid
-			acceptedCondition := newCondition(
-				ConditionTypeAccepted,
-				metav1.ConditionFalse,
-				validationErr.Reason,
-				validationErr.Message,
-				mcpServer.Generation,
-			)
-			preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
-
-			readyCondition := newCondition(
-				ConditionTypeReady,
-				metav1.ConditionFalse,
-				ReasonConfigurationInvalid,
-				"Configuration must be fixed before server can start",
-				mcpServer.Generation,
-			)
-			preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
-
-			status := acv1alpha1.MCPServerStatus().
-				WithObservedGeneration(mcpServer.Generation).
-				WithServiceName(mcpServer.Name).
-				WithConditions(
-					conditionToAC(acceptedCondition),
-					conditionToAC(readyCondition),
-				)
-
-			if err := r.applyStatus(ctx, mcpServer, status); err != nil {
-				logger.Error(err, "Failed to update MCPServer status")
-				return ctrl.Result{}, err
-			}
-
-			logger.Info("MCPServer configuration is invalid", "reason", validationErr.Reason)
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, r.reconcilePermanentValidationError(ctx, mcpServer, validationErr)
 		}
 
 		// Transient error - log and return to trigger retry with exponential backoff
@@ -242,6 +228,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
 			logger.Error(err, "Failed to update MCPServer status")
+		} else {
+			maybeEmitAccepted()
 		}
 		return ctrl.Result{}, err
 	}
@@ -269,6 +257,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
 			logger.Error(err, "Failed to update MCPServer status")
+		} else {
+			maybeEmitAccepted()
 		}
 		return ctrl.Result{}, err
 	}
@@ -349,6 +339,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Error(err, "Failed to apply MCPServer status")
 		return ctrl.Result{}, err
 	}
+	maybeEmitAccepted()
 
 	logger.Info("Successfully reconciled MCPServer",
 		"accepted", acceptedCondition.Status,
@@ -1036,6 +1027,75 @@ func (r *MCPServerReconciler) validateOwnership(
 		obj.GetNamespace(), obj.GetName(),
 		controllerOwner.Kind, controllerOwner.Name, controllerOwner.UID,
 		mcpServer.Namespace, mcpServer.Name, mcpServer.UID)
+}
+
+func acceptedConditionIsTrue(conditions []metav1.Condition) bool {
+	c := meta.FindStatusCondition(conditions, ConditionTypeAccepted)
+	return c != nil && c.Status == metav1.ConditionTrue
+}
+
+func (r *MCPServerReconciler) reconcilePermanentValidationError(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+	validationErr *ValidationError,
+) error {
+	logger := log.FromContext(ctx)
+
+	acceptedCondition := newCondition(
+		ConditionTypeAccepted,
+		metav1.ConditionFalse,
+		validationErr.Reason,
+		validationErr.Message,
+		mcpServer.Generation,
+	)
+	preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
+
+	readyCondition := newCondition(
+		ConditionTypeReady,
+		metav1.ConditionFalse,
+		ReasonConfigurationInvalid,
+		"Configuration must be fixed before server can start",
+		mcpServer.Generation,
+	)
+	preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+	prevAccepted := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeAccepted)
+
+	status := acv1alpha1.MCPServerStatus().
+		WithObservedGeneration(mcpServer.Generation).
+		WithServiceName(mcpServer.Name).
+		WithConditions(
+			conditionToAC(acceptedCondition),
+			conditionToAC(readyCondition),
+		)
+
+	if err := r.applyStatus(ctx, mcpServer, status); err != nil {
+		logger.Error(err, "Failed to update MCPServer status")
+		return err
+	}
+
+	duplicateInvalid := prevAccepted != nil && prevAccepted.Status == metav1.ConditionFalse &&
+		prevAccepted.Reason == validationErr.Reason && prevAccepted.Message == validationErr.Message
+	if !duplicateInvalid {
+		r.emitConfigurationInvalid(mcpServer, validationErr)
+	}
+
+	logger.Info("MCPServer configuration is invalid", "reason", validationErr.Reason)
+	return nil
+}
+
+func (r *MCPServerReconciler) emitConfigurationInvalid(mcpServer *mcpv1alpha1.MCPServer, validationErr *ValidationError) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, validationErr.Reason, eventActionConfigurationValidation, "%s", validationErr.Message)
+}
+
+func (r *MCPServerReconciler) emitConfigurationAccepted(mcpServer *mcpv1alpha1.MCPServer) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, ReasonValid, eventActionConfigurationAccepted, "%s", "MCPServer configuration is valid; Accepted=True")
 }
 
 func (r *MCPServerReconciler) applyStatus(

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -29,7 +29,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,6 +40,29 @@ import (
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 )
+
+// testRecorderBuffer is the capacity of fake event recorders used in controller tests.
+const testRecorderBuffer = 10000
+
+// testMCPDialerNoop succeeds without dialing; used so envtests do not run real MCP handshakes.
+func testMCPDialerNoop(context.Context, string) error {
+	return nil
+}
+
+func newReconcilerForTestWithFakeEvents(cli client.Client, sch *runtime.Scheme) (*MCPServerReconciler, *events.FakeRecorder) {
+	fr := events.NewFakeRecorder(testRecorderBuffer)
+	return &MCPServerReconciler{
+		Client:    cli,
+		Scheme:    sch,
+		Recorder:  fr,
+		MCPDialer: testMCPDialerNoop,
+	}, fr
+}
+
+func newReconcilerForTest(cli client.Client, sch *runtime.Scheme) *MCPServerReconciler {
+	r, _ := newReconcilerForTestWithFakeEvents(cli, sch)
+	return r
+}
 
 // newTestMCPServer returns an MCPServer with standard test defaults:
 // namespace "default", SourceTypeContainerImage with ref
@@ -95,10 +120,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -106,6 +128,28 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+
+		It("should emit a Normal Accepted configuration event only when Accepted transitions to True", func() {
+			controllerReconciler, fr := newReconcilerForTestWithFakeEvents(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var first string
+			Eventually(fr.Events).Should(Receive(&first))
+			Expect(first).To(ContainSubstring(corev1.EventTypeNormal))
+			Expect(first).To(ContainSubstring(ReasonValid))
+			Expect(first).To(ContainSubstring("Accepted=True"))
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Consistently(fr.Events, 300*time.Millisecond, 20*time.Millisecond).ShouldNot(Receive())
 		})
 	})
 
@@ -136,10 +180,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should propagate env vars to the deployment", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -162,10 +203,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should update deployment env vars when CR is changed", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Reconciling to create the initial deployment")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -226,10 +264,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource.Spec.Config.Arguments = []string{"--verbose", "--port=8080"}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Reconciling to create the initial deployment with args")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -293,10 +328,7 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Reconciling to create the initial deployment with serviceAccountName")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -368,10 +400,7 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
@@ -404,10 +433,7 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
@@ -444,10 +470,7 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
@@ -474,10 +497,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource := newTestMCPServer(resourceName + "-none")
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: resourceName + "-none", Namespace: "default"},
 			})
@@ -536,10 +556,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource.Spec.Runtime.Replicas = ptr.To(int32(3))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
@@ -559,10 +576,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource := newTestMCPServer(resourceName)
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
@@ -582,10 +596,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource.Spec.Runtime.Replicas = ptr.To(int32(0))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
@@ -605,10 +616,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource.Spec.Runtime.Replicas = ptr.To(int32(2))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Reconciling to create the initial deployment with 2 replicas")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -649,10 +657,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource.Spec.Runtime.Replicas = ptr.To(int32(3))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Reconciling to create the initial deployment with 3 replicas")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -693,11 +698,7 @@ var _ = Describe("MCPServer Controller", func() {
 			resource.Spec.Runtime.Replicas = ptr.To(int32(1))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				MCPDialer: func(ctx context.Context, url string) error { return nil },
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Initial reconciliation creates deployment with 1 replica")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -797,10 +798,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should requeue reconciliation when Deployment is unavailable", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Initial reconciliation creates deployment")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -844,11 +842,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should NOT requeue when Deployment becomes available", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				MCPDialer: func(ctx context.Context, url string) error { return nil },
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Initial reconciliation creates deployment")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -896,11 +890,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should eventually reach Ready=True after Deployment becomes available", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client:    k8sClient,
-				Scheme:    k8sClient.Scheme(),
-				MCPDialer: func(ctx context.Context, url string) error { return nil },
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Initial reconciliation creates deployment")
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1027,10 +1017,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should propagate envFrom to the deployment", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1065,10 +1052,7 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1120,10 +1104,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should set Accepted=False when envFrom references a missing ConfigMap", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler, fr := newReconcilerForTestWithFakeEvents(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1142,6 +1123,12 @@ var _ = Describe("MCPServer Controller", func() {
 			// Verify MCPServer status has correct conditions
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+			var ev string
+			Eventually(fr.Events).Should(Receive(&ev))
+			Expect(ev).To(ContainSubstring(corev1.EventTypeWarning))
+			Expect(ev).To(ContainSubstring(ReasonInvalid))
+			Expect(ev).To(ContainSubstring("nonexistent-configmap"))
 
 			acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
 			Expect(acceptedCondition).NotTo(BeNil())
@@ -1162,10 +1149,7 @@ var _ = Describe("MCPServer Controller", func() {
 			mcpServer.Spec.Config.EnvFrom[0].ConfigMapRef.Optional = &optional
 			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1209,10 +1193,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should set Accepted=False when envFrom references a missing Secret", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1251,10 +1232,7 @@ var _ = Describe("MCPServer Controller", func() {
 			mcpServer.Spec.Config.EnvFrom[0].SecretRef.Optional = &optional
 			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1269,10 +1247,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should preserve Accepted condition LastTransitionTime across reconciliations", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			// First reconciliation - should set Accepted condition
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1340,10 +1315,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should set Accepted=False when env valueFrom references a missing ConfigMap", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1382,10 +1354,7 @@ var _ = Describe("MCPServer Controller", func() {
 			mcpServer.Spec.Config.Env[0].ValueFrom.ConfigMapKeyRef.Optional = &optional
 			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1435,10 +1404,7 @@ var _ = Describe("MCPServer Controller", func() {
 		})
 
 		It("should set Accepted=False when env valueFrom references a missing Secret", func() {
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1477,10 +1443,7 @@ var _ = Describe("MCPServer Controller", func() {
 			mcpServer.Spec.Config.Env[0].ValueFrom.SecretKeyRef.Optional = &optional
 			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
-			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,


### PR DESCRIPTION
Part of #109: add Kubernetes Event recording to `MCPServerReconciler`.

* Wire `EventRecorder` from manager
* Emit Events for configuration outcomes
* Extend RBAC for Events
* Add test coverage

---

## Changes

* **Reconciler**

  * Add `Recorder` field to `MCPServerReconciler`
  * Initialize via `mgr.GetEventRecorderFor`

* **RBAC**

  * Add `create`, `patch` on Events in:

    * core (`""`)
    * `events.k8s.io`

* **Events**

  * **Normal**

    * On `Accepted=True` transition
    * Emitted once per transition (post-condition computation)
  * **Warning**

    * On permanent validation failure
    * Deduped if `Accepted=False` with same reason/message

* **Tests**

  * Use fake recorder (`events.NewFakeRecorder`)
  * Add `newReconcilerForTest` helper
  * Assert emitted Events

---

## Testing

* Unit tests updated/added
* Manually validated on Kind cluster (build → load → deploy → verify Events)

---

## Notes

* Emission point chosen post-condition computation (not post-status apply); can be revisited
* Aligns with controller-runtime event broadcaster behavior
---

## AI Disclosure

Drafted with AI assistance; verified via tests and local cluster validation.


## Related

- Closes: _(none — partial work for #109)_
- Part of: #109
- Follow-up PRs – e.g. events for Ready transitions, Deployment problems, Service issues, scale-to-zero, image pull failures, etc., each small and reviewable.


## Manual testing:

- <img width="2910" height="1892" alt="image" src="https://github.com/user-attachments/assets/c68c8053-16a8-4e76-9570-8a301b252488" />

- 
<img width="2394" height="1638" alt="image" src="https://github.com/user-attachments/assets/33deab4c-fb7c-4856-9562-102a8bfb5d20" />

- Patching with some invalid config:
<img width="1598" height="652" alt="image" src="https://github.com/user-attachments/assets/8111885c-f6cb-4abc-ab22-1317cd9339c7" />

- 
<img width="1958" height="1638" alt="image" src="https://github.com/user-attachments/assets/1868ce39-6921-4df3-b666-7abc73cc7a29" />

- Patching again:
<img width="3456" height="1650" alt="image" src="https://github.com/user-attachments/assets/857debd5-26c3-477e-83b1-eb0ebc1383b4" />

