### PR TITLE
docs: Prometheus metrics reference on documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Kubernetes operator that provides a declarative API to deploy, manage, and saf
 
 - [Introduction](https://mcp-lifecycle-operator.sigs.k8s.io/introduction/) - Architecture and MCPServer API overview
 - [Quickstart Guide](https://mcp-lifecycle-operator.sigs.k8s.io/guides/quickstart/) - Get up and running quickly
-- [Metrics](https://mcp-lifecycle-operator.sigs.k8s.io/metrics/) - Prometheus metrics reference
+- [Metrics](https://mcp-lifecycle-operator.sigs.k8s.io/operating/metrics/) - Prometheus metrics reference
 - [API Reference](https://mcp-lifecycle-operator.sigs.k8s.io/reference/) - Full MCPServer API documentation
 - [Complete MCPServer example](./config/samples/mcp_v1alpha1_mcpserver_complete.yaml) - YAML showing all available fields
 - [Contributing](https://mcp-lifecycle-operator.sigs.k8s.io/contributing/) - How to contribute to the project

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Kubernetes operator that provides a declarative API to deploy, manage, and saf
 
 - [Introduction](https://mcp-lifecycle-operator.sigs.k8s.io/introduction/) - Architecture and MCPServer API overview
 - [Quickstart Guide](https://mcp-lifecycle-operator.sigs.k8s.io/guides/quickstart/) - Get up and running quickly
+- [Metrics](https://mcp-lifecycle-operator.sigs.k8s.io/metrics/) - Prometheus metrics reference
 - [API Reference](https://mcp-lifecycle-operator.sigs.k8s.io/reference/) - Full MCPServer API documentation
 - [Complete MCPServer example](./config/samples/mcp_v1alpha1_mcpserver_complete.yaml) - YAML showing all available fields
 - [Contributing](https://mcp-lifecycle-operator.sigs.k8s.io/contributing/) - How to contribute to the project

--- a/site-src/.pages
+++ b/site-src/.pages
@@ -3,4 +3,5 @@ nav:
   - Introduction: introduction.md
   - Guides: guides
   - Reference: reference
+  - Metrics: metrics.md
   - Contributing: contributing

--- a/site-src/.pages
+++ b/site-src/.pages
@@ -3,5 +3,5 @@ nav:
   - Introduction: introduction.md
   - Guides: guides
   - Reference: reference
-  - Metrics: metrics.md
+  - Operating: operating
   - Contributing: contributing

--- a/site-src/README.md
+++ b/site-src/README.md
@@ -8,7 +8,8 @@ This directory contains the source files for the MCP Lifecycle Operator document
 site-src/
 ├── index.md              # Landing page
 ├── introduction.md       # Introduction and overview
-├── metrics.md            # Prometheus metrics reference
+├── operating/            # Day-2 operations (metrics, future topics)
+│   └── metrics.md        # Prometheus metrics reference
 ├── guides/               # Getting started guides
 │   ├── index.md
 │   └── quickstart.md

--- a/site-src/README.md
+++ b/site-src/README.md
@@ -8,6 +8,7 @@ This directory contains the source files for the MCP Lifecycle Operator document
 site-src/
 ├── index.md              # Landing page
 ├── introduction.md       # Introduction and overview
+├── metrics.md            # Prometheus metrics reference
 ├── guides/               # Getting started guides
 │   ├── index.md
 │   └── quickstart.md

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -15,6 +15,7 @@ Check out the [examples directory](https://github.com/kubernetes-sigs/mcp-lifecy
 
 ## Additional Resources
 
+- [Metrics](../metrics.md) - Prometheus metrics exposed by the operator
 - [API Reference](../reference/) - Complete API documentation
 - [Contributing Guide](../contributing/index.md) - How to contribute to the project
 - [SIG Apps](https://github.com/kubernetes/community/blob/main/sig-apps/README.md) - Join the community and attend meetings

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -15,7 +15,7 @@ Check out the [examples directory](https://github.com/kubernetes-sigs/mcp-lifecy
 
 ## Additional Resources
 
-- [Metrics](../metrics.md) - Prometheus metrics exposed by the operator
 - [API Reference](../reference/) - Complete API documentation
+- [Metrics](../operating/metrics.md) - Prometheus metrics exposed by the operator
 - [Contributing Guide](../contributing/index.md) - How to contribute to the project
 - [SIG Apps](https://github.com/kubernetes/community/blob/main/sig-apps/README.md) - Join the community and attend meetings

--- a/site-src/metrics.md
+++ b/site-src/metrics.md
@@ -10,7 +10,7 @@ Metrics are exposed over **HTTPS** at path **`/metrics`** on **port `8443`** on 
 
 After a typical install from the [release `install.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/latest), scrape:
 
-`https://mcp-lifecycle-operator-controller-manager-metrics-service.mcp-lifecycle-operator-system.svc:8443/metrics`
+[https://mcp-lifecycle-operator-controller-manager-metrics-service.mcp-lifecycle-operator-system.svc:8443/metrics](https://mcp-lifecycle-operator-controller-manager-metrics-service.mcp-lifecycle-operator-system.svc:8443/metrics)
 
 Adjust the Service name and namespace if you change the Kustomize `namePrefix` / `namespace` when deploying.
 
@@ -59,21 +59,20 @@ Only one active series exists per `(name, namespace, type)`. On delete, gauge se
 sum by (namespace, type, status, reason) (mcpserver_condition_info)
 ```
 
-### Labels for `mcpserver_validation_failures_total`
+### Labels for failure counters (`mcpserver_*_failures_total`)
+
+`mcpserver_validation_failures_total`, `mcpserver_deployment_failures_total`, and `mcpserver_service_failures_total` share the **same label set**:
 
 | Label | Description |
 | --- | --- |
 | `name` | `MCPServer` name |
 | `namespace` | `MCPServer` namespace |
-| `reason` | Validation failure reason; permanent errors currently use `Invalid` |
+| `reason` | Depends on which counter (see below) |
 
-### Labels for `mcpserver_deployment_failures_total` and `mcpserver_service_failures_total`
+**`reason` values**
 
-| Label | Description |
-| --- | --- |
-| `name` | `MCPServer` name |
-| `namespace` | `MCPServer` namespace |
-| `reason` | Failure reason; currently `ReconcileError` when the corresponding reconcile step returns an error |
+- **`mcpserver_validation_failures_total`** — permanent validation errors currently use `Invalid`.
+- **`mcpserver_deployment_failures_total`** and **`mcpserver_service_failures_total`** — currently `ReconcileError` when the corresponding reconcile step returns an error.
 
 ### Labels for `mcpserver_reconcile_phase_duration_seconds`
 

--- a/site-src/metrics.md
+++ b/site-src/metrics.md
@@ -1,18 +1,21 @@
-# Prometheus metrics
+# Metrics
 
-The controller manager exposes Prometheus metrics at `/metrics` on the metrics server when [`--metrics-bind-address`](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/server#Options) is non-zero. The generated **`config/default`** overlay patches the Deployment with `--metrics-bind-address=:8443` ([`manager_metrics_patch.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml)); combined with `--metrics-secure` defaulting to **true** in [`cmd/main.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/cmd/main.go), that serves TLS on 8443. Use `--metrics-secure=false` for plain HTTP (for example with `:8080`). Besides [controller-runtime default metrics](https://book.kubebuilder.io/reference/metrics.html) (workqueues, REST client, leader election, etc.), the MCPServer reconciler registers **custom metrics** under the `mcpserver_` namespace.
+This page describes **Prometheus** metrics exposed by the MCP Lifecycle Operator: built-in [controller-runtime metrics](https://book.kubebuilder.io/reference/metrics.html) (workqueues, REST client, leader election, and related instrumentation) and custom `mcpserver_*` series registered by the `MCPServer` reconciler.
+
+The metrics HTTP handler is served when [`--metrics-bind-address`](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/server#Options) is non-zero. The **`config/default`** Kustomize overlay patches the controller Deployment with `--metrics-bind-address=:8443` ([`manager_metrics_patch.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml)). With `--metrics-secure` defaulting to **true** in [`cmd/main.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/cmd/main.go), that endpoint uses TLS on port 8443. Use `--metrics-secure=false` for plain HTTP (for example with `:8080`).
 
 ## Scraping with Prometheus Operator
 
-A sample `ServiceMonitor` for the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) lives in the repo:
+A sample `ServiceMonitor` manifest for the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) is maintained in the repository:
 
-- Manifest: [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml)
+- [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml)
 
-It is **not** wired into the default install: enable it by uncommenting the `[PROMETHEUS]` entry (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml), then apply your overlay (for example kube-prometheus-stack) so the operator discovers the monitor.
+!!! note
+    The ServiceMonitor is **not** included in the default install. Uncomment the `[PROMETHEUS]` entry (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml`), then apply your monitoring stack (for example kube-prometheus-stack) so Prometheus can discover the monitor.
 
 ## Custom metrics reference
 
-All custom metric names are prefixed with `mcpserver_` (Prometheus namespace `mcpserver`).
+Custom series use the Prometheus namespace `mcpserver` (exported metric names are prefixed with `mcpserver_`).
 
 ### `mcpserver_condition_info`
 
@@ -29,7 +32,7 @@ All custom metric names are prefixed with `mcpserver_` (Prometheus namespace `mc
 | `namespace` | MCPServer namespace |
 | `type` | Condition type: `Accepted` or `Ready` |
 | `status` | Kubernetes condition status: `True`, `False`, or `Unknown` |
-| `reason` | Condition reason — intended to match `.status.conditions[]`; see [Gauge vs status](#gauge-vs-mcpserver-status) |
+| `reason` | Condition reason (intended to match `.status.conditions[]`; see [note below](#gauge-versus-api-status)) |
 
 For each `(name, namespace, type)` tuple, at most one time series is active: updating a condition deletes prior series with the same name, namespace, and type so only the current status/reason remains.
 
@@ -42,14 +45,15 @@ When an `MCPServer` is deleted, `cleanupMetrics` removes **only** `mcpserver_con
 
 For **Ready**, `status` may be `Unknown` (for example reason `Initializing` while the Deployment has not reported conditions yet).
 
-#### Gauge vs MCPServer status
+<span id="gauge-versus-api-status"></span>
 
-`recordCondition` runs at fixed points in [`Reconcile`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/mcpserver_controller.go). In rare cases the gauge can **diverge** from the API object’s `.status.conditions`:
+!!! note "Gauge versus API status"
+    `recordCondition` runs at fixed points in [`Reconcile`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/mcpserver_controller.go). In rare cases the gauge can **diverge** from the API object's `.status.conditions`:
 
-1. **Permanent validation error** — `Ready` / `ConfigurationInvalid` is passed to `recordCondition` only **after** `applyStatus` succeeds. If that update fails, the `validation_failures_total` counter and `Accepted` gauge may already have been updated, but the **Ready** gauge may still reflect an older reconcile.
-2. **MCP endpoint handshake** — When deployment-level readiness is `Available`, the reconciler runs an MCP handshake and may set status to `MCPEndpointUnavailable` if it fails. That happens **after** `recordCondition` ran with `Available`; **`recordCondition` is not invoked again** in that reconcile, so the Ready gauge can still show `Available` until a later reconcile updates it.
+    1. **Permanent validation error** — `Ready` / `ConfigurationInvalid` is passed to `recordCondition` only **after** `applyStatus` succeeds. If that update fails, the `validation_failures_total` counter and `Accepted` gauge may already have been updated, but the **Ready** gauge may still reflect an older reconcile.
+    2. **MCP endpoint handshake** — When deployment-level readiness is `Available`, the reconciler runs an MCP handshake and may set status to `MCPEndpointUnavailable` if it fails. That happens **after** `recordCondition` ran with `Available`; **`recordCondition` is not invoked again** in that reconcile, so the Ready gauge can still show `Available` until a later reconcile updates it.
 
-Treat **`MCPServer.status.conditions` as authoritative** for correctness; use this gauge for aggregation and alerting with the above limitations in mind.
+    Treat **`MCPServer.status.conditions` as authoritative** for correctness; use this gauge for aggregation and alerting with the above limitations in mind.
 
 Use this metric to count or alert on MCPServers by acceptance/readiness state, for example:
 
@@ -128,4 +132,11 @@ Use `_bucket`, `_sum`, and `_count` suffixes as usual for histogram quantiles an
 
 ## Implementation note
 
-Metric definitions and registration live in [`internal/controller/metrics.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/metrics.go). This document should stay aligned with that file when metrics are added or changed.
+Metric definitions and registration live in [`internal/controller/metrics.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/metrics.go). Keep this page aligned with that file when metrics change.
+
+## Next steps
+
+- **[Introduction](introduction.md)** — Architecture and `MCPServer` overview (including status conditions)
+- **[Quickstart](guides/quickstart.md)** — Deploy an MCP server and inspect status
+- **[API Reference](reference/)** — Full `MCPServer` API
+- **[Contributing](contributing/index.md)** — How to contribute

--- a/site-src/metrics.md
+++ b/site-src/metrics.md
@@ -1,138 +1,99 @@
 # Metrics
 
-This page describes **Prometheus** metrics exposed by the MCP Lifecycle Operator: built-in [controller-runtime metrics](https://book.kubebuilder.io/reference/metrics.html) (workqueues, REST client, leader election, and related instrumentation) and custom `mcpserver_*` series registered by the `MCPServer` reconciler.
+The MCP Lifecycle Operator exposes **Prometheus** metrics from the **controller manager** (the operator Deployment that reconciles `MCPServer` resources). Metrics include those registered by [controller-runtime](https://book.kubebuilder.io/reference/metrics.html) (for example workqueues and the Kubernetes API client) and **custom `mcpserver_*` series** documented below.
 
-The metrics HTTP handler is served when [`--metrics-bind-address`](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/server#Options) is non-zero. The **`config/default`** Kustomize overlay patches the controller Deployment with `--metrics-bind-address=:8443` ([`manager_metrics_patch.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml)). With `--metrics-secure` defaulting to **true** in [`cmd/main.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/cmd/main.go), that endpoint uses TLS on port 8443. Use `--metrics-secure=false` for plain HTTP (for example with `:8080`).
+This page is aimed at **platform and cluster operators** who scrape Prometheus and tune alerting—not at authors of `MCPServer` manifests alone.
 
-## Scraping with Prometheus Operator
+## Metrics endpoint
 
-A sample `ServiceMonitor` manifest for the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) is maintained in the repository:
+Metrics are exposed over **HTTPS** at path **`/metrics`** on **port `8443`** on the controller manager metrics **Service** (the Service port is named **`https`**).
 
-- [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml)
+After a typical install from the [release `install.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/latest), scrape:
 
-!!! note
-    The ServiceMonitor is **not** included in the default install. Uncomment the `[PROMETHEUS]` entry (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml`), then apply your monitoring stack (for example kube-prometheus-stack) so Prometheus can discover the monitor.
+`https://mcp-lifecycle-operator-controller-manager-metrics-service.mcp-lifecycle-operator-system.svc:8443/metrics`
 
-## Custom metrics reference
+Adjust the Service name and namespace if you change the Kustomize `namePrefix` / `namespace` when deploying.
 
-Custom series use the Prometheus namespace `mcpserver` (exported metric names are prefixed with `mcpserver_`).
+!!! note "Controller flags (advanced)"
+    `--metrics-bind-address` is a **string** flag; the literal value **`0`** turns the metrics server **off** ([`cmd/main.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/cmd/main.go)). Anything else (for example **`:8443`**) enables scraping on that address—the default Kustomize overlay sets **`--metrics-bind-address=:8443`** ([`config/default/manager_metrics_patch.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml)). **`--metrics-secure`** defaults to **true**. Adjust these only if you maintain a custom Deployment manifest.
 
-### `mcpserver_condition_info`
+## Custom metrics
 
-| Property | Value |
-|----------|--------|
-| **Type** | Gauge |
-| **Help** | Current condition state of MCPServer resources. Value is always `1`; use labels to filter. |
+Custom metrics use the Prometheus namespace **`mcpserver`** (exported names start with **`mcpserver_`**).
 
-**Labels**
+| Metric | Type | Description |
+| --- | --- | --- |
+| `mcpserver_condition_info` | gauge | Current **Accepted** / **Ready** condition snapshot per `MCPServer`. Value is always `1`; filter by labels. |
+| `mcpserver_validation_failures_total` | counter | Total permanent configuration validation failures (`ValidationError`). |
+| `mcpserver_deployment_failures_total` | counter | Total failures when reconciling the workload Deployment (`reason` is currently `ReconcileError`). |
+| `mcpserver_service_failures_total` | counter | Total failures when reconciling the Service (`reason` is currently `ReconcileError`). |
+| `mcpserver_reconcile_phase_duration_seconds` | histogram | Duration of reconciliation phases **validation**, **deployment**, and **service** (seconds; default Prometheus histogram buckets). |
+
+### Labels for `mcpserver_condition_info`
 
 | Label | Description |
-|-------|-------------|
-| `name` | MCPServer resource name |
-| `namespace` | MCPServer namespace |
+| --- | --- |
+| `name` | `MCPServer` name |
+| `namespace` | `MCPServer` namespace |
 | `type` | Condition type: `Accepted` or `Ready` |
-| `status` | Kubernetes condition status: `True`, `False`, or `Unknown` |
-| `reason` | Condition reason (intended to match `.status.conditions[]`; see [note below](#gauge-versus-api-status)) |
+| `status` | `True`, `False`, or `Unknown` |
+| `reason` | Condition reason (intended to mirror `.status.conditions[]`; see [note below](#gauge-versus-api-status)) |
 
-For each `(name, namespace, type)` tuple, at most one time series is active: updating a condition deletes prior series with the same name, namespace, and type so only the current status/reason remains.
+Only one active series exists per `(name, namespace, type)`. On delete, gauge series for that object are removed; **`*_failures_total` counters are not**—time series may remain in Prometheus.
 
-When an `MCPServer` is deleted, `cleanupMetrics` removes **only** `mcpserver_condition_info` series for that object. Counter metrics (`*_failures_total`) are not removed; their label sets may still appear in Prometheus after the resource is gone.
-
-**Typical reasons** (from reconciler logic; see [`internal/controller/mcpserver_controller.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/mcpserver_controller.go))
-
-- **Accepted:** `Valid`, `Invalid`
-- **Ready:** `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable`
-
-For **Ready**, `status` may be `Unknown` (for example reason `Initializing` while the Deployment has not reported conditions yet).
+**Typical reasons:** **Accepted:** `Valid`, `Invalid`. **Ready:** `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable`. **Ready** may use status **Unknown** (for example `Initializing`).
 
 <span id="gauge-versus-api-status"></span>
 
 !!! note "Gauge versus API status"
-    `recordCondition` runs at fixed points in [`Reconcile`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/mcpserver_controller.go). In rare cases the gauge can **diverge** from the API object's `.status.conditions`:
+    In rare cases the gauge can **diverge** from `MCPServer.status.conditions`: (1) **Permanent validation error** — `Ready` / `ConfigurationInvalid` is recorded only after a successful status write. (2) **MCP handshake** — after `Available`, a failed handshake may set status to `MCPEndpointUnavailable` without a second gauge update in the same reconcile. Prefer **`MCPServer.status` as source of truth** for correctness.
 
-    1. **Permanent validation error** — `Ready` / `ConfigurationInvalid` is passed to `recordCondition` only **after** `applyStatus` succeeds. If that update fails, the `validation_failures_total` counter and `Accepted` gauge may already have been updated, but the **Ready** gauge may still reflect an older reconcile.
-    2. **MCP endpoint handshake** — When deployment-level readiness is `Available`, the reconciler runs an MCP handshake and may set status to `MCPEndpointUnavailable` if it fails. That happens **after** `recordCondition` ran with `Available`; **`recordCondition` is not invoked again** in that reconcile, so the Ready gauge can still show `Available` until a later reconcile updates it.
-
-    Treat **`MCPServer.status.conditions` as authoritative** for correctness; use this gauge for aggregation and alerting with the above limitations in mind.
-
-Use this metric to count or alert on MCPServers by acceptance/readiness state, for example:
+**Example queries**
 
 ```promql
 sum by (namespace, type, status, reason) (mcpserver_condition_info)
 ```
 
-### `mcpserver_validation_failures_total`
+### Labels for counters and histogram
 
-| Property | Value |
-|----------|--------|
-| **Type** | Counter |
-| **Help** | Total number of configuration validation failures. |
+**`mcpserver_validation_failures_total`:** `name`, `namespace`, `reason` (permanent errors currently use `Invalid`).
 
-**Labels**
+**`mcpserver_deployment_failures_total` / `mcpserver_service_failures_total`:** `name`, `namespace`, `reason`.
 
-| Label | Description |
-|-------|-------------|
-| `name` | MCPServer resource name |
-| `namespace` | MCPServer namespace |
-| `reason` | Validation failure reason — today permanent errors use `Invalid` (`ReasonInvalid`) |
+**`mcpserver_reconcile_phase_duration_seconds`:** `phase` ∈ `validation`, `deployment`, `service`. Use `_bucket`, `_sum`, and `_count` for quantiles.
 
-Incremented once per reconcile that finishes with a permanent configuration validation error (`ValidationError`). Transient API errors during validation do not increment this counter; the controller retries without applying an `Accepted=False` status update for those failures.
+## Prometheus Operator
 
-### `mcpserver_deployment_failures_total`
+If you use the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), apply a `ServiceMonitor` that selects the controller-manager metrics Service (same pattern as [Argo CD’s metrics guide](https://argo-cd.readthedocs.io/en/latest/operator-manual/metrics/#prometheus-operator)). Example:
 
-| Property | Value |
-|----------|--------|
-| **Type** | Counter |
-| **Help** | Total number of deployment reconciliation failures. |
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: mcp-lifecycle-operator-system   # namespace where the operator runs
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: mcp-lifecycle-operator
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true   # tighten for production (e.g. cert-manager); see repo sample
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: mcp-lifecycle-operator
+```
 
-**Labels**
-
-| Label | Description |
-|-------|-------------|
-| `name` | MCPServer resource name |
-| `namespace` | MCPServer namespace |
-| `reason` | Failure reason (currently `ReconcileError` when `reconcileDeployment` returns an error) |
-
-### `mcpserver_service_failures_total`
-
-| Property | Value |
-|----------|--------|
-| **Type** | Counter |
-| **Help** | Total number of service reconciliation failures. |
-
-**Labels**
-
-| Label | Description |
-|-------|-------------|
-| `name` | MCPServer resource name |
-| `namespace` | MCPServer namespace |
-| `reason` | Failure reason (currently `ReconcileError` when `reconcileService` returns an error) |
-
-### `mcpserver_reconcile_phase_duration_seconds`
-
-| Property | Value |
-|----------|--------|
-| **Type** | Histogram |
-| **Help** | Duration of reconciliation phases in seconds. |
-| **Buckets** | Prometheus default histogram buckets (`DefBuckets`) |
-
-**Labels**
-
-| Label | Description |
-|-------|-------------|
-| `phase` | One of `validation`, `deployment`, or `service` |
-
-Observes wall-clock duration for:
-
-- **`validation`** — `validateConfig` (success, permanent validation failure, or transient error — all paths observe once per reconcile attempt that reaches this phase)
-- **`deployment`** — `reconcileDeployment` (always observed after the call returns)
-- **`service`** — `reconcileService` (always observed after the call returns)
-
-Use `_bucket`, `_sum`, and `_count` suffixes as usual for histogram quantiles and averages.
+The repository maintains the full sample at [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml). Wire it into your install by uncommenting the **`[PROMETHEUS]`** resource (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml`), or apply an equivalent manifest alongside kube-prometheus-stack. Add labels your Prometheus `ServiceMonitor` selector expects (for example `release: prometheus`).
 
 ## Implementation note
 
-Metric definitions and registration live in [`internal/controller/metrics.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/metrics.go). Keep this page aligned with that file when metrics change.
+Metric registration lives in [`internal/controller/metrics.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/metrics.go). Update this page when that file changes.
 
 ## Next steps
 

--- a/site-src/metrics.md
+++ b/site-src/metrics.md
@@ -1,0 +1,131 @@
+# Prometheus metrics
+
+The controller manager exposes Prometheus metrics at `/metrics` on the metrics server when [`--metrics-bind-address`](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/server#Options) is non-zero. The generated **`config/default`** overlay patches the Deployment with `--metrics-bind-address=:8443` ([`manager_metrics_patch.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml)); combined with `--metrics-secure` defaulting to **true** in [`cmd/main.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/cmd/main.go), that serves TLS on 8443. Use `--metrics-secure=false` for plain HTTP (for example with `:8080`). Besides [controller-runtime default metrics](https://book.kubebuilder.io/reference/metrics.html) (workqueues, REST client, leader election, etc.), the MCPServer reconciler registers **custom metrics** under the `mcpserver_` namespace.
+
+## Scraping with Prometheus Operator
+
+A sample `ServiceMonitor` for the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) lives in the repo:
+
+- Manifest: [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml)
+
+It is **not** wired into the default install: enable it by uncommenting the `[PROMETHEUS]` entry (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml), then apply your overlay (for example kube-prometheus-stack) so the operator discovers the monitor.
+
+## Custom metrics reference
+
+All custom metric names are prefixed with `mcpserver_` (Prometheus namespace `mcpserver`).
+
+### `mcpserver_condition_info`
+
+| Property | Value |
+|----------|--------|
+| **Type** | Gauge |
+| **Help** | Current condition state of MCPServer resources. Value is always `1`; use labels to filter. |
+
+**Labels**
+
+| Label | Description |
+|-------|-------------|
+| `name` | MCPServer resource name |
+| `namespace` | MCPServer namespace |
+| `type` | Condition type: `Accepted` or `Ready` |
+| `status` | Kubernetes condition status: `True`, `False`, or `Unknown` |
+| `reason` | Condition reason — intended to match `.status.conditions[]`; see [Gauge vs status](#gauge-vs-mcpserver-status) |
+
+For each `(name, namespace, type)` tuple, at most one time series is active: updating a condition deletes prior series with the same name, namespace, and type so only the current status/reason remains.
+
+When an `MCPServer` is deleted, `cleanupMetrics` removes **only** `mcpserver_condition_info` series for that object. Counter metrics (`*_failures_total`) are not removed; their label sets may still appear in Prometheus after the resource is gone.
+
+**Typical reasons** (from reconciler logic; see [`internal/controller/mcpserver_controller.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/mcpserver_controller.go))
+
+- **Accepted:** `Valid`, `Invalid`
+- **Ready:** `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable`
+
+For **Ready**, `status` may be `Unknown` (for example reason `Initializing` while the Deployment has not reported conditions yet).
+
+#### Gauge vs MCPServer status
+
+`recordCondition` runs at fixed points in [`Reconcile`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/mcpserver_controller.go). In rare cases the gauge can **diverge** from the API object’s `.status.conditions`:
+
+1. **Permanent validation error** — `Ready` / `ConfigurationInvalid` is passed to `recordCondition` only **after** `applyStatus` succeeds. If that update fails, the `validation_failures_total` counter and `Accepted` gauge may already have been updated, but the **Ready** gauge may still reflect an older reconcile.
+2. **MCP endpoint handshake** — When deployment-level readiness is `Available`, the reconciler runs an MCP handshake and may set status to `MCPEndpointUnavailable` if it fails. That happens **after** `recordCondition` ran with `Available`; **`recordCondition` is not invoked again** in that reconcile, so the Ready gauge can still show `Available` until a later reconcile updates it.
+
+Treat **`MCPServer.status.conditions` as authoritative** for correctness; use this gauge for aggregation and alerting with the above limitations in mind.
+
+Use this metric to count or alert on MCPServers by acceptance/readiness state, for example:
+
+```promql
+sum by (namespace, type, status, reason) (mcpserver_condition_info)
+```
+
+### `mcpserver_validation_failures_total`
+
+| Property | Value |
+|----------|--------|
+| **Type** | Counter |
+| **Help** | Total number of configuration validation failures. |
+
+**Labels**
+
+| Label | Description |
+|-------|-------------|
+| `name` | MCPServer resource name |
+| `namespace` | MCPServer namespace |
+| `reason` | Validation failure reason — today permanent errors use `Invalid` (`ReasonInvalid`) |
+
+Incremented once per reconcile that finishes with a permanent configuration validation error (`ValidationError`). Transient API errors during validation do not increment this counter; the controller retries without applying an `Accepted=False` status update for those failures.
+
+### `mcpserver_deployment_failures_total`
+
+| Property | Value |
+|----------|--------|
+| **Type** | Counter |
+| **Help** | Total number of deployment reconciliation failures. |
+
+**Labels**
+
+| Label | Description |
+|-------|-------------|
+| `name` | MCPServer resource name |
+| `namespace` | MCPServer namespace |
+| `reason` | Failure reason (currently `ReconcileError` when `reconcileDeployment` returns an error) |
+
+### `mcpserver_service_failures_total`
+
+| Property | Value |
+|----------|--------|
+| **Type** | Counter |
+| **Help** | Total number of service reconciliation failures. |
+
+**Labels**
+
+| Label | Description |
+|-------|-------------|
+| `name` | MCPServer resource name |
+| `namespace` | MCPServer namespace |
+| `reason` | Failure reason (currently `ReconcileError` when `reconcileService` returns an error) |
+
+### `mcpserver_reconcile_phase_duration_seconds`
+
+| Property | Value |
+|----------|--------|
+| **Type** | Histogram |
+| **Help** | Duration of reconciliation phases in seconds. |
+| **Buckets** | Prometheus default histogram buckets (`DefBuckets`) |
+
+**Labels**
+
+| Label | Description |
+|-------|-------------|
+| `phase` | One of `validation`, `deployment`, or `service` |
+
+Observes wall-clock duration for:
+
+- **`validation`** — `validateConfig` (success, permanent validation failure, or transient error — all paths observe once per reconcile attempt that reaches this phase)
+- **`deployment`** — `reconcileDeployment` (always observed after the call returns)
+- **`service`** — `reconcileService` (always observed after the call returns)
+
+Use `_bucket`, `_sum`, and `_count` suffixes as usual for histogram quantiles and averages.
+
+## Implementation note
+
+Metric definitions and registration live in [`internal/controller/metrics.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/metrics.go). This document should stay aligned with that file when metrics are added or changed.

--- a/site-src/metrics.md
+++ b/site-src/metrics.md
@@ -41,7 +41,12 @@ Custom metrics use the Prometheus namespace **`mcpserver`** (exported names star
 
 Only one active series exists per `(name, namespace, type)`. On delete, gauge series for that object are removed; **`*_failures_total` counters are not**—time series may remain in Prometheus.
 
-**Typical reasons:** **Accepted:** `Valid`, `Invalid`. **Ready:** `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable`. **Ready** may use status **Unknown** (for example `Initializing`).
+**Typical reasons**
+
+| `type` | Typical `reason` values | `status` notes |
+| --- | --- | --- |
+| `Accepted` | `Valid`, `Invalid` | Usually `True` or `False` |
+| `Ready` | `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable` | May be `Unknown` (for example `Initializing` while the Deployment has not reported conditions yet) |
 
 <span id="gauge-versus-api-status"></span>
 
@@ -54,13 +59,29 @@ Only one active series exists per `(name, namespace, type)`. On delete, gauge se
 sum by (namespace, type, status, reason) (mcpserver_condition_info)
 ```
 
-### Labels for counters and histogram
+### Labels for `mcpserver_validation_failures_total`
 
-**`mcpserver_validation_failures_total`:** `name`, `namespace`, `reason` (permanent errors currently use `Invalid`).
+| Label | Description |
+| --- | --- |
+| `name` | `MCPServer` name |
+| `namespace` | `MCPServer` namespace |
+| `reason` | Validation failure reason; permanent errors currently use `Invalid` |
 
-**`mcpserver_deployment_failures_total` / `mcpserver_service_failures_total`:** `name`, `namespace`, `reason`.
+### Labels for `mcpserver_deployment_failures_total` and `mcpserver_service_failures_total`
 
-**`mcpserver_reconcile_phase_duration_seconds`:** `phase` ∈ `validation`, `deployment`, `service`. Use `_bucket`, `_sum`, and `_count` for quantiles.
+| Label | Description |
+| --- | --- |
+| `name` | `MCPServer` name |
+| `namespace` | `MCPServer` namespace |
+| `reason` | Failure reason; currently `ReconcileError` when the corresponding reconcile step returns an error |
+
+### Labels for `mcpserver_reconcile_phase_duration_seconds`
+
+| Label | Description |
+| --- | --- |
+| `phase` | Reconciliation phase: `validation`, `deployment`, or `service` |
+
+Histogram time series use the usual `_bucket`, `_sum`, and `_count` suffixes for quantiles and averages.
 
 ## Prometheus Operator
 
@@ -90,10 +111,6 @@ spec:
 ```
 
 The repository maintains the full sample at [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml). Wire it into your install by uncommenting the **`[PROMETHEUS]`** resource (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml`), or apply an equivalent manifest alongside kube-prometheus-stack. Add labels your Prometheus `ServiceMonitor` selector expects (for example `release: prometheus`).
-
-## Implementation note
-
-Metric registration lives in [`internal/controller/metrics.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/internal/controller/metrics.go). Update this page when that file changes.
 
 ## Next steps
 

--- a/site-src/metrics.md
+++ b/site-src/metrics.md
@@ -138,5 +138,4 @@ Metric definitions and registration live in [`internal/controller/metrics.go`](h
 
 - **[Introduction](introduction.md)** — Architecture and `MCPServer` overview (including status conditions)
 - **[Quickstart](guides/quickstart.md)** — Deploy an MCP server and inspect status
-- **[API Reference](reference/)** — Full `MCPServer` API
 - **[Contributing](contributing/index.md)** — How to contribute

--- a/site-src/metrics.md
+++ b/site-src/metrics.md
@@ -64,7 +64,7 @@ sum by (namespace, type, status, reason) (mcpserver_condition_info)
 
 ## Prometheus Operator
 
-If you use the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), apply a `ServiceMonitor` that selects the controller-manager metrics Service (same pattern as [Argo CD’s metrics guide](https://argo-cd.readthedocs.io/en/latest/operator-manual/metrics/#prometheus-operator)). Example:
+If you use the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), apply a `ServiceMonitor` that selects the controller-manager metrics Service. Example:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1

--- a/site-src/operating/.pages
+++ b/site-src/operating/.pages
@@ -1,0 +1,2 @@
+nav:
+  - Metrics: metrics.md

--- a/site-src/operating/metrics.md
+++ b/site-src/operating/metrics.md
@@ -6,7 +6,7 @@ This page is aimed at **platform and cluster operators** who scrape Prometheus a
 
 ## Metrics endpoint
 
-Metrics are exposed over **HTTPS** at path **`/metrics`** on **port `8443`** on the controller manager metrics **Service** (the Service port is named **`https`**).
+Metrics are exposed over **HTTPS** at path **`/metrics`** on **port `8443`** on the controller manager metrics **Service**.
 
 After a typical install from the [release `install.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/latest), scrape:
 
@@ -14,8 +14,20 @@ After a typical install from the [release `install.yaml`](https://github.com/kub
 
 Adjust the Service name and namespace if you change the Kustomize `namePrefix` / `namespace` when deploying.
 
-!!! note "Controller flags (advanced)"
-    `--metrics-bind-address` is a **string** flag; the literal value **`0`** turns the metrics server **off** ([`cmd/main.go`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/cmd/main.go)). Anything else (for example **`:8443`**) enables scraping on that address—the default Kustomize overlay sets **`--metrics-bind-address=:8443`** ([`config/default/manager_metrics_patch.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml)). **`--metrics-secure`** defaults to **true**. Adjust these only if you maintain a custom Deployment manifest.
+### Tuning the metrics listen address (advanced)
+
+If you installed from the [release `install.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/latest), metrics are already available on **`:8443`** with HTTPS—you can use the scrape URL above and skip this section.
+
+If you **customize the operator Deployment**, check how the manager container sets its `args`. The repository’s sample patch shows what a typical install uses:
+
+[`config/default/manager_metrics_patch.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml)
+
+Those `args` correspond to the following flags:
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--metrics-bind-address` | `0` (disabled) | Address to serve metrics on. Set to **`:8443`** for HTTPS or **`:8080`** for HTTP. The sample patch above [sets this to `:8443`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/manager_metrics_patch.yaml). |
+| `--metrics-secure` | `true` | Serve metrics over HTTPS. Set to **`false`** for plain HTTP. |
 
 ## Custom metrics
 
@@ -37,7 +49,7 @@ Custom metrics use the Prometheus namespace **`mcpserver`** (exported names star
 | `namespace` | `MCPServer` namespace |
 | `type` | Condition type: `Accepted` or `Ready` |
 | `status` | `True`, `False`, or `Unknown` |
-| `reason` | Condition reason (intended to mirror `.status.conditions[]`; see [note below](#gauge-versus-api-status)) |
+| `reason` | Condition reason (intended to mirror `.status.conditions[]`; see [Gauge versus API status](#gauge-versus-api-status)) |
 
 Only one active series exists per `(name, namespace, type)`. On delete, gauge series for that object are removed; **`*_failures_total` counters are not**—time series may remain in Prometheus.
 
@@ -48,15 +60,32 @@ Only one active series exists per `(name, namespace, type)`. On delete, gauge se
 | `Accepted` | `Valid`, `Invalid` | Usually `True` or `False` |
 | `Ready` | `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable` | May be `Unknown` (for example `Initializing` while the Deployment has not reported conditions yet) |
 
-<span id="gauge-versus-api-status"></span>
+### Gauge versus API status
 
-!!! note "Gauge versus API status"
-    In rare cases the gauge can **diverge** from `MCPServer.status.conditions`: (1) **Permanent validation error** — `Ready` / `ConfigurationInvalid` is recorded only after a successful status write. (2) **MCP handshake** — after `Available`, a failed handshake may set status to `MCPEndpointUnavailable` without a second gauge update in the same reconcile. Prefer **`MCPServer.status` as source of truth** for correctness.
+In rare cases the **`mcpserver_condition_info` gauge** can **diverge** from what you see in **`MCPServer.status.conditions`**. When investigating correctness, treat **`MCPServer.status` as the source of truth**.
+
+- **Permanent validation error** — `Ready` / `ConfigurationInvalid` may appear in the API only after a successful status write, while the gauge updated earlier or on a different path.
+- **MCP handshake** — after `Available`, a failed handshake can set status to `MCPEndpointUnavailable` without a second gauge update in the same reconcile.
 
 **Example queries**
 
 ```promql
 sum by (namespace, type, status, reason) (mcpserver_condition_info)
+```
+
+```promql
+sum by (reason) (mcpserver_condition_info{type="Ready", status="False"})
+```
+
+```promql
+sum(rate(mcpserver_validation_failures_total[5m])) by (namespace)
+```
+
+```promql
+histogram_quantile(
+  0.99,
+  sum(rate(mcpserver_reconcile_phase_duration_seconds_bucket[5m])) by (le, phase)
+)
 ```
 
 ### Labels for failure counters (`mcpserver_*_failures_total`)
@@ -109,10 +138,10 @@ spec:
       app.kubernetes.io/name: mcp-lifecycle-operator
 ```
 
-The repository maintains the full sample at [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml). Wire it into your install by uncommenting the **`[PROMETHEUS]`** resource (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml`), or apply an equivalent manifest alongside kube-prometheus-stack. Add labels your Prometheus `ServiceMonitor` selector expects (for example `release: prometheus`).
+The repository maintains the full sample at [`config/prometheus/monitor.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/prometheus/monitor.yaml). Wire it into your install by uncommenting the **`[PROMETHEUS]`** resource (`../prometheus`) in [`config/default/kustomization.yaml`](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/default/kustomization.yaml), or apply an equivalent manifest alongside kube-prometheus-stack. Add labels your Prometheus `ServiceMonitor` selector expects (for example `release: prometheus`).
 
 ## Next steps
 
-- **[Introduction](introduction.md)** — Architecture and `MCPServer` overview (including status conditions)
-- **[Quickstart](guides/quickstart.md)** — Deploy an MCP server and inspect status
-- **[Contributing](contributing/index.md)** — How to contribute
+- **[Introduction](../introduction.md)** — Architecture and `MCPServer` overview (including status conditions)
+- **[Quickstart](../guides/quickstart.md)** — Deploy an MCP server and inspect status
+- **[Contributing](../contributing/index.md)** — How to contribute


### PR DESCRIPTION
**Summary**
https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/101
Documents the custom mcpserver_* Prometheus metrics added for operator observability (see #100 and related implementation work).

**This PR includes:**

New site-src/metrics.md (MkDocs source) covering:
Metric names, types, and labels
Reconciliation phases
Enabling the repository’s ServiceMonitor
Notes on where condition gauges may diverge from MCPServer status
Updates to site navigation (.pages)
Additions to Guides → “Additional resources”
Updates to site-src/README.md and root README.md

**AI Disclosure**

Parts of this documentation were drafted with AI assistance (Cursor) and manually verified against:

internal/controller/metrics.go
Reconciler paths introduced alongside the metrics work in #100
<img width="1958" height="1824" alt="image" src="https://github.com/user-attachments/assets/1d114bcc-6198-4498-9796-cbaae8e33dbd" />
