### PR TITLE
deps: bump go to 1.26.2 to fix govulncheck errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.1/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
 
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.0


### PR DESCRIPTION
This PR fixes the failing govulncheck action by bumping the go version.