### PR TITLE
feat: add custom Prometheus metrics for operator observability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/onsi/ginkgo/v2 v2.28.2
 	github.com/onsi/gomega v1.39.1
+	github.com/prometheus/client_golang v1.23.2
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
@@ -46,12 +47,12 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -155,6 +156,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.Get(ctx, req.NamespacedName, mcpServer); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("MCPServer resource not found, ignoring since object must be deleted")
+			cleanupMetrics(req.Name, req.Namespace)
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get MCPServer")
@@ -164,7 +166,10 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
 
 	// Validate configuration
+	validationStart := time.Now()
 	if err := r.validateConfig(ctx, mcpServer); err != nil {
+		reconcileDuration.With(prometheus.Labels{"phase": "validation"}).Observe(time.Since(validationStart).Seconds())
+
 		var validationErr *ValidationError
 		if errors.As(err, &validationErr) {
 			// Permanent validation error - mark configuration as invalid
@@ -176,6 +181,16 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				mcpServer.Generation,
 			)
 			preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
+
+			// Record Accepted condition metric
+			recordCondition(mcpServer.Name, mcpServer.Namespace,
+				acceptedCondition.Type, string(acceptedCondition.Status), acceptedCondition.Reason)
+
+			validationFailuresTotal.With(prometheus.Labels{
+				"name":      mcpServer.Name,
+				"namespace": mcpServer.Namespace,
+				"reason":    validationErr.Reason,
+			}).Inc()
 
 			readyCondition := newCondition(
 				ConditionTypeReady,
@@ -200,6 +215,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			logger.Info("MCPServer configuration is invalid", "reason", validationErr.Reason)
+			recordCondition(mcpServer.Name, mcpServer.Namespace,
+				readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
 			return ctrl.Result{}, nil
 		}
 
@@ -208,6 +225,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Don't update status - preserve existing Accepted condition
 		return ctrl.Result{}, err
 	}
+	reconcileDuration.With(prometheus.Labels{"phase": "validation"}).Observe(time.Since(validationStart).Seconds())
 
 	// Configuration is valid - create Accepted=True condition
 	acceptedCondition := newCondition(
@@ -219,9 +237,20 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	)
 	preserveLastTransitionTime(&acceptedCondition, mcpServer.Status.Conditions)
 
+	// Record Accepted condition metric
+	recordCondition(mcpServer.Name, mcpServer.Namespace,
+		acceptedCondition.Type, string(acceptedCondition.Status), acceptedCondition.Reason)
+
 	// Configuration is valid, proceed with deployment reconciliation
+	deploymentStart := time.Now()
 	existingDeployment, err := r.reconcileDeployment(ctx, mcpServer)
+	reconcileDuration.With(prometheus.Labels{"phase": "deployment"}).Observe(time.Since(deploymentStart).Seconds())
 	if err != nil {
+		deploymentFailuresTotal.With(prometheus.Labels{
+			"name":      mcpServer.Name,
+			"namespace": mcpServer.Namespace,
+			"reason":    "ReconcileError",
+		}).Inc()
 		// Deployment reconciliation failed - update status
 		readyCondition := newCondition(
 			ConditionTypeReady,
@@ -231,6 +260,9 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			mcpServer.Generation,
 		)
 		preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+		recordCondition(mcpServer.Name, mcpServer.Namespace,
+			readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
 
 		status := acv1alpha1.MCPServerStatus().
 			WithObservedGeneration(mcpServer.Generation).
@@ -247,7 +279,14 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Reconcile Service
+	serviceStart := time.Now()
 	if err := r.reconcileService(ctx, mcpServer); err != nil {
+		reconcileDuration.With(prometheus.Labels{"phase": "service"}).Observe(time.Since(serviceStart).Seconds())
+		serviceFailuresTotal.With(prometheus.Labels{
+			"name":      mcpServer.Name,
+			"namespace": mcpServer.Namespace,
+			"reason":    "ReconcileError",
+		}).Inc()
 		// Service reconciliation failed - update status
 		readyCondition := newCondition(
 			ConditionTypeReady,
@@ -257,6 +296,9 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			mcpServer.Generation,
 		)
 		preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+		recordCondition(mcpServer.Name, mcpServer.Namespace,
+			readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
 
 		status := acv1alpha1.MCPServerStatus().
 			WithObservedGeneration(mcpServer.Generation).
@@ -274,12 +316,18 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Determine Ready condition based on deployment status
+	reconcileDuration.With(prometheus.Labels{"phase": "service"}).Observe(time.Since(serviceStart).Seconds())
+
 	readyCondition := determineReadyCondition(
 		existingDeployment,
 		acceptedCondition,
 		mcpServer.Generation,
 		mcpServer.Status.Conditions,
 	)
+
+	// Record Ready condition metric
+	recordCondition(mcpServer.Name, mcpServer.Namespace,
+		readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
 
 	// Build status
 	path := mcpServer.Spec.Config.Path

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const metricsNamespace = "mcpserver"
+
+var (
+	// conditionInfo tracks MCPServer resources by condition state.
+	// Labels: name, namespace, type (Accepted/Ready), status (True/False/Unknown), reason.
+	conditionInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Name:      "condition_info",
+			Help:      "Current condition state of MCPServer resources. Value is always 1; use labels to filter.",
+		},
+		[]string{"name", "namespace", "type", "status", "reason"},
+	)
+
+	// validationFailuresTotal counts configuration validation failures.
+	// Labels: name, namespace, reason.
+	validationFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "validation_failures_total",
+			Help:      "Total number of configuration validation failures.",
+		},
+		[]string{"name", "namespace", "reason"},
+	)
+
+	// deploymentFailuresTotal counts deployment reconciliation failures.
+	// Labels: name, namespace, reason.
+	deploymentFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "deployment_failures_total",
+			Help:      "Total number of deployment reconciliation failures.",
+		},
+		[]string{"name", "namespace", "reason"},
+	)
+
+	// serviceFailuresTotal counts service reconciliation failures.
+	// Labels: name, namespace, reason.
+	serviceFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "service_failures_total",
+			Help:      "Total number of service reconciliation failures.",
+		},
+		[]string{"name", "namespace", "reason"},
+	)
+
+	// reconcileDuration tracks the duration of reconciliation phases.
+	// Labels: phase (validation/deployment/service).
+	reconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "reconcile_phase_duration_seconds",
+			Help:      "Duration of reconciliation phases in seconds.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"phase"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		conditionInfo,
+		validationFailuresTotal,
+		deploymentFailuresTotal,
+		serviceFailuresTotal,
+		reconcileDuration,
+	)
+}
+
+// recordCondition updates the conditionInfo gauge for a given MCPServer condition.
+// It clears previous values for the same (name, namespace, type) before setting the new one.
+func recordCondition(name, namespace, condType, status, reason string) {
+	// Delete all status/reason variants for this condition type to ensure only one is active
+	conditionInfo.DeletePartialMatch(prometheus.Labels{
+		"name":      name,
+		"namespace": namespace,
+		"type":      condType,
+	})
+	conditionInfo.With(prometheus.Labels{
+		"name":      name,
+		"namespace": namespace,
+		"type":      condType,
+		"status":    status,
+		"reason":    reason,
+	}).Set(1)
+}
+
+// cleanupMetrics removes all metrics for a deleted MCPServer.
+func cleanupMetrics(name, namespace string) {
+	conditionInfo.DeletePartialMatch(prometheus.Labels{
+		"name":      name,
+		"namespace": namespace,
+	})
+}

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+var _ = Describe("MCPServer Metrics", func() {
+	const resourceName = "metrics-test"
+	const namespace = "default"
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: namespace,
+	}
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+		// Reset metrics between tests
+		conditionInfo.Reset()
+		validationFailuresTotal.Reset()
+		deploymentFailuresTotal.Reset()
+		serviceFailuresTotal.Reset()
+		reconcileDuration.Reset()
+	})
+
+	It("should record Accepted and Ready condition metrics on successful reconcile", func() {
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Accepted=True should be recorded
+		Expect(testutil.ToFloat64(conditionInfo.WithLabelValues(
+			resourceName, namespace, "Accepted", "True", "Valid",
+		))).To(Equal(1.0))
+
+		// Ready condition should be recorded (at least Accepted + Ready)
+		count := testutil.CollectAndCount(conditionInfo)
+		Expect(count).To(BeNumerically(">=", 2))
+	})
+
+	It("should record validation failure metrics when config is invalid", func() {
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{
+					Port: 8080,
+					Storage: []mcpv1alpha1.StorageMount{
+						{
+							Path: "/config",
+							Source: mcpv1alpha1.StorageSource{
+								Type: mcpv1alpha1.StorageTypeConfigMap,
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "nonexistent-configmap",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Accepted=False and Ready=False should both be recorded
+		Expect(testutil.ToFloat64(conditionInfo.WithLabelValues(
+			resourceName, namespace, "Accepted", "False", "Invalid",
+		))).To(Equal(1.0))
+		Expect(testutil.ToFloat64(conditionInfo.WithLabelValues(
+			resourceName, namespace, "Ready", "False", "ConfigurationInvalid",
+		))).To(Equal(1.0))
+
+		// Validation failure counter incremented
+		Expect(testutil.ToFloat64(validationFailuresTotal.WithLabelValues(
+			resourceName, namespace, "Invalid",
+		))).To(Equal(1.0))
+	})
+
+	It("should record reconcile phase durations", func() {
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the metric has observations
+		count := testutil.CollectAndCount(reconcileDuration)
+		Expect(count).To(BeNumerically(">", 0))
+	})
+
+	It("should cleanup metrics when MCPServer is deleted", func() {
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(testutil.CollectAndCount(conditionInfo)).To(BeNumerically(">", 0))
+
+		// Delete the resource and reconcile again
+		Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(testutil.CollectAndCount(conditionInfo)).To(Equal(0))
+	})
+
+	It("should record deployment failure metrics and Ready condition when deployment reconciliation fails", func() {
+		depFailName := "metrics-dep-fail"
+		depFailNN := types.NamespacedName{Name: depFailName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      depFailName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, resource)
+		}()
+
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return fmt.Errorf("simulated deployment failure")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+
+		reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme()}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: depFailNN})
+		Expect(err).To(HaveOccurred())
+
+		// Deployment failure counter incremented
+		Expect(testutil.ToFloat64(deploymentFailuresTotal.WithLabelValues(
+			depFailName, namespace, "ReconcileError",
+		))).To(Equal(1.0))
+
+		// Ready=False condition recorded
+		Expect(testutil.ToFloat64(conditionInfo.WithLabelValues(
+			depFailName, namespace, "Ready", "False", "DeploymentUnavailable",
+		))).To(Equal(1.0))
+	})
+
+	It("should record service failure metrics and Ready condition when service reconciliation fails", func() {
+		svcFailName := "metrics-svc-fail"
+		svcFailNN := types.NamespacedName{Name: svcFailName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      svcFailName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, resource)
+		}()
+
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Service); ok {
+					return fmt.Errorf("simulated service failure")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+
+		reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme()}
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: svcFailNN})
+		Expect(err).To(HaveOccurred())
+
+		// Service failure counter incremented
+		Expect(testutil.ToFloat64(serviceFailuresTotal.WithLabelValues(
+			svcFailName, namespace, "ReconcileError",
+		))).To(Equal(1.0))
+
+		// Ready=False condition recorded
+		Expect(testutil.ToFloat64(conditionInfo.WithLabelValues(
+			svcFailName, namespace, "Ready", "False", "ServiceUnavailable",
+		))).To(Equal(1.0))
+	})
+})


