### PR TITLE
feat: improve status conditions to report pod status on failures

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -107,6 +107,19 @@ const (
 	ReasonMCPEndpointUnavailable = "MCPEndpointUnavailable"
 )
 
+// Container waiting reasons from Kubernetes pod status.
+const (
+	WaitingReasonImagePullBackOff           = "ImagePullBackOff"
+	WaitingReasonErrImagePull               = "ErrImagePull"
+	WaitingReasonCrashLoopBackOff           = "CrashLoopBackOff"
+	WaitingReasonCreateContainerConfigError = "CreateContainerConfigError"
+)
+
+// Container terminated reasons from Kubernetes pod status.
+const (
+	TerminatedReasonOOMKilled = "OOMKilled"
+)
+
 // Reconciliation constants.
 const (
 	// requeueDelayDeploymentUnavailable is the delay before requeuing when a deployment is not yet available.
@@ -164,6 +177,7 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
@@ -304,7 +318,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Determine Ready condition based on deployment status
 	reconcileDuration.With(prometheus.Labels{"phase": "service"}).Observe(time.Since(serviceStart).Seconds())
 
-	readyCondition := determineReadyCondition(
+	readyCondition := r.reconcileReadyCondition(
+		ctx,
 		existingDeployment,
 		acceptedCondition,
 		mcpServer.Generation,
@@ -559,140 +574,199 @@ func isHTTPAuthError(err error) bool {
 		strings.HasSuffix(msg, ": "+http.StatusText(http.StatusForbidden))
 }
 
-// determineReadyCondition analyzes deployment status and accepted condition to determine
-// the Ready condition.
-func determineReadyCondition(
+// deploymentState summarises the health signals from a Deployment's status conditions.
+type deploymentState struct {
+	available      bool
+	progressing    bool
+	replicaFailure bool
+	message        string // most relevant message from unhealthy conditions
+}
+
+// extractDeploymentState reads the standard Deployment condition types and
+// returns a compact summary used by reconcileReadyCondition.
+func extractDeploymentState(deployment *appsv1.Deployment) deploymentState {
+	var state deploymentState
+	var progressingMessage string
+	var availableMessage string
+	for _, cond := range deployment.Status.Conditions {
+		switch cond.Type {
+		case appsv1.DeploymentAvailable:
+			state.available = cond.Status == corev1.ConditionTrue
+			if cond.Status == corev1.ConditionFalse {
+				availableMessage = cond.Message
+			}
+		case appsv1.DeploymentProgressing:
+			state.progressing = cond.Status == corev1.ConditionTrue
+			if cond.Status == corev1.ConditionFalse {
+				progressingMessage = cond.Message
+			}
+		case appsv1.DeploymentReplicaFailure:
+			if cond.Status == corev1.ConditionTrue {
+				state.replicaFailure = true
+				if cond.Message != "" {
+					state.message = cond.Message
+				}
+			}
+		}
+	}
+
+	// Prefer ReplicaFailure message; fall back to Progressing, then Available.
+	if state.message == "" {
+		state.message = progressingMessage
+	}
+	if state.message == "" {
+		state.message = availableMessage
+	}
+
+	return state
+}
+
+// analyzePodFailures inspects pod container statuses to build a human-readable
+// message describing why pods are unhealthy. Returns "" if no specific failure
+// can be identified. Only the first failure across all pods is returned to keep
+// the status condition message concise.
+func analyzePodFailures(pods []corev1.Pod) string {
+	for _, pod := range pods {
+		for _, cs := range pod.Status.InitContainerStatuses {
+			if msg := analyzeContainerStatus(cs, pod.Name); msg != "" {
+				return msg
+			}
+		}
+
+		for _, cs := range pod.Status.ContainerStatuses {
+			if msg := analyzeContainerStatus(cs, pod.Name); msg != "" {
+				return msg
+			}
+		}
+	}
+
+	return ""
+}
+
+// analyzeContainerStatus checks a single container status for known failure
+// patterns and returns a human-readable message, or "" if none is found.
+func analyzeContainerStatus(cs corev1.ContainerStatus, podName string) string {
+	if w := cs.State.Waiting; w != nil {
+		switch w.Reason {
+		case WaitingReasonImagePullBackOff, WaitingReasonErrImagePull:
+			return fmt.Sprintf("Image pull failed for %q: %s (pod: %s)", cs.Image, w.Message, podName)
+		case WaitingReasonCrashLoopBackOff:
+			if t := cs.LastTerminationState.Terminated; t != nil {
+				return fmt.Sprintf("Container crashing: exit code %d, restarts: %d (pod: %s)",
+					t.ExitCode, cs.RestartCount, podName)
+			}
+			return fmt.Sprintf("Container crashing: restarts: %d (pod: %s)",
+				cs.RestartCount, podName)
+		case WaitingReasonCreateContainerConfigError:
+			return fmt.Sprintf("Container config error: %s (pod: %s)", w.Message, podName)
+		}
+	}
+	if t := cs.State.Terminated; t != nil {
+		if t.Reason == TerminatedReasonOOMKilled {
+			return fmt.Sprintf("Container OOMKilled: exit code %d, restarts: %d (pod: %s)",
+				t.ExitCode, cs.RestartCount, podName)
+		}
+	}
+	// Running but not ready with restarts indicates a probe failure.
+	// We require RestartCount > 0 to avoid false positives during initial startup
+	// when the readiness probe hasn't passed yet.
+	if cs.State.Running != nil && !cs.Ready && cs.RestartCount > 0 {
+		return fmt.Sprintf("Container not passing health checks: restarts: %d (pod: %s)",
+			cs.RestartCount, podName)
+	}
+	return ""
+}
+
+// reconcileReadyCondition determines the Ready condition for an MCPServer by
+// inspecting deployment status. When the deployment is in a failure state, it
+// fetches pods to surface specific error details (image pull failures, crash
+// loops, OOM, etc.) rather than showing generic deployment messages.
+func (r *MCPServerReconciler) reconcileReadyCondition(
+	ctx context.Context,
 	deployment *appsv1.Deployment,
 	acceptedCondition metav1.Condition,
 	generation int64,
 	existingConditions []metav1.Condition,
 ) metav1.Condition {
-	// If configuration is not accepted, Ready=False
 	if acceptedCondition.Status == metav1.ConditionFalse {
-		condition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionFalse,
-			ReasonConfigurationInvalid,
-			"Configuration must be fixed before server can start",
-			generation,
-		)
-		preserveLastTransitionTime(&condition, existingConditions)
-		return condition
+		return newReadyCondition(metav1.ConditionFalse, ReasonConfigurationInvalid,
+			"Configuration must be fixed before server can start", generation, existingConditions)
 	}
 
-	// Check if scaled to zero
-	// Note: Following Kubernetes Deployment semantics, we set Ready=True when scaled to 0.
 	// Scaling to zero is an intentional, valid desired state (not a failure).
-	// This prevents false alerts and aligns with core K8s resource conventions where
-	// conditions indicate "is the system in its desired state?" rather than "is it doing work?".
-	// Users can check the ScaledToZero reason or status.replicas for operational state.
 	if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas == 0 {
-		condition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionTrue,
-			ReasonScaledToZero,
-			"Server is ready (scaled to 0 replicas)",
-			generation,
-		)
-		preserveLastTransitionTime(&condition, existingConditions)
-		return condition
+		return newReadyCondition(metav1.ConditionTrue, ReasonScaledToZero,
+			"Server is ready (scaled to 0 replicas)", generation, existingConditions)
 	}
 
-	// Extract deployment conditions
-	deploymentAvailable := false
-	deploymentProgressing := false
-	deploymentReplicaFailure := false
-	var deploymentMessage string
+	if len(deployment.Status.Conditions) == 0 && deployment.Status.ReadyReplicas == 0 {
+		return newReadyCondition(metav1.ConditionUnknown, ReasonInitializing,
+			"Waiting for Deployment to report status", generation, existingConditions)
+	}
 
-	for _, cond := range deployment.Status.Conditions {
-		switch cond.Type {
-		case appsv1.DeploymentAvailable:
-			if cond.Status == corev1.ConditionTrue {
-				deploymentAvailable = true
-			}
-		case appsv1.DeploymentProgressing:
-			if cond.Status == corev1.ConditionTrue {
-				deploymentProgressing = true
-			}
-			if cond.Status == corev1.ConditionFalse {
-				deploymentMessage = cond.Message
-			}
-		case appsv1.DeploymentReplicaFailure:
-			if cond.Status == corev1.ConditionTrue {
-				deploymentReplicaFailure = true
-				deploymentMessage = cond.Message
+	state := extractDeploymentState(deployment)
+
+	if deployment.Status.ObservedGeneration > 0 && deployment.Status.ObservedGeneration < deployment.Generation {
+		return newReadyCondition(metav1.ConditionFalse, ReasonDeploymentUnavailable,
+			"Deployment is processing spec update", generation, existingConditions)
+	}
+
+	if state.available && deployment.Status.ReadyReplicas > 0 {
+		return newReadyCondition(metav1.ConditionTrue, ReasonAvailable,
+			fmt.Sprintf("MCP server is ready (%d of %d instances healthy)",
+				deployment.Status.ReadyReplicas, ptr.Deref(deployment.Spec.Replicas, 1)),
+			generation, existingConditions)
+	}
+
+	// Failure path — fetch pods for detailed diagnostics.
+	podFailureMessage := r.getPodFailureMessage(ctx, deployment)
+	if state.replicaFailure ||
+		(!state.progressing && !state.available) ||
+		(state.progressing && deployment.Status.ReadyReplicas == 0 && podFailureMessage != "") {
+		if podFailureMessage == "" {
+			podFailureMessage = "No healthy instances (pod details unavailable)"
+			if state.message != "" {
+				podFailureMessage = podFailureMessage + ": " + state.message
 			}
 		}
+
+		return newReadyCondition(metav1.ConditionFalse, ReasonDeploymentUnavailable,
+			podFailureMessage, generation, existingConditions)
 	}
 
-	// Deployment has no status yet
-	if len(deployment.Status.Conditions) == 0 && deployment.Status.ReadyReplicas == 0 {
-		condition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionUnknown,
-			ReasonInitializing,
-			"Waiting for Deployment to report status",
-			generation,
-		)
-		preserveLastTransitionTime(&condition, existingConditions)
-		return condition
+	return newReadyCondition(metav1.ConditionFalse, ReasonDeploymentUnavailable,
+		"Waiting for instances to become healthy", generation, existingConditions)
+}
+
+// getPodFailureMessage lists the pods for a deployment and returns a detailed
+// message from their container statuses. Returns "" when pod details are
+// unavailable or no known failure pattern is found.
+func (r *MCPServerReconciler) getPodFailureMessage(
+	ctx context.Context,
+	deployment *appsv1.Deployment,
+) string {
+	logger := log.FromContext(ctx)
+
+	if deployment.Spec.Selector == nil {
+		return ""
 	}
 
-	// Deployment hasn't processed the latest spec yet
-	// Only check if ObservedGeneration is non-zero (0 is the initial state)
-	if deployment.Status.ObservedGeneration > 0 && deployment.Status.ObservedGeneration < deployment.Generation {
-		condition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionFalse,
-			ReasonDeploymentUnavailable,
-			"Deployment is processing spec update",
-			generation,
-		)
-		preserveLastTransitionTime(&condition, existingConditions)
-		return condition
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		logger.Error(err, "Failed to parse deployment selector")
+		return ""
 	}
 
-	// At least one replica is ready - SUCCESS
-	if deploymentAvailable && deployment.Status.ReadyReplicas > 0 {
-		message := fmt.Sprintf("MCP server is ready (%d of %d instances healthy)",
-			deployment.Status.ReadyReplicas,
-			ptr.Deref(deployment.Spec.Replicas, 1))
-		condition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionTrue,
-			ReasonAvailable,
-			message,
-			generation,
-		)
-		preserveLastTransitionTime(&condition, existingConditions)
-		return condition
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList,
+		client.InNamespace(deployment.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		logger.Error(err, "Failed to list pods for deployment failure analysis")
+		return ""
 	}
 
-	// Deployment exists but no replicas ready - FAILURE
-	// This covers: ImagePullBackOff, CrashLoop, OOM, Security errors, Probe failures, etc.
-	if deploymentReplicaFailure || (!deploymentProgressing && !deploymentAvailable) {
-		message := analyzeDeploymentFailure(deploymentMessage)
-		condition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionFalse,
-			ReasonDeploymentUnavailable,
-			message,
-			generation,
-		)
-		preserveLastTransitionTime(&condition, existingConditions)
-		return condition
-	}
-
-	// Still progressing (no replicas ready yet)
-	condition := newCondition(
-		ConditionTypeReady,
-		metav1.ConditionFalse,
-		ReasonDeploymentUnavailable,
-		"Waiting for instances to become healthy",
-		generation,
-	)
-	preserveLastTransitionTime(&condition, existingConditions)
-	return condition
+	return analyzePodFailures(podList.Items)
 }
 
 // reconcileDeployment creates or updates the Deployment for the MCPServer
@@ -1327,35 +1401,18 @@ func newCondition(
 	}
 }
 
-// analyzeDeploymentFailure examines the deployment message to build a detailed message
-// about why pods are not healthy. Returns a message with specifics.
-func analyzeDeploymentFailure(deploymentMessage string) string {
-	if deploymentMessage == "" {
-		return "No healthy instances available"
-	}
-
-	// Extract the most relevant error information
-	msg := deploymentMessage
-
-	// Common patterns - extract the key info
-	if strings.Contains(msg, "ImagePullBackOff") || strings.Contains(msg, "ErrImagePull") {
-		return fmt.Sprintf("No healthy instances: ImagePullBackOff - %s", msg)
-	}
-	if strings.Contains(msg, "runAsNonRoot") || strings.Contains(msg, "CreateContainerConfigError") {
-		return fmt.Sprintf("No healthy instances: CreateContainerConfigError - %s", msg)
-	}
-	if strings.Contains(msg, "OOMKilled") {
-		return fmt.Sprintf("No healthy instances: OOMKilled - %s", msg)
-	}
-	if strings.Contains(msg, "CrashLoopBackOff") {
-		return fmt.Sprintf("No healthy instances: CrashLoopBackOff - %s", msg)
-	}
-	if strings.Contains(msg, "Liveness probe failed") || strings.Contains(msg, "Readiness probe failed") {
-		return fmt.Sprintf("No healthy instances: Probe failed - %s", msg)
-	}
-
-	// Generic failure
-	return fmt.Sprintf("No healthy instances: %s", msg)
+// newReadyCondition creates a Ready condition and preserves the LastTransitionTime
+// from existingConditions when the status has not changed.
+func newReadyCondition(
+	status metav1.ConditionStatus,
+	reason string,
+	message string,
+	generation int64,
+	existingConditions []metav1.Condition,
+) metav1.Condition {
+	c := newCondition(ConditionTypeReady, status, reason, message, generation)
+	preserveLastTransitionTime(&c, existingConditions)
+	return c
 }
 
 // classifyAPIError classifies a Kubernetes API error as either a permanent ValidationError

--- a/internal/controller/mcpserver_controller_conditions_test.go
+++ b/internal/controller/mcpserver_controller_conditions_test.go
@@ -28,24 +28,358 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("determineReadyCondition", func() {
+var _ = Describe("extractDeploymentState", func() {
+	It("should extract available condition", func() {
+		deployment := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		state := extractDeploymentState(deployment)
+		Expect(state.available).To(BeTrue())
+		Expect(state.progressing).To(BeFalse())
+		Expect(state.replicaFailure).To(BeFalse())
+	})
+
+	It("should extract progressing condition", func() {
+		deployment := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		state := extractDeploymentState(deployment)
+		Expect(state.progressing).To(BeTrue())
+	})
+
+	It("should capture message from failed progressing condition", func() {
+		deployment := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse, Message: "timed out"},
+				},
+			},
+		}
+		state := extractDeploymentState(deployment)
+		Expect(state.progressing).To(BeFalse())
+		Expect(state.message).To(Equal("timed out"))
+	})
+
+	It("should extract replica failure with message", func() {
+		deployment := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionTrue, Message: "quota exceeded"},
+				},
+			},
+		}
+		state := extractDeploymentState(deployment)
+		Expect(state.replicaFailure).To(BeTrue())
+		Expect(state.message).To(Equal("quota exceeded"))
+	})
+
+	It("should prefer ReplicaFailure message over Progressing message", func() {
+		deployment := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse, Message: "timed out"},
+					{Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionTrue, Message: "quota exceeded"},
+				},
+			},
+		}
+		state := extractDeploymentState(deployment)
+		Expect(state.replicaFailure).To(BeTrue())
+		Expect(state.message).To(Equal("quota exceeded"))
+	})
+
+	It("should keep Progressing message when ReplicaFailure message is empty", func() {
+		deployment := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse, Message: "timed out"},
+					{Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionTrue, Message: ""},
+				},
+			},
+		}
+		state := extractDeploymentState(deployment)
+		Expect(state.replicaFailure).To(BeTrue())
+		Expect(state.message).To(Equal("timed out"))
+	})
+
+	It("should return zero state for empty conditions", func() {
+		deployment := &appsv1.Deployment{}
+		state := extractDeploymentState(deployment)
+		Expect(state.available).To(BeFalse())
+		Expect(state.progressing).To(BeFalse())
+		Expect(state.replicaFailure).To(BeFalse())
+		Expect(state.message).To(BeEmpty())
+	})
+})
+
+var _ = Describe("analyzePodFailures", func() {
+	It("should detect ImagePullBackOff", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  WaitingReasonImagePullBackOff,
+							Message: "Back-off pulling image \"ghcr.io/user/image:tag\"",
+						},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("Image pull failed"))
+		Expect(result).To(ContainSubstring("ghcr.io/user/image:tag"))
+		Expect(result).To(ContainSubstring("my-pod-abc123"))
+	})
+
+	It("should detect ErrImagePull", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  WaitingReasonErrImagePull,
+							Message: "manifest unknown",
+						},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("Image pull failed"))
+		Expect(result).To(ContainSubstring("my-pod-abc123"))
+	})
+
+	It("should detect CrashLoopBackOff with exit code from last termination", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					RestartCount: 5,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: WaitingReasonCrashLoopBackOff,
+						},
+					},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+						},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("Container crashing"))
+		Expect(result).To(ContainSubstring("exit code 1"))
+		Expect(result).To(ContainSubstring("restarts: 5"))
+		Expect(result).To(ContainSubstring("my-pod-abc123"))
+	})
+
+	It("should detect CrashLoopBackOff without last termination state", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					RestartCount: 3,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: WaitingReasonCrashLoopBackOff,
+						},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("Container crashing"))
+		Expect(result).To(ContainSubstring("restarts: 3"))
+		Expect(result).To(ContainSubstring("my-pod-abc123"))
+	})
+
+	It("should detect CreateContainerConfigError", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  WaitingReasonCreateContainerConfigError,
+							Message: "configmap \"my-config\" not found",
+						},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("Container config error"))
+		Expect(result).To(ContainSubstring("my-config"))
+		Expect(result).To(ContainSubstring("my-pod-abc123"))
+	})
+
+	It("should detect OOMKilled", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					RestartCount: 2,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   TerminatedReasonOOMKilled,
+							ExitCode: 137,
+						},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("OOMKilled"))
+		Expect(result).To(ContainSubstring("exit code 137"))
+		Expect(result).To(ContainSubstring("restarts: 2"))
+		Expect(result).To(ContainSubstring("my-pod-abc123"))
+	})
+
+	It("should detect init container failures", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  WaitingReasonImagePullBackOff,
+							Message: "Back-off pulling image \"init-image:latest\"",
+						},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("Image pull failed"))
+		Expect(result).To(ContainSubstring("init-image:latest"))
+	})
+
+	It("should detect probe failure (running but not ready)", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Ready:        false,
+					RestartCount: 4,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(ContainSubstring("not passing health checks"))
+		Expect(result).To(ContainSubstring("restarts: 4"))
+		Expect(result).To(ContainSubstring("my-pod-abc123"))
+	})
+
+	It("should not flag running container with zero restarts as probe failure", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Ready:        false,
+					RestartCount: 0,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(BeEmpty())
+	})
+
+	It("should return empty string when no failures detected", func() {
+		pods := []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-pod-abc123"},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				}},
+			},
+		}}
+		result := analyzePodFailures(pods)
+		Expect(result).To(BeEmpty())
+	})
+
+	It("should return empty string for empty pod list", func() {
+		result := analyzePodFailures(nil)
+		Expect(result).To(BeEmpty())
+	})
+})
+
+var _ = Describe("newReadyCondition", func() {
+	It("should preserve LastTransitionTime when status hasn't changed", func() {
+		pastTime := metav1.NewTime(metav1.Now().Add(-5 * time.Minute))
+		existing := []metav1.Condition{{
+			Type:               ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             ReasonDeploymentUnavailable,
+			LastTransitionTime: pastTime,
+		}}
+		condition := newReadyCondition(metav1.ConditionFalse, ReasonDeploymentUnavailable,
+			"some message", 1, existing)
+		Expect(condition.LastTransitionTime).To(Equal(pastTime))
+	})
+
+	It("should update LastTransitionTime when status changes", func() {
+		pastTime := metav1.NewTime(metav1.Now().Add(-5 * time.Minute))
+		existing := []metav1.Condition{{
+			Type:               ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			LastTransitionTime: pastTime,
+		}}
+		condition := newReadyCondition(metav1.ConditionTrue, ReasonAvailable,
+			"ready", 1, existing)
+		Expect(condition.LastTransitionTime).NotTo(Equal(pastTime))
+	})
+
+	It("should set the correct fields", func() {
+		condition := newReadyCondition(metav1.ConditionTrue, ReasonAvailable,
+			"all good", 42, nil)
+		Expect(condition.Type).To(Equal(ConditionTypeReady))
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Reason).To(Equal(ReasonAvailable))
+		Expect(condition.Message).To(Equal("all good"))
+		Expect(condition.ObservedGeneration).To(Equal(int64(42)))
+	})
+})
+
+var _ = Describe("reconcileReadyCondition", func() {
 	var generation int64 = 1
 	var acceptedCondition metav1.Condition
+	var reconciler *MCPServerReconciler
 
 	BeforeEach(func() {
-		// Default to valid configuration
 		acceptedCondition = metav1.Condition{
 			Type:   ConditionTypeAccepted,
 			Status: metav1.ConditionTrue,
 			Reason: ReasonValid,
 		}
+		reconciler = &MCPServerReconciler{Client: k8sClient}
 	})
 
 	It("should return Initializing when deployment has no conditions and no ready replicas", func() {
 		deployment := &appsv1.Deployment{
 			Status: appsv1.DeploymentStatus{},
 		}
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
 		Expect(condition.Reason).To(Equal(ReasonInitializing))
 		Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
 	})
@@ -58,216 +392,228 @@ var _ = Describe("determineReadyCondition", func() {
 			Status: appsv1.DeploymentStatus{
 				ReadyReplicas: 1,
 				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
+					{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
 				},
 			},
 		}
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
 		Expect(condition.Reason).To(Equal(ReasonAvailable))
 		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 	})
 
-	It("should return DeploymentUnavailable when deployment has replica failure", func() {
+	It("should return ConfigurationInvalid when configuration is not accepted", func() {
+		invalidAccepted := metav1.Condition{
+			Type:   ConditionTypeAccepted,
+			Status: metav1.ConditionFalse,
+			Reason: ReasonInvalid,
+		}
+		deployment := &appsv1.Deployment{}
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, invalidAccepted, generation, nil)
+		Expect(condition.Reason).To(Equal(ReasonConfigurationInvalid))
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+	})
+
+	It("should return Ready=True with ScaledToZero when deployment is scaled to 0", func() {
 		deployment := &appsv1.Deployment{
-			Status: appsv1.DeploymentStatus{
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:    appsv1.DeploymentReplicaFailure,
-						Status:  corev1.ConditionTrue,
-						Message: "replica failed",
-					},
-				},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](0),
 			},
 		}
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
-		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
-		Expect(condition.Message).To(ContainSubstring("replica failed"))
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
+		Expect(condition.Reason).To(Equal(ReasonScaledToZero))
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Message).To(ContainSubstring("scaled to 0 replicas"))
 	})
 
 	It("should return DeploymentUnavailable when deployment is progressing", func() {
 		deployment := &appsv1.Deployment{
 			Status: appsv1.DeploymentStatus{
 				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-					},
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
 				},
 			},
 		}
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
 		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
 	})
 
