### PR TITLE
feat: default Service SessionAffinity to ClientIP for stateful MCP sessions

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -964,11 +964,14 @@ func (r *MCPServerReconciler) reconcileService(
 		ownershipChanged = oldOwnerUID != string(newOwner.UID)
 	}
 
-	// Update if ports changed OR if we adopted an orphaned resource
-	needsUpdate := !equality.Semantic.DeepEqual(service.Spec.Ports, existingService.Spec.Ports) || ownershipChanged
+	// Update if ports or session affinity changed, or if we adopted an orphaned resource
+	needsUpdate := !equality.Semantic.DeepEqual(service.Spec.Ports, existingService.Spec.Ports) ||
+		existingService.Spec.SessionAffinity != service.Spec.SessionAffinity ||
+		ownershipChanged
 	if needsUpdate {
 		logger.Info("Updating Service", "name", existingService.Name)
 		existingService.Spec.Ports = service.Spec.Ports
+		existingService.Spec.SessionAffinity = service.Spec.SessionAffinity
 		if err := r.Update(ctx, existingService); err != nil {
 			logger.Error(err, "Failed to update Service")
 			return err
@@ -998,6 +1001,7 @@ func (r *MCPServerReconciler) createService(mcpServer *mcpv1alpha1.MCPServer) *c
 			Selector: map[string]string{
 				"mcp-server": mcpServer.Name,
 			},
+			SessionAffinity: corev1.ServiceAffinityClientIP,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "mcp",

--- a/internal/controller/mcpserver_controller_service_test.go
+++ b/internal/controller/mcpserver_controller_service_test.go
@@ -250,6 +250,7 @@ var _ = Describe("MCPServer Controller - reconcileService", func() {
 		}, svc)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svc.Name).To(Equal(resourceName))
+		Expect(svc.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityClientIP))
 	})
 
 	It("should not error when service already exists", func() {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/143

Adding simplified "session affinity" 