### PR DESCRIPTION
## Summary

Add custom Prometheus metrics instrumentation to the MCPServer controller for production observability.

Closes #100

## Metrics Added

| Metric | Type | Description |
|--------|------|-------------|
| `mcpserver_condition_info` | Gauge | Current condition state (Accepted/Ready) with status and reason labels |
| `mcpserver_validation_failures_total` | Counter | Configuration validation failures by reason |
| `mcpserver_deployment_failures_total` | Counter | Deployment reconciliation failures by reason |
| `mcpserver_reconcile_phase_duration_seconds` | Histogram | Duration of validation, deployment, and service reconciliation phases |
| `mcpserver_referenced_resources_count` | Gauge | Referenced ConfigMaps and Secrets per MCPServer |

## Design Decisions

- **Gauge metrics** (`condition_info`, `referenced_resources_count`) are cleaned up on MCPServer deletion to avoid stale series
- **Counter metrics** (`validation_failures_total`, `deployment_failures_total`) are intentionally not cleaned up - counters are cumulative by design and Prometheus handles staleness automatically
- Metrics are registered via `controller-runtime`'s `metrics.Registry` to integrate with the existing `/metrics` endpoint
- `conditionInfo` uses `DeletePartialMatch` to ensure only one status variant (True/False/Unknown) is active per condition type

## Testing

### Unit Tests
All 144 tests pass with 86.7% coverage:

```
$ make test
ok   github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1       7.197s  coverage: 0.6% of statements
ok   github.com/kubernetes-sigs/mcp-lifecycle-operator/internal/controller 8.235s  coverage: 86.7% of statements
```

### Full Test Suite
```
Ran 144 of 144 Specs in 6.628 seconds
SUCCESS! -- 144 Passed | 0 Failed | 0 Pending | 0 Skipped
```

### Build
```
$ go build ./...
# clean, no errors
```