### PR TITLE
fix: update stateless field docs and add missing test coverage

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpconfig.go
@@ -28,7 +28,11 @@ package v1alpha1
 type MCPConfigApplyConfiguration struct {
 	// Stateless indicates whether the MCP server is stateless (does not maintain session state).
 	// Only set this to true if the MCP server you are deploying declares that it is stateless.
-	// Defaults to false (stateful)
+	// When true, the generated Service uses SessionAffinity "None", allowing
+	// requests to be freely load-balanced across replicas.
+	// When false or unset, the Service uses SessionAffinity "ClientIP" so that
+	// a given client's requests are routed to the same pod.
+	// Defaults to false (stateful).
 	Stateless *bool `json:"stateless,omitempty"`
 }
 

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -360,7 +360,7 @@ type MCPServerSpec struct {
 	// This section describes the MCP server's protocol-level behavior,
 	// as opposed to how it is sourced, configured, or managed at runtime.
 	// +optional
-	MCP MCPConfig `json:"mcp,omitempty"`
+	MCP MCPConfig `json:"mcp,omitzero"`
 }
 
 // MCPConfig defines Model Context Protocol specific properties of the server.
@@ -370,7 +370,11 @@ type MCPServerSpec struct {
 type MCPConfig struct {
 	// Stateless indicates whether the MCP server is stateless (does not maintain session state).
 	// Only set this to true if the MCP server you are deploying declares that it is stateless.
-	// Defaults to false (stateful)
+	// When true, the generated Service uses SessionAffinity "None", allowing
+	// requests to be freely load-balanced across replicas.
+	// When false or unset, the Service uses SessionAffinity "ClientIP" so that
+	// a given client's requests are routed to the same pod.
+	// Defaults to false (stateful).
 	// +optional
 	Stateless *bool `json:"stateless,omitempty"`
 }

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -602,7 +602,11 @@ spec:
                     description: |-
                       Stateless indicates whether the MCP server is stateless (does not maintain session state).
                       Only set this to true if the MCP server you are deploying declares that it is stateless.
-                      Defaults to false (stateful)
+                      When true, the generated Service uses SessionAffinity "None", allowing
+                      requests to be freely load-balanced across replicas.
+                      When false or unset, the Service uses SessionAffinity "ClientIP" so that
+                      a given client's requests are routed to the same pod.
+                      Defaults to false (stateful).
                     type: boolean
                 type: object
               runtime:

--- a/internal/controller/mcpserver_controller_service_test.go
+++ b/internal/controller/mcpserver_controller_service_test.go
@@ -308,6 +308,29 @@ var _ = Describe("MCPServer Controller - Stateless Service", func() {
 		Expect(svc.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityNone))
 	})
 
+	It("should create a service with ClientIP session affinity when mcp is not set", func() {
+		resource := newTestMCPServer(resourceName)
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		err := reconciler.reconcileService(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		svc := &corev1.Service{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      resourceName,
+			Namespace: "default",
+		}, svc)).To(Succeed())
+		Expect(svc.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityClientIP))
+	})
+
 	It("should create a service with ClientIP session affinity when stateless is false", func() {
 		resource := newTestMCPServer(resourceName)
 		resource.Spec.MCP.Stateless = new(false)
@@ -367,6 +390,43 @@ var _ = Describe("MCPServer Controller - Stateless Service", func() {
 		By("Verifying session affinity was updated to None")
 		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, svc)).To(Succeed())
 		Expect(svc.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityNone))
+	})
+
+	It("should update session affinity when stateless changes from true to false", func() {
+		resource := newTestMCPServer(resourceName)
+		resource.Spec.MCP.Stateless = new(true)
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		controllerReconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		By("Reconciling to create the service with no session affinity")
+		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		svc := &corev1.Service{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, svc)).To(Succeed())
+		Expect(svc.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityNone))
+
+		By("Updating stateless to false")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		mcpServer.Spec.MCP.Stateless = new(false)
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		By("Reconciling again to pick up the stateless change")
+		_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying session affinity was updated to ClientIP")
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, svc)).To(Succeed())
+		Expect(svc.Spec.SessionAffinity).To(Equal(corev1.ServiceAffinityClientIP))
 	})
 })
 


### PR DESCRIPTION
Follow-up to #147.

- Update `MCPConfig` and `Stateless` field descriptions to document session affinity implications
- Fix `omitempty` → `omitzero` on `MCP` field for consistency with other struct fields
- Add tests for nil/unset default case and true→false update path

cc @Cali0707

