### PR TITLE
ci: run govulncheck daily and on PRs to release branches

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -4,7 +4,12 @@ name: Govulncheck
 
 on:
   pull_request:
-    branches: ['main']
+    branches:
+      - main
+      - 'release-*'
+  schedule:
+    # Weekly Monday 08:00 UTC — catches new CVEs in the DB when no PRs run the check.
+    - cron: '0 8 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -8,8 +8,8 @@ on:
       - main
       - 'release-*'
   schedule:
-    # Weekly Monday 08:00 UTC — catches new CVEs in the DB when no PRs run the check.
-    - cron: '0 8 * * 1'
+    # Daily 08:00 UTC — catches new CVEs in the DB when no PRs run the check.
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

- Run the Govulncheck workflow daily schedule (08:00 UTC) so new CVEs in the Go vulnerability database are surfaced even when there are no PRs for a while.
- Run Govulncheck on pull requests whose **base** branch is `main` or `release-*` (in addition to existing `workflow_dispatch`).

## Why

Complements [issue #117](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/117): Dependabot and PR checks alone do not cover “quiet” periods; a periodic run closes that gap. Release branches get the same gate as `main` when changes are proposed via PR.

## Notes

- Scheduled workflows run from the default branch’s workflow definition and operate on the checked-out ref (typically `main` for cron runs).