### PR TITLE
fix: correct Service label-removal and clean up extra metadata helpers

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverspec.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverspec.go
@@ -23,11 +23,10 @@ package v1alpha1
 //
 // MCPServerSpec defines the desired state of MCPServer.
 type MCPServerSpecApplyConfiguration struct {
-	// ExtraLabels provides end users a mechanism to add labels to the MCPServer object child resources.
-	// The labels should be appended to the existing labels
+	// ExtraLabels are applied to the Deployment metadata, PodTemplate metadata, and Service metadata.
+	// The operator-managed keys "app" and "mcp-server" cannot be overridden.
 	ExtraLabels map[string]string `json:"extraLabels,omitempty"`
-	// ExtraAnnotations provides end users a mechanism to add annotations to the MCPServer object child resources.
-	// The annotations would be appended to the existing annotations on the child resources
+	// ExtraAnnotations are applied to the Deployment metadata, PodTemplate metadata, and Service metadata.
 	ExtraAnnotations map[string]string `json:"extraAnnotations,omitempty"`
 	// Source is a required field that defines where the MCP server should be sourced from.
 	// Currently supports container images, with potential for additional source types in the future.

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -332,12 +332,11 @@ type RuntimeConfig struct {
 
 // MCPServerSpec defines the desired state of MCPServer.
 type MCPServerSpec struct {
-	// ExtraLabels provides end users a mechanism to add labels to the MCPServer object child resources.
-	// The labels should be appended to the existing labels
+	// ExtraLabels are applied to the Deployment metadata, PodTemplate metadata, and Service metadata.
+	// The operator-managed keys "app" and "mcp-server" cannot be overridden.
 	// +optional
 	ExtraLabels map[string]string `json:"extraLabels,omitempty"`
-	// ExtraAnnotations provides end users a mechanism to add annotations to the MCPServer object child resources.
-	// The annotations would be appended to the existing annotations on the child resources
+	// ExtraAnnotations are applied to the Deployment metadata, PodTemplate metadata, and Service metadata.
 	// +optional
 	ExtraAnnotations map[string]string `json:"extraAnnotations,omitempty"`
 	// Source is a required field that defines where the MCP server should be sourced from.

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -582,16 +582,15 @@ spec:
               extraAnnotations:
                 additionalProperties:
                   type: string
-                description: |-
-                  ExtraAnnotations provides end users a mechanism to add annotations to the MCPServer object child resources.
-                  The annotations would be appended to the existing annotations on the child resources
+                description: ExtraAnnotations are applied to the Deployment metadata,
+                  PodTemplate metadata, and Service metadata.
                 type: object
               extraLabels:
                 additionalProperties:
                   type: string
-                description: |-
-                  ExtraLabels provides end users a mechanism to add labels to the MCPServer object child resources.
-                  The labels should be appended to the existing labels
+                description: ExtraLabels are applied to the Deployment metadata, PodTemplate
+                  metadata, and Service metadata. The operator-managed keys "app"
+                  and "mcp-server" cannot be overridden.
                 type: object
               runtime:
                 description: |-

--- a/internal/controller/custom_metadata.go
+++ b/internal/controller/custom_metadata.go
@@ -13,6 +13,27 @@ import (
 
 var ErrNilMap = errors.New("destination map not initialized")
 
+const jsonNull = "null"
+
+var reservedLabelKeys = map[string]bool{
+	"app":        true,
+	"mcp-server": true,
+}
+
+func filterReservedKeys(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return m
+	}
+	filtered := make(map[string]string, len(m))
+	for k, v := range m {
+		if reservedLabelKeys[k] {
+			continue
+		}
+		filtered[k] = v
+	}
+	return filtered
+}
+
 // mergeMaps is a custom function aimed at merging maps
 // It will merge maps with exception of attempts to override
 // application defined map keys
@@ -20,22 +41,12 @@ func mergeMaps(dst, src map[string]string) error {
 	if dst == nil {
 		return ErrNilMap
 	}
-	// if no custom map is provided,
-	// not further processing is needed
 	if len(src) == 0 {
 		return nil
 	}
 
-	// copy source to destination map
-	// if destination map is empty
-	if len(dst) == 0 && len(src) > 0 {
-		maps.Copy(dst, src)
-		return nil
-	}
-
 	for k, v := range src {
-		// prevent overriding known application labels
-		if k == "app" || k == "mcp-server" {
+		if reservedLabelKeys[k] {
 			continue
 		}
 
@@ -52,7 +63,9 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		}
 	}
 
-	if !maps.Equal(mcpServer.Spec.ExtraLabels, currentLabels) {
+	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
+
+	if !maps.Equal(effectiveLabels, currentLabels) {
 		for key := range currentLabels {
 			delete(deployment.Labels, key)
 			delete(deployment.Spec.Template.Labels, key)
@@ -75,15 +88,14 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		delete(deployment.Annotations, managedExtraAnnotations)
 	}
 
-	if len(mcpServer.Spec.ExtraLabels) == 0 &&
+	if len(effectiveLabels) == 0 &&
 		len(mcpServer.Spec.ExtraAnnotations) == 0 &&
 		len(currentLabels) == 0 &&
 		len(currentAnnotations) == 0 {
 		return nil
 	}
 
-	// apply extra labels to deployment if supplied
-	if mcpServer.Spec.ExtraLabels != nil {
+	if len(effectiveLabels) > 0 {
 		if deployment.Labels == nil {
 			deployment.Labels = make(map[string]string)
 		}
@@ -129,20 +141,20 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		deployment.Annotations = make(map[string]string)
 	}
 
-	extraLabelsByte, err := json.Marshal(mcpServer.Spec.ExtraLabels)
+	extraLabelsByte, err := json.Marshal(effectiveLabels)
 	if err != nil {
 		return fmt.Errorf("marshaling .spec.extraLabels failed; %w", err)
 	}
-	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != "null" {
-		deployment.Annotations[managedExtraLabels] = fmt.Sprintf("%s", extraLabelsByte)
+	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != jsonNull {
+		deployment.Annotations[managedExtraLabels] = string(extraLabelsByte)
 	}
 
 	extraAnnotationsByte, err := json.Marshal(mcpServer.Spec.ExtraAnnotations)
 	if err != nil {
 		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
 	}
-	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != "null" {
-		deployment.Annotations[managedExtraAnnotations] = fmt.Sprintf("%s", extraAnnotationsByte)
+	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != jsonNull {
+		deployment.Annotations[managedExtraAnnotations] = string(extraAnnotationsByte)
 	}
 
 	return nil
@@ -150,7 +162,15 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 
 func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Service) error {
 	currentLabels := make(map[string]string)
-	if !maps.Equal(mcpServer.Spec.ExtraLabels, currentLabels) {
+	if managedLabels, ok := service.Annotations[managedExtraLabels]; ok {
+		if err := json.Unmarshal([]byte(managedLabels), &currentLabels); err != nil {
+			return fmt.Errorf("retrieving current custom labels failed; %w", err)
+		}
+	}
+
+	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
+
+	if !maps.Equal(effectiveLabels, currentLabels) {
 		for key := range currentLabels {
 			delete(service.Labels, key)
 		}
@@ -171,7 +191,7 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 		delete(service.Annotations, managedExtraAnnotations)
 	}
 
-	if len(mcpServer.Spec.ExtraLabels) == 0 &&
+	if len(effectiveLabels) == 0 &&
 		len(mcpServer.Spec.ExtraAnnotations) == 0 &&
 		len(currentLabels) == 0 &&
 		len(currentAnnotations) == 0 {
@@ -186,7 +206,7 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 		service.Annotations = make(map[string]string)
 	}
 
-	if mcpServer.Spec.ExtraLabels != nil {
+	if len(effectiveLabels) > 0 {
 		if err := mergeMaps(service.Labels, mcpServer.Spec.ExtraLabels); err != nil {
 			return fmt.Errorf("appending service labels failed; %w", err)
 		}
@@ -198,26 +218,28 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 		}
 	}
 
-	extraLabelsByte, err := json.Marshal(mcpServer.Spec.ExtraLabels)
+	extraLabelsByte, err := json.Marshal(effectiveLabels)
 	if err != nil {
 		return fmt.Errorf("marshaling .spec.extraLabels failed; %w", err)
 	}
-	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != "null" {
-		service.Annotations[managedExtraLabels] = fmt.Sprintf("%s", extraLabelsByte)
+	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != jsonNull {
+		service.Annotations[managedExtraLabels] = string(extraLabelsByte)
 	}
 
 	extraAnnotationsByte, err := json.Marshal(mcpServer.Spec.ExtraAnnotations)
 	if err != nil {
 		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
 	}
-	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != "null" {
-		service.Annotations[managedExtraAnnotations] = fmt.Sprintf("%s", extraAnnotationsByte)
+	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != jsonNull {
+		service.Annotations[managedExtraAnnotations] = string(extraAnnotationsByte)
 	}
 
 	return nil
 }
 
 func deploymentLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv1.Deployment) bool {
+	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
+
 	var currentLabels map[string]string
 	vals, ok := deployment.Annotations[managedExtraLabels]
 	if ok {
@@ -226,12 +248,12 @@ func deploymentLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv
 		}
 
 		if len(currentLabels) > 0 {
-			if len(mcpServer.Spec.ExtraLabels) != 0 &&
-				!maps.Equal(currentLabels, mcpServer.Spec.ExtraLabels) {
+			if len(effectiveLabels) != 0 &&
+				!maps.Equal(currentLabels, effectiveLabels) {
 				return true
 			}
 
-			if len(mcpServer.Spec.ExtraLabels) == 0 {
+			if len(effectiveLabels) == 0 {
 				return true
 			}
 
@@ -248,7 +270,7 @@ func deploymentLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv
 	}
 
 	if len(currentLabels) == 0 &&
-		len(mcpServer.Spec.ExtraLabels) != 0 {
+		len(effectiveLabels) != 0 {
 		return true
 	}
 
@@ -273,7 +295,7 @@ func deploymentAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *
 				return true
 			}
 
-			// check if current annoations and .spec.ExtraAnnotations match
+			// check if current annotations and .spec.ExtraAnnotations match
 			for k := range currentAnnotations {
 				if _, ok := deployment.Annotations[k]; !ok {
 					return true
@@ -294,6 +316,8 @@ func deploymentAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *
 }
 
 func serviceLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Service) bool {
+	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
+
 	var currentLabels map[string]string
 	vals, ok := service.Annotations[managedExtraLabels]
 	if ok {
@@ -302,12 +326,12 @@ func serviceLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Serv
 		}
 
 		if len(currentLabels) > 0 {
-			if len(mcpServer.Spec.ExtraLabels) != 0 &&
-				!maps.Equal(currentLabels, mcpServer.Spec.ExtraLabels) {
+			if len(effectiveLabels) != 0 &&
+				!maps.Equal(currentLabels, effectiveLabels) {
 				return true
 			}
 
-			if len(mcpServer.Spec.ExtraLabels) == 0 {
+			if len(effectiveLabels) == 0 {
 				return true
 			}
 
@@ -318,11 +342,10 @@ func serviceLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Serv
 				}
 			}
 		}
-
 	}
 
 	if len(currentLabels) == 0 &&
-		len(mcpServer.Spec.ExtraLabels) != 0 {
+		len(effectiveLabels) != 0 {
 		return true
 	}
 
@@ -347,7 +370,7 @@ func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1
 				return true
 			}
 
-			// check if current labels and .spec.ExtraAnnotations match
+			// check if current annotations and .spec.ExtraAnnotations match
 			for k := range currentAnnotations {
 				if _, ok := service.Annotations[k]; !ok {
 					return true

--- a/internal/controller/custom_metadata_test.go
+++ b/internal/controller/custom_metadata_test.go
@@ -131,7 +131,6 @@ func Test_mergeMaps(t *testing.T) {
 			},
 			want: want{
 				m: map[string]string{
-					"app": "web",
 					"env": "production",
 				},
 				wantErr: false,
@@ -441,7 +440,9 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			applyCustomDeploymentMetadata(tc.args.mcp, tc.args.deployment)
+			if err := applyCustomDeploymentMetadata(tc.args.mcp, tc.args.deployment); err != nil {
+				t.Fatalf("applyCustomDeploymentMetadata returned unexpected error: %v", err)
+			}
 			if !maps.Equal(tc.args.deployment.Labels, tc.want.Labels) {
 				t.Errorf("wanted deployment labels to be %v but got, %v",
 					tc.want.Labels,
@@ -531,6 +532,100 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "remove all custom labels on service",
+			args: extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app":                      "webserver",
+							"kubernetes.io/managed-by": "mcp-lifecycle-operator",
+						},
+						Annotations: map[string]string{
+							"mcp.x-k8s.io/managed-extra-labels": "{\"kubernetes.io/managed-by\":\"mcp-lifecycle-operator\"}",
+						},
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "webserver",
+					},
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name: "remove some custom labels on service",
+			args: extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraLabels: map[string]string{
+							"department": "procurement",
+						},
+					},
+				},
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app":                      "webserver",
+							"department":               "procurement",
+							"kubernetes.io/managed-by": "mcp-lifecycle-operator",
+						},
+						Annotations: map[string]string{
+							"mcp.x-k8s.io/managed-extra-labels": "{\"kubernetes.io/managed-by\":\"mcp-lifecycle-operator\",\"department\":\"procurement\"}",
+						},
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":        "webserver",
+						"department": "procurement",
+					},
+					Annotations: map[string]string{
+						"mcp.x-k8s.io/managed-extra-labels": "{\"department\":\"procurement\"}",
+					},
+				},
+			},
+		},
+		{
+			name: "reserved keys in spec are not tracked or removed",
+			args: extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraLabels: map[string]string{
+							"app":        "should-be-ignored",
+							"mcp-server": "should-be-ignored",
+							"env":        "production",
+						},
+					},
+				},
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "webserver",
+						},
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "webserver",
+						"env": "production",
+					},
+					Annotations: map[string]string{
+						"mcp.x-k8s.io/managed-extra-labels": "{\"env\":\"production\"}",
+					},
+				},
+			},
+		},
+		{
 			name: "render service with extra annotations",
 			args: extraMetaArgs{
 				mcp: &mcpv1alpha1.MCPServer{
@@ -564,7 +659,9 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			applyCustomServiceMetadata(tc.args.mcp, tc.args.service)
+			if err := applyCustomServiceMetadata(tc.args.mcp, tc.args.service); err != nil {
+				t.Fatalf("applyCustomServiceMetadata returned unexpected error: %v", err)
+			}
 			if !maps.Equal(tc.want.Labels, tc.args.service.Labels) {
 				t.Errorf("wanted service labels to be %v but got, %v",
 					tc.want.Labels,

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -762,33 +762,9 @@ func (r *MCPServerReconciler) reconcileDeployment(
 		ownershipChanged = oldOwnerUID != string(newOwner.UID)
 	}
 
-	oldPodSpec := existingDeployment.Spec.Template.Spec
-	newPodSpec := deployment.Spec.Template.Spec
-
-	var needsUpdate bool
-	if len(oldPodSpec.Containers) == 0 {
+	needsUpdate := deploymentNeedsUpdate(mcpServer, existingDeployment, deployment, ownershipChanged)
+	if needsUpdate && len(existingDeployment.Spec.Template.Spec.Containers) == 0 {
 		logger.Info("Recovering deployment with empty containers list", "name", existingDeployment.Name)
-		needsUpdate = true
-	} else {
-		needsUpdate = !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec) ||
-			// Explicit DeepEqual checks for fields that can be zeroed/removed by the user.
-			// DeepDerivative skips zero-value fields in the desired spec, so removals
-			// (clearing args, env, volumes, etc.) would go undetected without these.
-			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Args, newPodSpec.Containers[0].Args) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Env, newPodSpec.Containers[0].Env) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].EnvFrom, newPodSpec.Containers[0].EnvFrom) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.SecurityContext, newPodSpec.SecurityContext) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.Volumes, newPodSpec.Volumes) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].VolumeMounts, newPodSpec.Containers[0].VolumeMounts) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Resources, newPodSpec.Containers[0].Resources) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].LivenessProbe, newPodSpec.Containers[0].LivenessProbe) ||
-			!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].ReadinessProbe, newPodSpec.Containers[0].ReadinessProbe) ||
-			oldPodSpec.ServiceAccountName != newPodSpec.ServiceAccountName ||
-			!equality.Semantic.DeepEqual(existingDeployment.Spec.Replicas, deployment.Spec.Replicas) ||
-			!equality.Semantic.DeepEqual(existingDeployment.Spec.Template.Annotations, deployment.Spec.Template.Annotations) ||
-			deploymentAnnotationsChanged(mcpServer, existingDeployment) ||
-			deploymentLabelsChanged(mcpServer, existingDeployment) ||
-			ownershipChanged
 	}
 	if needsUpdate {
 		logger.Info("Updating Deployment", "name", existingDeployment.Name)
@@ -814,6 +790,35 @@ func (r *MCPServerReconciler) reconcileDeployment(
 	}
 
 	return existingDeployment, nil
+}
+
+func deploymentNeedsUpdate(mcpServer *mcpv1alpha1.MCPServer, existing, desired *appsv1.Deployment, ownershipChanged bool) bool {
+	oldPodSpec := existing.Spec.Template.Spec
+	newPodSpec := desired.Spec.Template.Spec
+
+	if len(oldPodSpec.Containers) == 0 {
+		return true
+	}
+
+	return !equality.Semantic.DeepDerivative(newPodSpec, oldPodSpec) ||
+		// Explicit DeepEqual checks for fields that can be zeroed/removed by the user.
+		// DeepDerivative skips zero-value fields in the desired spec, so removals
+		// (clearing args, env, volumes, etc.) would go undetected without these.
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Args, newPodSpec.Containers[0].Args) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Env, newPodSpec.Containers[0].Env) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].EnvFrom, newPodSpec.Containers[0].EnvFrom) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.SecurityContext, newPodSpec.SecurityContext) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Volumes, newPodSpec.Volumes) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].VolumeMounts, newPodSpec.Containers[0].VolumeMounts) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].Resources, newPodSpec.Containers[0].Resources) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].LivenessProbe, newPodSpec.Containers[0].LivenessProbe) ||
+		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].ReadinessProbe, newPodSpec.Containers[0].ReadinessProbe) ||
+		oldPodSpec.ServiceAccountName != newPodSpec.ServiceAccountName ||
+		!equality.Semantic.DeepEqual(existing.Spec.Replicas, desired.Spec.Replicas) ||
+		!equality.Semantic.DeepEqual(existing.Spec.Template.Annotations, desired.Spec.Template.Annotations) ||
+		deploymentAnnotationsChanged(mcpServer, existing) ||
+		deploymentLabelsChanged(mcpServer, existing) ||
+		ownershipChanged
 }
 
 // createDeployment creates a Deployment for the MCPServer


### PR DESCRIPTION
Fix applyCustomServiceMetadata not reading managed labels from the tracking annotation, causing label removals to silently fail on Services. Also remove dead branch in mergeMaps that bypassed the reserved-key check, replace fmt.Sprintf with string conversion, fix typo, and clarify API field documentation.

this is a follow up on https://github.com/kubernetes-sigs/mcp-lifecycle-operator/pull/79