### PR TITLE
feat: trigger rolling update when referenced Secrets/ConfigMaps change

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -21,9 +21,11 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -119,6 +121,10 @@ const (
 	// until the next spec change triggers a new reconciliation.
 	maxMCPHandshakeRetries = 10
 )
+
+// configHashAnnotation is the pod template annotation key used to trigger
+// rolling updates when referenced ConfigMap or Secret data changes.
+const configHashAnnotation = "mcp.x-k8s.io/config-hash"
 
 // Index keys for field indexing.
 const (
@@ -659,6 +665,10 @@ func (r *MCPServerReconciler) reconcileDeployment(
 		return nil, err
 	}
 
+	if err := r.applyConfigHash(ctx, mcpServer, deployment); err != nil {
+		return nil, err
+	}
+
 	existingDeployment := &appsv1.Deployment{}
 	err = r.Get(ctx, client.ObjectKey{Name: deployment.Name, Namespace: deployment.Namespace}, existingDeployment)
 	if err != nil && apierrors.IsNotFound(err) {
@@ -727,11 +737,13 @@ func (r *MCPServerReconciler) reconcileDeployment(
 			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].ReadinessProbe, newPodSpec.Containers[0].ReadinessProbe) ||
 			oldPodSpec.ServiceAccountName != newPodSpec.ServiceAccountName ||
 			!equality.Semantic.DeepEqual(existingDeployment.Spec.Replicas, deployment.Spec.Replicas) ||
+			!equality.Semantic.DeepEqual(existingDeployment.Spec.Template.Annotations, deployment.Spec.Template.Annotations) ||
 			ownershipChanged
 	}
 	if needsUpdate {
 		logger.Info("Updating Deployment", "name", existingDeployment.Name)
 		existingDeployment.Spec.Replicas = deployment.Spec.Replicas
+		existingDeployment.Spec.Template.Annotations = deployment.Spec.Template.Annotations
 		existingDeployment.Spec.Template.Spec = deployment.Spec.Template.Spec
 		if err := r.Update(ctx, existingDeployment); err != nil {
 			logger.Error(err, "Failed to update Deployment")
@@ -1487,6 +1499,102 @@ func extractSecretNames(obj client.Object) []string {
 	}
 
 	return secrets
+}
+
+// applyConfigHash computes the config hash and sets it as a pod template
+// annotation on the deployment. This is extracted from reconcileDeployment
+// to keep cyclomatic complexity in check.
+func (r *MCPServerReconciler) applyConfigHash(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+	deployment *appsv1.Deployment,
+) error {
+	configHash, err := r.computeConfigHash(ctx, mcpServer)
+	if err != nil {
+		return err
+	}
+	if configHash != "" {
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = make(map[string]string)
+		}
+		deployment.Spec.Template.Annotations[configHashAnnotation] = configHash
+	}
+	return nil
+}
+
+// computeConfigHash computes a SHA-256 hash of all ConfigMap and Secret data
+// referenced by the MCPServer. This hash is placed in a pod template annotation
+// so that changes to referenced resource data trigger a rolling update.
+// Returns "" if no ConfigMaps or Secrets are referenced.
+func (r *MCPServerReconciler) computeConfigHash(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+) (string, error) {
+	configMapNames := extractConfigMapNames(mcpServer)
+	secretNames := extractSecretNames(mcpServer)
+
+	if len(configMapNames) == 0 && len(secretNames) == 0 {
+		return "", nil
+	}
+
+	h := sha256.New()
+
+	sort.Strings(configMapNames)
+	for _, name := range configMapNames {
+		cm := &corev1.ConfigMap{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Name:      name,
+			Namespace: mcpServer.Namespace,
+		}, cm); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", err
+		}
+		keys := make([]string, 0, len(cm.Data)+len(cm.BinaryData))
+		for k := range cm.Data {
+			keys = append(keys, k)
+		}
+		for k := range cm.BinaryData {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			_, _ = fmt.Fprintf(h, "configmap/%s/%s=", name, k)
+			if v, ok := cm.Data[k]; ok {
+				_, _ = fmt.Fprint(h, v)
+			} else {
+				_, _ = h.Write(cm.BinaryData[k])
+			}
+			_, _ = h.Write([]byte{0})
+		}
+	}
+
+	sort.Strings(secretNames)
+	for _, name := range secretNames {
+		secret := &corev1.Secret{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Name:      name,
+			Namespace: mcpServer.Namespace,
+		}, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return "", err
+		}
+		keys := make([]string, 0, len(secret.Data))
+		for k := range secret.Data {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			_, _ = fmt.Fprintf(h, "secret/%s/%s=", name, k)
+			_, _ = h.Write(secret.Data[k])
+			_, _ = h.Write([]byte{0})
+		}
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 // findMCPServersForResource is a generic helper that finds all MCPServers

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -1525,7 +1525,7 @@ func (r *MCPServerReconciler) applyConfigHash(
 // computeConfigHash computes a SHA-256 hash of all ConfigMap and Secret data
 // referenced by the MCPServer. This hash is placed in a pod template annotation
 // so that changes to referenced resource data trigger a rolling update.
-// Returns "" if no ConfigMaps or Secrets are referenced.
+// Returns "" if no refs are listed or all referenced resources are not found.
 func (r *MCPServerReconciler) computeConfigHash(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
@@ -1538,6 +1538,7 @@ func (r *MCPServerReconciler) computeConfigHash(
 	}
 
 	h := sha256.New()
+	dataWritten := false
 
 	sort.Strings(configMapNames)
 	for _, name := range configMapNames {
@@ -1551,6 +1552,7 @@ func (r *MCPServerReconciler) computeConfigHash(
 			}
 			return "", err
 		}
+		dataWritten = true
 		keys := make([]string, 0, len(cm.Data)+len(cm.BinaryData))
 		for k := range cm.Data {
 			keys = append(keys, k)
@@ -1582,6 +1584,7 @@ func (r *MCPServerReconciler) computeConfigHash(
 			}
 			return "", err
 		}
+		dataWritten = true
 		keys := make([]string, 0, len(secret.Data))
 		for k := range secret.Data {
 			keys = append(keys, k)
@@ -1592,6 +1595,10 @@ func (r *MCPServerReconciler) computeConfigHash(
 			_, _ = h.Write(secret.Data[k])
 			_, _ = h.Write([]byte{0})
 		}
+	}
+
+	if !dataWritten {
+		return "", nil
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil

--- a/internal/controller/mcpserver_controller_confighash_test.go
+++ b/internal/controller/mcpserver_controller_confighash_test.go
@@ -1,0 +1,576 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+var _ = Describe("MCPServer Controller - Config Hash", func() {
+	ctx := context.Background()
+
+	Context("When reconciling with no external refs (inline env only)", func() {
+		const resourceName = "test-confighash-no-refs"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.Env = []corev1.EnvVar{
+				{
+					Name:  "INLINE_VAR",
+					Value: "inline-value",
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should not set config-hash annotation on deployment", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			annotations := deployment.Spec.Template.Annotations
+			if annotations != nil {
+				Expect(annotations).NotTo(HaveKey(configHashAnnotation))
+			}
+		})
+	})
+
+	Context("When reconciling with ConfigMap envFrom reference", func() {
+		const resourceName = "test-confighash-cm-envfrom"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-test-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"key1": "value1",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-test-cm",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-test-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should set config-hash annotation on deployment", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(deployment.Spec.Template.Annotations).To(HaveKey(configHashAnnotation))
+			Expect(deployment.Spec.Template.Annotations[configHashAnnotation]).NotTo(BeEmpty())
+		})
+	})
+
+	Context("When reconciling with Secret env valueFrom reference", func() {
+		const resourceName = "test-confighash-secret-env"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-test-secret",
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"password": "s3cret",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.Env = []corev1.EnvVar{
+				{
+					Name: "DB_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "hash-test-secret",
+							},
+							Key: "password",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			secret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-test-secret", Namespace: "default"}, secret)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should set config-hash annotation on deployment", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(deployment.Spec.Template.Annotations).To(HaveKey(configHashAnnotation))
+			Expect(deployment.Spec.Template.Annotations[configHashAnnotation]).NotTo(BeEmpty())
+		})
+	})
+
+	Context("When ConfigMap data changes", func() {
+		const resourceName = "test-confighash-cm-change"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-change-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"key1": "original-value",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-change-cm",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-change-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should update the config-hash annotation when ConfigMap data changes", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// First reconcile
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			originalHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(originalHash).NotTo(BeEmpty())
+
+			// Update the ConfigMap data
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-change-cm", Namespace: "default"}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			configMap.Data["key1"] = "updated-value"
+			Expect(k8sClient.Update(ctx, configMap)).To(Succeed())
+
+			// Reconcile again
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Re-fetch deployment
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			newHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(newHash).NotTo(BeEmpty())
+			Expect(newHash).NotTo(Equal(originalHash))
+		})
+	})
+
+	Context("When Secret data changes", func() {
+		const resourceName = "test-confighash-secret-change"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-change-secret",
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"token": "original-token",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-change-secret",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			secret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-change-secret", Namespace: "default"}, secret)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should update the config-hash annotation when Secret data changes", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// First reconcile
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			originalHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(originalHash).NotTo(BeEmpty())
+
+			// Update the Secret data
+			secret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-change-secret", Namespace: "default"}, secret)
+			Expect(err).NotTo(HaveOccurred())
+			secret.Data["token"] = []byte("updated-token")
+			Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+			// Reconcile again
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Re-fetch deployment
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			newHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(newHash).NotTo(BeEmpty())
+			Expect(newHash).NotTo(Equal(originalHash))
+		})
+	})
+
+	Context("When computing hash determinism", func() {
+		const resourceName = "test-confighash-deterministic"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-deterministic-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-deterministic-cm",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-deterministic-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should produce the same hash on consecutive reconciles with unchanged data", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// First reconcile
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			hash1 := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(hash1).NotTo(BeEmpty())
+
+			// Second reconcile without changes
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			hash2 := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(hash2).To(Equal(hash1))
+		})
+	})
+
+	Context("When a referenced ConfigMap does not exist", func() {
+		It("should skip missing refs gracefully in computeConfigHash", func() {
+			// Test computeConfigHash directly since the controller validates
+			// config before reaching deployment creation, and a missing
+			// ConfigMap causes the MCPServer to be marked Invalid.
+			reconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			mcpServer := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-confighash-missing-ref",
+					Namespace: "default",
+				},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Config: mcpv1alpha1.ServerConfig{
+						EnvFrom: []corev1.EnvFromSource{
+							{
+								ConfigMapRef: &corev1.ConfigMapEnvSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "nonexistent-configmap",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			hash, err := reconciler.computeConfigHash(ctx, mcpServer)
+			Expect(err).NotTo(HaveOccurred())
+			// All refs were missing and skipped, so no data was hashed.
+			// The function returns "" when there is nothing to hash into the digest.
+			// However, since refs were listed (len > 0), the hasher was created
+			// but no data was written. The result is still a valid (empty-input) hash.
+			// The key assertion is that no error occurred.
+			_ = hash
+		})
+	})
+})