-	It("should return ConfigurationInvalid when configuration is not accepted", func() {
-		invalidAcceptedCondition := metav1.Condition{
-			Type:   ConditionTypeAccepted,
-			Status: metav1.ConditionFalse,
-			Reason: ReasonInvalid,
-		}
-		deployment := &appsv1.Deployment{}
-		condition := determineReadyCondition(deployment, invalidAcceptedCondition, generation, make([]metav1.Condition, 0))
-		Expect(condition.Reason).To(Equal(ReasonConfigurationInvalid))
-		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-	})
+	It("should surface pod failure when progressing with zero ready replicas and ImagePullBackOff", func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-prog-imgpull-"}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
-	It("should return Ready=True with ScaledToZero reason when deployment is scaled to 0 replicas", func() {
+		labels := map[string]string{"test": "progressing-imgpull"}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "imgpull-pod",
+				Namespace: ns.Name,
+				Labels:    labels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "ghcr.io/bad/image:v1"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "c",
+			Image: "ghcr.io/bad/image:v1",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason:  WaitingReasonImagePullBackOff,
+					Message: "Back-off pulling image \"ghcr.io/bad/image:v1\"",
+				},
+			},
+		}}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
 		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
 			},
 			Status: appsv1.DeploymentStatus{
 				ReadyReplicas: 0,
-			},
-		}
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
-		Expect(condition.Reason).To(Equal(ReasonScaledToZero))
-		// Ready=True following Kubernetes Deployment semantics: replicas=0 is a valid desired state
-		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
-		Expect(condition.Message).To(ContainSubstring("scaled to 0 replicas"))
-	})
-
-	It("should preserve LastTransitionTime when condition status hasn't changed", func() {
-		// Create an existing condition with a specific timestamp
-		pastTime := metav1.NewTime(metav1.Now().Add(-5 * time.Minute))
-		existingConditions := []metav1.Condition{
-			{
-				Type:               ConditionTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             ReasonDeploymentUnavailable,
-				LastTransitionTime: pastTime,
-			},
-		}
-
-		// Create a deployment that would result in the same condition
-		deployment := &appsv1.Deployment{
-			Status: appsv1.DeploymentStatus{
 				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-					},
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
 				},
 			},
 		}
