### PR TITLE
ci: fix lint issues on go 1.26

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: v2.7.2
+          version: v2.10.1

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -37,7 +37,7 @@ var (
 	SchemeGroupVersion = GroupVersion
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion} //nolint:staticcheck // TODO: migrate to runtime.SchemeBuilder
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -588,9 +588,9 @@ spec:
               extraLabels:
                 additionalProperties:
                   type: string
-                description: ExtraLabels are applied to the Deployment metadata, PodTemplate
-                  metadata, and Service metadata. The operator-managed keys "app"
-                  and "mcp-server" cannot be overridden.
+                description: |-
+                  ExtraLabels are applied to the Deployment metadata, PodTemplate metadata, and Service metadata.
+                  The operator-managed keys "app" and "mcp-server" cannot be overridden.
                 type: object
               runtime:
                 description: |-
@@ -1320,7 +1320,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -970,7 +970,7 @@ func (r *MCPServerReconciler) processStorageMounts(
 			volumeMount.ReadOnly = false
 		case mcpv1alpha1.MountPermissionsRecursiveReadOnly:
 			volumeMount.ReadOnly = true
-			volumeMount.RecursiveReadOnly = ptr.To(corev1.RecursiveReadOnlyEnabled)
+			volumeMount.RecursiveReadOnly = new(corev1.RecursiveReadOnlyEnabled)
 		}
 
 		volumeMounts = append(volumeMounts, volumeMount)
@@ -1279,9 +1279,9 @@ func preserveLastTransitionTime(condition *metav1.Condition, existingConditions 
 // security context applied to MCP server containers by default.
 func defaultContainerSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
-		AllowPrivilegeEscalation: ptr.To(false),
-		ReadOnlyRootFilesystem:   ptr.To(true),
-		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: new(false),
+		ReadOnlyRootFilesystem:   new(true),
+		RunAsNonRoot:             new(true),
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 	}

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -109,7 +108,7 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 						Kind:       "MCPServer",
 						Name:       "test-empty-containers",
 						UID:        "fake-uid",
-						Controller: ptr.To(true),
+						Controller: new(true),
 					},
 				},
 			},

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -232,7 +231,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 		By("Setting replicas to 0")
 		mcpServer := &mcpv1alpha1.MCPServer{}
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-		mcpServer.Spec.Runtime.Replicas = ptr.To(int32(0))
+		mcpServer.Spec.Runtime.Replicas = new(int32(0))
 		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
 		By("Initial reconciliation creates deployment")

--- a/internal/controller/mcpserver_controller_ownership_test.go
+++ b/internal/controller/mcpserver_controller_ownership_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -187,7 +186,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 							Kind:       "SomeOtherController",
 							Name:       "foreign-owner",
 							UID:        types.UID("foreign-controller-uid"),
-							Controller: ptr.To(true),
+							Controller: new(true),
 						},
 					},
 				},
@@ -275,7 +274,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 							Kind:       "SomeOtherController",
 							Name:       "foreign-svc-owner",
 							UID:        types.UID("foreign-svc-controller-uid"),
-							Controller: ptr.To(true),
+							Controller: new(true),
 						},
 					},
 				},
@@ -520,14 +519,14 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 							Kind:       "MCPServer",
 							Name:       "some-other-server",
 							UID:        types.UID("other-mcpserver-uid"),
-							Controller: ptr.To(false), // Not a controller
+							Controller: new(false), // Not a controller
 						},
 						{
 							APIVersion: "apps/v1",
 							Kind:       "ReplicaSet",
 							Name:       "some-replicaset",
 							UID:        types.UID("replicaset-uid"),
-							Controller: ptr.To(false), // Also not a controller
+							Controller: new(false), // Also not a controller
 						},
 					},
 				},
@@ -628,14 +627,14 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 							Kind:       "MCPServer",
 							Name:       "some-other-server",
 							UID:        types.UID("other-mcpserver-uid"),
-							Controller: ptr.To(false), // Not a controller
+							Controller: new(false), // Not a controller
 						},
 						{
 							APIVersion: "v1",
 							Kind:       "ConfigMap",
 							Name:       "some-config",
 							UID:        types.UID("config-uid"),
-							Controller: ptr.To(false), // Also not a controller
+							Controller: new(false), // Also not a controller
 						},
 					},
 				},

