### PR TITLE
fix(controller): centralize workload labels and metric phase strings

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// Kubernetes label keys reserved and applied by the operator on managed workloads.
+const (
+	LabelKeyApp       = "app"
+	LabelKeyMCPServer = "mcp-server"
+)
+
+// ManagedWorkloadName is the standard app label value and name of the main container
+// in operator-created Deployments.
+const ManagedWorkloadName = "mcp-server"
+
+// ReconcilePhase is the value for the "phase" label on mcpserver_reconcile_phase_duration_seconds.
+const (
+	ReconcilePhaseValidation = "validation"
+	ReconcilePhaseDeployment = "deployment"
+	ReconcilePhaseService    = "service"
+)
+
+// MetricReasonReconcileError is the `reason` label on deployment/service failure counters
+// when the corresponding reconcile step returns an error.
+const MetricReasonReconcileError = "ReconcileError"

--- a/internal/controller/custom_metadata.go
+++ b/internal/controller/custom_metadata.go
@@ -16,8 +16,8 @@ var ErrNilMap = errors.New("destination map not initialized")
 const jsonNull = "null"
 
 var reservedLabelKeys = map[string]bool{
-	"app":        true,
-	"mcp-server": true,
+	LabelKeyApp:       true,
+	LabelKeyMCPServer: true,
 }
 
 func filterReservedKeys(m map[string]string) map[string]string {

--- a/internal/controller/custom_metadata_test.go
+++ b/internal/controller/custom_metadata_test.go
@@ -37,8 +37,8 @@ func Test_mergeMaps(t *testing.T) {
 				src map[string]string
 			}{
 				dst: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 				src: map[string]string{
 					"compontent": "proxy",
@@ -46,7 +46,7 @@ func Test_mergeMaps(t *testing.T) {
 			},
 			want: want{
 				m: map[string]string{
-					"app":        "web",
+					LabelKeyApp:  "web",
 					"env":        "production",
 					"compontent": "proxy",
 				},
@@ -60,17 +60,17 @@ func Test_mergeMaps(t *testing.T) {
 				src map[string]string
 			}{
 				dst: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 				src: map[string]string{
-					"app": "proxy",
+					LabelKeyApp: "proxy",
 				},
 			},
 			want: want{
 				m: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 				wantErr: false,
 			},
@@ -82,8 +82,8 @@ func Test_mergeMaps(t *testing.T) {
 				src map[string]string
 			}{
 				dst: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 				src: map[string]string{
 					"env": "dev",
@@ -91,8 +91,8 @@ func Test_mergeMaps(t *testing.T) {
 			},
 			want: want{
 				m: map[string]string{
-					"app": "web",
-					"env": "dev",
+					LabelKeyApp: "web",
+					"env":       "dev",
 				},
 				wantErr: false,
 			},
@@ -104,15 +104,15 @@ func Test_mergeMaps(t *testing.T) {
 				src map[string]string
 			}{
 				dst: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 				src: map[string]string{},
 			},
 			want: want{
 				m: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 				wantErr: false,
 			},
@@ -125,8 +125,8 @@ func Test_mergeMaps(t *testing.T) {
 			}{
 				dst: map[string]string{},
 				src: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 			},
 			want: want{
@@ -143,8 +143,8 @@ func Test_mergeMaps(t *testing.T) {
 				src map[string]string
 			}{
 				src: map[string]string{
-					"app": "web",
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 			},
 			want: want{
@@ -173,19 +173,19 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "web",
 				Labels: map[string]string{
-					"app": "web",
+					LabelKeyApp: "web",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"app": "web",
+						LabelKeyApp: "web",
 					},
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "web",
+							LabelKeyApp: "web",
 						},
 					},
 				},
@@ -210,19 +210,19 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "web",
 					Labels: map[string]string{
-						"app": "web",
+						LabelKeyApp: "web",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": "web",
+							LabelKeyApp: "web",
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"app": "web",
+								LabelKeyApp: "web",
 							},
 						},
 					},
@@ -245,7 +245,7 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "web",
 					Labels: map[string]string{
-						"app": "web",
+						LabelKeyApp: "web",
 					},
 					Annotations: map[string]string{
 						"department":                             "finance",
@@ -255,13 +255,13 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": "web",
+							LabelKeyApp: "web",
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"app": "web",
+								LabelKeyApp: "web",
 							},
 							Annotations: map[string]string{
 								"department": "finance",
@@ -287,7 +287,7 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "web",
 					Labels: map[string]string{
-						"app":                      "web",
+						LabelKeyApp:                "web",
 						"kubernetes.io/managed-by": "mcp-lifecyle-operator",
 					},
 					Annotations: map[string]string{
@@ -297,13 +297,13 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": "web",
+							LabelKeyApp: "web",
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"app":                      "web",
+								LabelKeyApp:                "web",
 								"kubernetes.io/managed-by": "mcp-lifecyle-operator",
 							},
 						},
@@ -321,7 +321,7 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "web",
 						Labels: map[string]string{
-							"app":                      "web",
+							LabelKeyApp:                "web",
 							"kubernetes.io/managed-by": "mcp-lifecyle-operator",
 						},
 						Annotations: map[string]string{
@@ -331,13 +331,13 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 					Spec: appsv1.DeploymentSpec{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"app": "web",
+								LabelKeyApp: "web",
 							},
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app":                      "web",
+									LabelKeyApp:                "web",
 									"kubernetes.io/managed-by": "mcp-lifecyle-operator",
 								},
 							},
@@ -349,19 +349,19 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "web",
 					Labels: map[string]string{
-						"app": "web",
+						LabelKeyApp: "web",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": "web",
+							LabelKeyApp: "web",
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"app": "web",
+								LabelKeyApp: "web",
 							},
 						},
 					},
@@ -382,7 +382,7 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "web",
 						Labels: map[string]string{
-							"app":                      "web",
+							LabelKeyApp:                "web",
 							"department":               "procurement",
 							"kubernetes.io/managed-by": "mcp-lifecyle-operator",
 						},
@@ -393,13 +393,13 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 					Spec: appsv1.DeploymentSpec{
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"app": "web",
+								LabelKeyApp: "web",
 							},
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app":                      "web",
+									LabelKeyApp:                "web",
 									"department":               "procurement",
 									"kubernetes.io/managed-by": "mcp-lifecyle-operator",
 								},