-
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, existingConditions)
-
-		// The LastTransitionTime should be preserved from the existing condition
-		Expect(condition.LastTransitionTime).To(Equal(pastTime))
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		Expect(condition.Message).To(ContainSubstring("Image pull failed"))
+		Expect(condition.Message).To(ContainSubstring("ghcr.io/bad/image:v1"))
 	})
 
-	It("should update LastTransitionTime when condition status changes", func() {
-		// Create an existing condition with Status=False
-		pastTime := metav1.NewTime(metav1.Now().Add(-5 * time.Minute))
-		existingConditions := []metav1.Condition{
-			{
-				Type:               ConditionTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             ReasonInitializing,
-				LastTransitionTime: pastTime,
+	It("should surface pod failure when progressing with zero ready replicas and CrashLoopBackOff", func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-prog-crash-"}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		labels := map[string]string{"test": "progressing-crash"}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "crash-pod",
+				Namespace: ns.Name,
+				Labels:    labels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "myimage:latest"}},
 			},
 		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:         "c",
+			RestartCount: 5,
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason: WaitingReasonCrashLoopBackOff,
+				},
+			},
+			LastTerminationState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 1},
+			},
+		}}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 
-		// Create a deployment that would result in Status=True (different status)
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+			},
+			Status: appsv1.DeploymentStatus{
+				ReadyReplicas: 0,
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		Expect(condition.Message).To(ContainSubstring("Container crashing"))
+		Expect(condition.Message).To(ContainSubstring("exit code 1"))
+		Expect(condition.Message).To(ContainSubstring("restarts: 5"))
+	})
+
+	It("should return waiting message when progressing with zero ready replicas but no pod failures", func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-prog-nofail-"}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		labels := map[string]string{"test": "progressing-nofail"}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "healthy-pod",
+				Namespace: ns.Name,
+				Labels:    labels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "myimage:latest"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "c",
+			Ready: false,
+			State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{},
+			},
+		}}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: labels},
+			},
+			Status: appsv1.DeploymentStatus{
+				ReadyReplicas: 0,
+				Conditions: []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		Expect(condition.Message).To(ContainSubstring("Waiting for instances to become healthy"))
+	})
+
+	It("should return DeploymentUnavailable with fallback message on replica failure", func() {
 		deployment := &appsv1.Deployment{
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "no-such-pods"},
+				},
 			},
 			Status: appsv1.DeploymentStatus{
-				ReadyReplicas: 1,
 				Conditions: []appsv1.DeploymentCondition{
 					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
+						Type:    appsv1.DeploymentReplicaFailure,
+						Status:  corev1.ConditionTrue,
+						Message: "quota exceeded",
 					},
 				},
 			},
 		}
