### PR TITLE
fix(metrics): delete per-resource counters when MCPServer is removed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.26.3
+go 1.26.2
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.0

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -111,8 +111,12 @@ func recordCondition(name, namespace, condType, status, reason string) {
 
 // cleanupMetrics removes all metrics for a deleted MCPServer.
 func cleanupMetrics(name, namespace string) {
-	conditionInfo.DeletePartialMatch(prometheus.Labels{
+	labels := prometheus.Labels{
 		"name":      name,
 		"namespace": namespace,
-	})
+	}
+	conditionInfo.DeletePartialMatch(labels)
+	validationFailuresTotal.DeletePartialMatch(labels)
+	deploymentFailuresTotal.DeletePartialMatch(labels)
+	serviceFailuresTotal.DeletePartialMatch(labels)
 }

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -180,7 +180,22 @@ var _ = Describe("MCPServer Metrics", func() {
 						Ref: "docker.io/library/test-image:latest",
 					},
 				},
-				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+				Config: mcpv1alpha1.ServerConfig{
+					Port: 8080,
+					Storage: []mcpv1alpha1.StorageMount{
+						{
+							Path: "/config",
+							Source: mcpv1alpha1.StorageSource{
+								Type: mcpv1alpha1.StorageTypeConfigMap,
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "nonexistent-configmap",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
@@ -190,6 +205,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(testutil.CollectAndCount(conditionInfo)).To(BeNumerically(">", 0))
+		Expect(testutil.CollectAndCount(validationFailuresTotal)).To(BeNumerically(">", 0))
 
 		// Delete the resource and reconcile again
 		Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
@@ -197,6 +213,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(testutil.CollectAndCount(conditionInfo)).To(Equal(0))
+		Expect(testutil.CollectAndCount(validationFailuresTotal)).To(Equal(0))
 	})
 
 	It("should record deployment failure metrics and Ready condition when deployment reconciliation fails", func() {

--- a/site-src/operating/metrics.md
+++ b/site-src/operating/metrics.md
@@ -51,7 +51,7 @@ Custom metrics use the Prometheus namespace **`mcpserver`** (exported names star
 | `status` | `True`, `False`, or `Unknown` |
 | `reason` | Condition reason (intended to mirror `.status.conditions[]`; see [Gauge versus API status](#gauge-versus-api-status)) |
 
-Only one active series exists per `(name, namespace, type)`. On delete, gauge series for that object are removed; **`*_failures_total` counters are not**—time series may remain in Prometheus.
+Only one active series exists per `(name, namespace, type)`. On delete, both gauge series and **`*_failures_total` counter series** for that object are removed from the exporter.
 
 **Typical reasons**
 


### PR DESCRIPTION
Closes [kubernetes-sigs/mcp-lifecycle-operator#159](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/159)

**Summary**
When an `MCPServer` is deleted, the reconciler calls `cleanupMetrics` so Prometheus series tied to that object do not accumulate forever. That helper already removed `mcpserver_condition_info` samples via `DeletePartialMatch` on name and namespace. The three failure counters also use name and namespace (plus reason), but were never cleaned up, so high churn could inflate label cardinality in the metrics registry.

This PR extends cleanupMetrics to call `DeletePartialMatch` on `validation_failures_total`, `deployment_failures_total`, and `service_failures_total` with the same `name / namespace labels.` `reconcile_phase_duration_seconds` is intentionally unchanged because it is not per-resource (only a phase label).

**Test plan**
The existing “should cleanup metrics when MCPServer is deleted” spec is updated to use invalid storage (missing ConfigMap) so `validation_failures_total` is populated, then to assert both conditionInfo and validationFailuresTotal have zero collected series after delete and a final reconcile.

Verified with run `make test` in an environment 