@@ -412,7 +412,7 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "web",
 					Labels: map[string]string{
-						"app":        "web",
+						LabelKeyApp:  "web",
 						"department": "procurement",
 					},
 					Annotations: map[string]string{
@@ -422,13 +422,13 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app": "web",
+							LabelKeyApp: "web",
 						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"app":        "web",
+								LabelKeyApp:  "web",
 								"department": "procurement",
 							},
 						},
@@ -488,7 +488,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 					},
 				},
@@ -496,7 +496,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "webserver",
+						LabelKeyApp: "webserver",
 					},
 				},
 			},
@@ -514,7 +514,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 					},
 				},
@@ -522,7 +522,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":                      "webserver",
+						LabelKeyApp:                "webserver",
 						"kubernetes.io/managed-by": "mcp-lifecycle-operator",
 					},
 					Annotations: map[string]string{
@@ -540,7 +540,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app":                      "webserver",
+							LabelKeyApp:                "webserver",
 							"kubernetes.io/managed-by": "mcp-lifecycle-operator",
 						},
 						Annotations: map[string]string{
@@ -552,7 +552,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "webserver",
+						LabelKeyApp: "webserver",
 					},
 					Annotations: map[string]string{},
 				},
@@ -571,7 +571,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app":                      "webserver",
+							LabelKeyApp:                "webserver",
 							"department":               "procurement",
 							"kubernetes.io/managed-by": "mcp-lifecycle-operator",
 						},
@@ -584,7 +584,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":        "webserver",
+						LabelKeyApp:  "webserver",
 						"department": "procurement",
 					},
 					Annotations: map[string]string{
@@ -599,16 +599,16 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 				mcp: &mcpv1alpha1.MCPServer{
 					Spec: mcpv1alpha1.MCPServerSpec{
 						ExtraLabels: map[string]string{
-							"app":        "should-be-ignored",
-							"mcp-server": "should-be-ignored",
-							"env":        "production",
+							LabelKeyApp:       "should-be-ignored",
+							LabelKeyMCPServer: "should-be-ignored",
+							"env":             "production",
 						},
 					},
 				},
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 					},
 				},
@@ -616,8 +616,8 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "webserver",
-						"env": "production",
+						LabelKeyApp: "webserver",
+						"env":       "production",
 					},
 					Annotations: map[string]string{
 						"mcp.x-k8s.io/managed-extra-labels": "{\"env\":\"production\"}",
@@ -638,7 +638,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 					},
 				},