--- a/internal/controller/mcpserver_controller_service_test.go
+++ b/internal/controller/mcpserver_controller_service_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -58,7 +57,7 @@ var _ = Describe("MCPServer Controller - Address URL", func() {
 
 		It("should set the address URL with default path after reconciliation", func() {
 			resource := newTestMCPServer(resourceName)
-			resource.Spec.Runtime.Replicas = ptr.To(int32(1))
+			resource.Spec.Runtime.Replicas = new(int32(1))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{
@@ -118,7 +117,7 @@ var _ = Describe("MCPServer Controller - Address URL", func() {
 
 		It("should persist the address URL across reconciliations", func() {
 			resource := newTestMCPServer(resourceName)
-			resource.Spec.Runtime.Replicas = ptr.To(int32(1))
+			resource.Spec.Runtime.Replicas = new(int32(1))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{

--- a/internal/controller/mcpserver_controller_storage_test.go
+++ b/internal/controller/mcpserver_controller_storage_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -789,7 +788,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "optional-configmap",
 							},
-							Optional: ptr.To(true),
+							Optional: new(true),
 						},
 					},
 				},
@@ -852,7 +851,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 						Type: mcpv1alpha1.StorageTypeSecret,
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: "optional-secret",
-							Optional:   ptr.To(true),
+							Optional:   new(true),
 						},
 					},
 				},

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -553,7 +552,7 @@ var _ = Describe("MCPServer Controller", func() {
 
 		It("should set replicas on deployment when specified", func() {
 			resource := newTestMCPServer(resourceName)
-			resource.Spec.Runtime.Replicas = ptr.To(int32(3))
+			resource.Spec.Runtime.Replicas = new(int32(3))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
@@ -593,7 +592,7 @@ var _ = Describe("MCPServer Controller", func() {
 
 		It("should allow 0 replicas for scale-to-zero", func() {
 			resource := newTestMCPServer(resourceName)
-			resource.Spec.Runtime.Replicas = ptr.To(int32(0))
+			resource.Spec.Runtime.Replicas = new(int32(0))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
@@ -613,7 +612,7 @@ var _ = Describe("MCPServer Controller", func() {
 
 		It("should update deployment when replicas changes", func() {
 			resource := newTestMCPServer(resourceName)
-			resource.Spec.Runtime.Replicas = ptr.To(int32(2))
+			resource.Spec.Runtime.Replicas = new(int32(2))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
@@ -635,7 +634,7 @@ var _ = Describe("MCPServer Controller", func() {
 			By("Updating replicas to 5")
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
-			mcpServer.Spec.Runtime.Replicas = ptr.To(int32(5))
+			mcpServer.Spec.Runtime.Replicas = new(int32(5))
 			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
 			By("Reconciling again to pick up the change")
@@ -654,7 +653,7 @@ var _ = Describe("MCPServer Controller", func() {
 
 		It("should update deployment when replicas is removed", func() {
 			resource := newTestMCPServer(resourceName)
-			resource.Spec.Runtime.Replicas = ptr.To(int32(3))
+			resource.Spec.Runtime.Replicas = new(int32(3))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
@@ -695,7 +694,7 @@ var _ = Describe("MCPServer Controller", func() {
 
 		It("should correctly handle MCPServer status after spec update", func() {
 			resource := newTestMCPServer(resourceName)
-			resource.Spec.Runtime.Replicas = ptr.To(int32(1))
+			resource.Spec.Runtime.Replicas = new(int32(1))
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
@@ -743,7 +742,7 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
 
 			By("Updating replicas to 3")
-			mcpServer.Spec.Runtime.Replicas = ptr.To(int32(3))
+			mcpServer.Spec.Runtime.Replicas = new(int32(3))
 			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
 
 			By("Reconciling after spec update")


### PR DESCRIPTION
This fixes failing lint by:
1. bumping golangci-lint to a version that supports g0 1.26
2. Fixes the surfaced lint errors