-
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, existingConditions)
-
-		// The LastTransitionTime should be NEW (not the past time)
-		Expect(condition.LastTransitionTime).NotTo(Equal(pastTime))
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
+		Expect(condition.Reason).To(Equal(ReasonDeploymentUnavailable))
+		Expect(condition.Message).To(ContainSubstring("quota exceeded"))
 	})
 
 	It("should handle nil replicas gracefully when deployment is available", func() {
-		// Create a deployment with nil replicas (tests the ptr.Deref fix)
 		deployment := &appsv1.Deployment{
 			Spec: appsv1.DeploymentSpec{
-				Replicas: nil, // nil replicas should default to 1 in the message
+				Replicas: nil,
 			},
 			Status: appsv1.DeploymentStatus{
 				ReadyReplicas: 1,
 				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-					},
+					{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
 				},
 			},
 		}
-
-		condition := determineReadyCondition(deployment, acceptedCondition, generation, make([]metav1.Condition, 0))
-
-		// Should succeed without panicking
+		condition := reconciler.reconcileReadyCondition(ctx, deployment, acceptedCondition, generation, nil)
 		Expect(condition.Reason).To(Equal(ReasonAvailable))
 		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
-		// Message should use default value of 1 for nil replicas
 		Expect(condition.Message).To(ContainSubstring("1 of 1 instances healthy"))
-	})
-})
-
-var _ = Describe("analyzeDeploymentFailure", func() {
-	It("should identify ImagePullBackOff errors", func() {
-		message := "Back-off pulling image \"nonexistent:latest\": ImagePullBackOff"
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(ContainSubstring("ImagePullBackOff"))
-	})
-
-	It("should identify ErrImagePull errors", func() {
-		message := "Failed to pull image: ErrImagePull"
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(ContainSubstring("ImagePullBackOff"))
-	})
-
-	It("should identify OOMKilled errors", func() {
-		message := "Container was OOMKilled"
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(ContainSubstring("OOMKilled"))
-	})
-
-	It("should identify CrashLoopBackOff errors", func() {
-		message := "Back-off restarting failed container: CrashLoopBackOff"
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(ContainSubstring("CrashLoopBackOff"))
-	})
-
-	It("should identify CreateContainerConfigError errors", func() {
-		message := "Error: container has runAsNonRoot and image will run as root: CreateContainerConfigError"
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(ContainSubstring("CreateContainerConfigError"))
-	})
-
-	It("should identify probe failures", func() {
-		message := "Liveness probe failed: HTTP probe failed"
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(ContainSubstring("Probe failed"))
-	})
-
-	It("should handle empty message", func() {
-		message := ""
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(Equal("No healthy instances available"))
-	})
-
-	It("should handle generic failures", func() {
-		message := "Some unknown error occurred"
-		result := analyzeDeploymentFailure(message)
-		Expect(result).To(ContainSubstring("No healthy instances"))
-		Expect(result).To(ContainSubstring("Some unknown error occurred"))
 	})
 })


### PR DESCRIPTION
Fixes #88 

This improves the status `Ready` condition messages when a deployment is failing, so that users do not need to find and check the pods themselves.

While working on this I refactored the `determineReadyCondition` function as it was getting hard to work with - 120 lines of code, lots of different cases.