@@ -646,7 +646,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "webserver",
+						LabelKeyApp: "webserver",
 					},
 					Annotations: map[string]string{
 						"department":                             "finance",
@@ -690,7 +690,7 @@ func Test_deploymentLabelsChanged(t *testing.T) {
 				deployment: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 						Annotations: map[string]string{},
 					},
@@ -698,7 +698,7 @@ func Test_deploymentLabelsChanged(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app": "webserver",
+									LabelKeyApp: "webserver",
 								},
 							},
 							Spec: corev1.PodSpec{},
@@ -721,7 +721,7 @@ func Test_deploymentLabelsChanged(t *testing.T) {
 				deployment: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app":        "webserver",
+							LabelKeyApp:  "webserver",
 							"department": "procurement",
 						},
 						Annotations: map[string]string{
@@ -732,7 +732,7 @@ func Test_deploymentLabelsChanged(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app":        "webserver",
+									LabelKeyApp:  "webserver",
 									"department": "procurement",
 								},
 							},
@@ -752,7 +752,7 @@ func Test_deploymentLabelsChanged(t *testing.T) {
 				deployment: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app":        "webserver",
+							LabelKeyApp:  "webserver",
 							"department": "procurement",
 						},
 						Annotations: map[string]string{
@@ -763,7 +763,7 @@ func Test_deploymentLabelsChanged(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app":        "webserver",
+									LabelKeyApp:  "webserver",
 									"department": "procurement",
 								},
 							},
@@ -805,7 +805,7 @@ func Test_deploymentAnnotationsChanged(t *testing.T) {
 				deployment: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 						Annotations: map[string]string{},
 					},
@@ -813,7 +813,7 @@ func Test_deploymentAnnotationsChanged(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app": "webserver",
+									LabelKeyApp: "webserver",
 								},
 							},
 							Spec: corev1.PodSpec{},
