### PR TITLE
Bump golang from 1.26.2 to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.0


### PR DESCRIPTION
Bump golang from 1.26.2 to 1.26.3 due to govulncheck failures. Example: https://github.com/kubernetes-sigs/mcp-lifecycle-operator/actions/runs/25581346926/job/75100745261?pr=164

/hold


Please hold as I need to verify a couple of things (e.g. images) first