--- a/internal/controller/mcpserver_controller_confighash_test.go
+++ b/internal/controller/mcpserver_controller_confighash_test.go
@@ -565,12 +565,496 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 			hash, err := reconciler.computeConfigHash(ctx, mcpServer)
 			Expect(err).NotTo(HaveOccurred())
-			// All refs were missing and skipped, so no data was hashed.
-			// The function returns "" when there is nothing to hash into the digest.
-			// However, since refs were listed (len > 0), the hasher was created
-			// but no data was written. The result is still a valid (empty-input) hash.
-			// The key assertion is that no error occurred.
-			_ = hash
+			Expect(hash).To(Equal(""))
+		})
+	})
+
+	Context("When reconciling with storage-mounted ConfigMap", func() {
+		const resourceName = "test-confighash-storage-cm"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-storage-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"config.yaml": "key: value",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+				{
+					Path: "/etc/config",
+					Source: mcpv1alpha1.StorageSource{
+						Type: mcpv1alpha1.StorageTypeConfigMap,
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "hash-storage-cm",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-storage-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should set config-hash annotation on deployment", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(deployment.Spec.Template.Annotations).To(HaveKey(configHashAnnotation))
+			Expect(deployment.Spec.Template.Annotations[configHashAnnotation]).NotTo(BeEmpty())
+		})
+	})
+
+	Context("When reconciling with both ConfigMap and Secret", func() {
+		const resourceName = "test-confighash-both"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-both-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"key1": "cm-value",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-both-secret",
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"token": "secret-value",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-both-cm",
+						},
+					},
+				},
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-both-secret",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-both-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			secret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-both-secret", Namespace: "default"}, secret)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should set a single config-hash and update when ConfigMap changes", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(deployment.Spec.Template.Annotations).To(HaveKey(configHashAnnotation))
+			originalHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(originalHash).NotTo(BeEmpty())
+
+			// Update ConfigMap data
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-both-cm", Namespace: "default"}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			configMap.Data["key1"] = "updated-cm-value"
+			Expect(k8sClient.Update(ctx, configMap)).To(Succeed())
+
+			// Reconcile again
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			newHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(newHash).NotTo(BeEmpty())
+			Expect(newHash).NotTo(Equal(originalHash))
+		})
+	})
+
+	Context("When reconciling with ConfigMap BinaryData", func() {
+		const resourceName = "test-confighash-binarydata"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-binary-cm",
+					Namespace: "default",
+				},
+				BinaryData: map[string][]byte{
+					"cert.pem": []byte("original-binary-data"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-binary-cm",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-binary-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should set config-hash and update when BinaryData changes", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(deployment.Spec.Template.Annotations).To(HaveKey(configHashAnnotation))
+			originalHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(originalHash).NotTo(BeEmpty())
+
+			// Update BinaryData
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-binary-cm", Namespace: "default"}, configMap)
+			Expect(err).NotTo(HaveOccurred())
+			configMap.BinaryData["cert.pem"] = []byte("updated-binary-data")
+			Expect(k8sClient.Update(ctx, configMap)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			newHash := deployment.Spec.Template.Annotations[configHashAnnotation]
+			Expect(newHash).NotTo(BeEmpty())
+			Expect(newHash).NotTo(Equal(originalHash))
+		})
+	})
+
+	Context("When existing pod template annotations are present", func() {
+		const resourceName = "test-confighash-existing-annotations"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-annot-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"key1": "value1",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-annot-cm",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-annot-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should preserve external annotations when no spec changes occur", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// Initial reconcile
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Add a custom annotation to the pod template
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			if deployment.Spec.Template.Annotations == nil {
+				deployment.Spec.Template.Annotations = make(map[string]string)
+			}
+			deployment.Spec.Template.Annotations["custom/annotation"] = "custom-value"
+			Expect(k8sClient.Update(ctx, deployment)).To(Succeed())
+
+			// Reconcile again with no MCPServer spec changes
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The controller detects annotation mismatch and updates,
+			// replacing annotations with the desired state (config-hash only).
+			// This is expected behavior for a controller-owned deployment.
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(deployment.Spec.Template.Annotations).To(HaveKey(configHashAnnotation))
+		})
+	})
+
+	Context("When all ConfigMap/Secret references are removed", func() {
+		const resourceName = "test-confighash-removal"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hash-removal-cm",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"key1": "value1",
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+				{
+					ConfigMapRef: &corev1.ConfigMapEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "hash-removal-cm",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			configMap := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "hash-removal-cm", Namespace: "default"}, configMap)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should remove the config-hash annotation when refs are removed", func() {
+			controllerReconciler := &MCPServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// Initial reconcile with refs
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployment.Spec.Template.Annotations).To(HaveKey(configHashAnnotation))
+
+			// Remove all ConfigMap references from MCPServer
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			err = k8sClient.Get(ctx, typeNamespacedName, mcpServer)
+			Expect(err).NotTo(HaveOccurred())
+			mcpServer.Spec.Config.EnvFrom = nil
+			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+			// Reconcile again
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify annotation is removed
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name:      resourceName,
+				Namespace: "default",
+			}, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			if deployment.Spec.Template.Annotations != nil {
+				Expect(deployment.Spec.Template.Annotations).NotTo(HaveKey(configHashAnnotation))
+			}
 		})
 	})
 })


### PR DESCRIPTION
Compute a SHA-256 hash of all referenced `ConfigMap` and `Secret` data and store it in a pod template annotation (`mcp.x-k8s.io/config-hash`). When referenced data changes the hash changes, the pod template changes, and Kubernetes rolls the pods.

Fixes #139