@@ -836,7 +836,7 @@ func Test_deploymentAnnotationsChanged(t *testing.T) {
 				deployment: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 						Annotations: map[string]string{
 							managedExtraAnnotations: "{\"department\":\"procurement\"}",
@@ -847,7 +847,7 @@ func Test_deploymentAnnotationsChanged(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app": "webserver",
+									LabelKeyApp: "webserver",
 								},
 								Annotations: map[string]string{
 									"department": "procurement",
@@ -869,7 +869,7 @@ func Test_deploymentAnnotationsChanged(t *testing.T) {
 				deployment: &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "webserver",
+							LabelKeyApp: "webserver",
 						},
 						Annotations: map[string]string{
 							managedExtraAnnotations: "{\"department\":\"procurement\"}",
@@ -880,7 +880,7 @@ func Test_deploymentAnnotationsChanged(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									"app": "webserver",
+									LabelKeyApp: "webserver",
 								},
 								Annotations: map[string]string{
 									"department": "procurement",
@@ -929,7 +929,7 @@ func Test_serviceLabelsChanged(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "mariadb-mcp",
+							LabelKeyApp: "mariadb-mcp",
 						},
 					},
 				},
@@ -949,7 +949,7 @@ func Test_serviceLabelsChanged(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app":        "mariadb-mcp",
+							LabelKeyApp:  "mariadb-mcp",
 							"department": "procurement",
 						},
 						Annotations: map[string]string{
@@ -974,7 +974,7 @@ func Test_serviceLabelsChanged(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app":        "mariadb-mcp",
+							LabelKeyApp:  "mariadb-mcp",
 							"department": "procurement",
 						},
 						Annotations: map[string]string{
@@ -1014,7 +1014,7 @@ func Test_serviceAnnotationsChanged(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "mariadb-mcp",
+							LabelKeyApp: "mariadb-mcp",
 						},
 					},
 				},
@@ -1034,7 +1034,7 @@ func Test_serviceAnnotationsChanged(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "mariadb-mcp",
+							LabelKeyApp: "mariadb-mcp",
 						},
 						Annotations: map[string]string{
 							managedExtraAnnotations: "{\"department\":\"procurement\"}",
@@ -1059,7 +1059,7 @@ func Test_serviceAnnotationsChanged(t *testing.T) {
 				service: &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"app": "mariadb-mcp",
+							LabelKeyApp: "mariadb-mcp",
 						},
 						Annotations: map[string]string{
 							managedExtraAnnotations: "{\"department\":\"procurement\",\"env\": \"production\"}",

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -194,7 +194,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Validate configuration
 	validationStart := time.Now()
 	if err := r.validateConfig(ctx, mcpServer); err != nil {
-		reconcileDuration.With(prometheus.Labels{"phase": "validation"}).Observe(time.Since(validationStart).Seconds())
+		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseValidation}).Observe(time.Since(validationStart).Seconds())
 
 		var validationErr *ValidationError
 		if errors.As(err, &validationErr) {
@@ -206,7 +206,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Don't update status - preserve existing Accepted condition
 		return ctrl.Result{}, err
 	}
-	reconcileDuration.With(prometheus.Labels{"phase": "validation"}).Observe(time.Since(validationStart).Seconds())
+	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseValidation}).Observe(time.Since(validationStart).Seconds())
 
 	// Configuration is valid - create Accepted=True condition
 	acceptedCondition := newCondition(
@@ -230,12 +230,12 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Configuration is valid, proceed with deployment reconciliation
 	deploymentStart := time.Now()
 	existingDeployment, err := r.reconcileDeployment(ctx, mcpServer)
-	reconcileDuration.With(prometheus.Labels{"phase": "deployment"}).Observe(time.Since(deploymentStart).Seconds())
+	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseDeployment}).Observe(time.Since(deploymentStart).Seconds())
 	if err != nil {
 		deploymentFailuresTotal.With(prometheus.Labels{
 			"name":      mcpServer.Name,
 			"namespace": mcpServer.Namespace,
-			"reason":    "ReconcileError",
+			"reason":    MetricReasonReconcileError,
 		}).Inc()
 		// Deployment reconciliation failed - update status
 		readyCondition := newCondition(
@@ -267,11 +267,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Reconcile Service
 	serviceStart := time.Now()
 	if err := r.reconcileService(ctx, mcpServer); err != nil {
-		reconcileDuration.With(prometheus.Labels{"phase": "service"}).Observe(time.Since(serviceStart).Seconds())
+		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
 		serviceFailuresTotal.With(prometheus.Labels{
 			"name":      mcpServer.Name,
 			"namespace": mcpServer.Namespace,
-			"reason":    "ReconcileError",
+			"reason":    MetricReasonReconcileError,
 		}).Inc()
 		// Service reconciliation failed - update status
 		readyCondition := newCondition(
@@ -302,7 +302,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Determine Ready condition based on deployment status
-	reconcileDuration.With(prometheus.Labels{"phase": "service"}).Observe(time.Since(serviceStart).Seconds())
+	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
 
 	readyCondition := determineReadyCondition(
 		existingDeployment,
@@ -821,6 +821,17 @@ func deploymentNeedsUpdate(mcpServer *mcpv1alpha1.MCPServer, existing, desired *
 		ownershipChanged
 }
 
+func managedWorkloadLabels(mcpServerName string) map[string]string {
+	return map[string]string{
+		LabelKeyApp:       ManagedWorkloadName,
+		LabelKeyMCPServer: mcpServerName,
+	}
+}
+
+func managedWorkloadSelector(mcpServerName string) map[string]string {
+	return map[string]string{LabelKeyMCPServer: mcpServerName}
+}
+
 // createDeployment creates a Deployment for the MCPServer
 func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer) (*appsv1.Deployment, error) {
 	// Validate source type and extract image reference
@@ -840,13 +851,10 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 	if mcpServer.Spec.Runtime.Replicas != nil {
 		replicas = *mcpServer.Spec.Runtime.Replicas
 	}
-	labels := map[string]string{
-		"app":        "mcp-server",
-		"mcp-server": mcpServer.Name,
-	}
+	labels := managedWorkloadLabels(mcpServer.Name)
 
 	container := corev1.Container{
-		Name:  "mcp-server",
+		Name:  ManagedWorkloadName,
 		Image: imageRef,
 		Ports: []corev1.ContainerPort{
 			{
@@ -915,9 +923,7 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"mcp-server": mcpServer.Name,
-				},
+				MatchLabels: managedWorkloadSelector(mcpServer.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1076,10 +1082,7 @@ func (r *MCPServerReconciler) reconcileService(
 
 // createService creates a Service for the MCPServer
 func (r *MCPServerReconciler) createService(mcpServer *mcpv1alpha1.MCPServer) *corev1.Service {
-	labels := map[string]string{
-		"app":        "mcp-server",
-		"mcp-server": mcpServer.Name,
-	}
+	labels := managedWorkloadLabels(mcpServer.Name)
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1088,10 +1091,8 @@ func (r *MCPServerReconciler) createService(mcpServer *mcpv1alpha1.MCPServer) *c
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeClusterIP,
-			Selector: map[string]string{
-				"mcp-server": mcpServer.Name,
-			},
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: managedWorkloadSelector(mcpServer.Name),
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "mcp",

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -114,14 +114,11 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"mcp-server": "test-empty-containers"},
+					MatchLabels: managedWorkloadSelector("test-empty-containers"),
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"app":        "mcp-server",
-							"mcp-server": "test-empty-containers",
-						},
+						Labels: managedWorkloadLabels("test-empty-containers"),
 					},
 					Spec: corev1.PodSpec{
 						Containers: nil,

--- a/internal/controller/mcpserver_controller_ownership_test.go
+++ b/internal/controller/mcpserver_controller_ownership_test.go
@@ -192,14 +192,11 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"mcp-server": resourceName},
+						MatchLabels: managedWorkloadSelector(resourceName),
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"app":        "mcp-server",
-								"mcp-server": resourceName,
-							},
+							Labels: managedWorkloadLabels(resourceName),
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
@@ -279,7 +276,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Selector: map[string]string{"mcp-server": resourceName},
+					Selector: managedWorkloadSelector(resourceName),
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "http",
@@ -354,11 +351,11 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"app": "manual"},
+						MatchLabels: map[string]string{LabelKeyApp: "manual"},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"app": "manual"},
+							Labels: map[string]string{LabelKeyApp: "manual"},
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
@@ -441,7 +438,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 					// No ownerReferences
 				},
 				Spec: corev1.ServiceSpec{
-					Selector: map[string]string{"app": "manual"},
+					Selector: map[string]string{LabelKeyApp: "manual"},
 					Ports: []corev1.ServicePort{
 						{
 							Name:     "http",
@@ -532,19 +529,16 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 				},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"mcp-server": resourceName},
+						MatchLabels: managedWorkloadSelector(resourceName),
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"app":        "mcp-server",
-								"mcp-server": resourceName,
-							},
+							Labels: managedWorkloadLabels(resourceName),
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Name:  "mcp-server",
+									Name:  ManagedWorkloadName,
 									Image: "manual-image:latest",
 								},
 							},
@@ -639,7 +633,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 					},
 				},
 				Spec: corev1.ServiceSpec{
-					Selector: map[string]string{"app": "manual"},
+					Selector: map[string]string{LabelKeyApp: "manual"},
 					Ports: []corev1.ServicePort{
 						{
 							Name:     "http",

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -69,7 +69,7 @@ var (
 	)
 
 	// reconcileDuration tracks the duration of reconciliation phases.
-	// Labels: phase (validation/deployment/service).
+	// Labels: phase (ReconcilePhaseValidation / ReconcilePhaseDeployment / ReconcilePhaseService).
 	reconcileDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -239,7 +239,7 @@ var _ = Describe("MCPServer Metrics", func() {
 
 		// Deployment failure counter incremented
 		Expect(testutil.ToFloat64(deploymentFailuresTotal.WithLabelValues(
-			depFailName, namespace, "ReconcileError",
+			depFailName, namespace, MetricReasonReconcileError,
 		))).To(Equal(1.0))
 
 		// Ready=False condition recorded
@@ -288,7 +288,7 @@ var _ = Describe("MCPServer Metrics", func() {
 
 		// Service failure counter incremented
 		Expect(testutil.ToFloat64(serviceFailuresTotal.WithLabelValues(
-			svcFailName, namespace, "ReconcileError",
+			svcFailName, namespace, MetricReasonReconcileError,
 		))).To(Equal(1.0))
 
 		// Ready=False condition recorded


### PR DESCRIPTION
**Closes:** Fixes [kubernetes-sigs/mcp-lifecycle-operator#158](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/158).

**Description**
This PR removes scattered string literals for operator-managed Kubernetes labels, Prometheus reconcile phase labels, and failure-counter reasons by introducing shared constants and small helpers for workload label/selector maps.
**Included:**
New `internal/controller/constants.go:`` LabelKeyApp`,` LabelKeyMCPServer`, `ManagedWorkloadName`, `ReconcilePhase{Validation,Deployment,Service}`, `MetricReasonReconcileError`
`reservedLabelKeys` in `custom_metadata.go` uses the label key constants
managedWorkloadLabels / managedWorkloadSelector in `mcpserver_controller.go` for consistent Deployment/Service labels and selectors
Reconcile path updated to use phase and failure-reason constants for metrics

**Test Plan**
`make test` (unit + envtest for api/v1alpha1 and internal/controller)
`make lint-fix` / golangci-lint clean
`go build ./...`