### PR TITLE
chore: bump Go toolchain baseline to 1.25.9

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.25.9",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ __pycache__/
 site/
 site-src/reference/index.md
 .venv-mkdocs/
+
+# Do not set GOMODCACHE/GOCACHE to these paths; a module cache inside the repo
+# can break controller-gen (paths=./...) and produce spurious missing go.sum errors.
+.gomodcache/
+.gocache/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.5.0
@@ -77,7 +77,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.50.0 // indirect
+	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
-golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
-golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
+golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
+golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=


### PR DESCRIPTION
## Description
https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/127
This PR standardizes the project on **Go 1.25.9** to ensure we stay on the 1.25 release line while incorporating the latest patched dependencies and security fixes.

### Changes included:

* Updated `go.mod` to use `go 1.25.9`
* Aligned development and build environments:

  * Updated `Dockerfile` builder image to `golang:1.25.9`
  * Updated `.devcontainer/devcontainer.json` to use a Go 1.25.9 image
* Upgraded `golang.org/x/net` to `v0.51.0` (or newer patched version)
* Regenerated `go.sum` as needed

### Validation:

* Ran `make test` to ensure all builds and tests pass successfully on Go 1.25.x

This change keeps toolchains consistent across local development and CI while avoiding the need to migrate to Go 1.26 at this time.
ye
<img width="3550" height="294" alt="image" src="https://github.com/user-attachments/assets/425efa7b-822d-45b7-bcb8-005839ecf7bf" />
