### PR TITLE
fix(controller): persist handshake retry count in status field

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
@@ -41,6 +41,10 @@ type MCPServerStatusApplyConfiguration struct {
 	// MCP server during the protocol initialize handshake.
 	// This field is populated only after a successful handshake.
 	ServerInfo *MCPServerInfoApplyConfiguration `json:"serverInfo,omitempty"`
+	// HandshakeRetryCount tracks the number of consecutive MCP handshake
+	// failures for the current generation. Reset to 0 on success, spec change,
+	// or when reconciliation does not reach the handshake phase.
+	HandshakeRetryCount *int32 `json:"handshakeRetryCount,omitempty"`
 	// Conditions represent the latest available observations of the MCPServer's state.
 	//
 	// Standard condition types:
@@ -107,6 +111,14 @@ func (b *MCPServerStatusApplyConfiguration) WithAddress(value *MCPServerAddressA
 // If called multiple times, the ServerInfo field is set to the value of the last call.
 func (b *MCPServerStatusApplyConfiguration) WithServerInfo(value *MCPServerInfoApplyConfiguration) *MCPServerStatusApplyConfiguration {
 	b.ServerInfo = value
+	return b
+}
+
+// WithHandshakeRetryCount sets the HandshakeRetryCount field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the HandshakeRetryCount field is set to the value of the last call.
+func (b *MCPServerStatusApplyConfiguration) WithHandshakeRetryCount(value int32) *MCPServerStatusApplyConfiguration {
+	b.HandshakeRetryCount = &value
 	return b
 }
 

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -455,6 +455,12 @@ type MCPServerStatus struct {
 	// +optional
 	ServerInfo *MCPServerInfo `json:"serverInfo,omitempty"`
 
+	// HandshakeRetryCount tracks the number of consecutive MCP handshake
+	// failures for the current generation. Reset to 0 on success, spec change,
+	// or when reconciliation does not reach the handshake phase.
+	// +optional
+	HandshakeRetryCount int32 `json:"handshakeRetryCount,omitempty"`
+
 	// Conditions represent the latest available observations of the MCPServer's state.
 	//
 	// Standard condition types:

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -1656,6 +1656,13 @@ spec:
                 description: DeploymentName is the name of the Deployment created
                   for this MCPServer.
                 type: string
+              handshakeRetryCount:
+                description: |-
+                  HandshakeRetryCount tracks the number of consecutive MCP handshake
+                  failures for the current generation. Reset to 0 on success, spec change,
+                  or when reconciliation does not reach the handshake phase.
+                format: int32
+                type: integer
               observedGeneration:
                 description: |-
                   ObservedGeneration reflects the generation most recently observed by the controller.

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -332,7 +332,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var handshakeRetryCount int32
 	if readyCondition.Reason == ReasonMCPEndpointUnavailable {
-		handshakeRetryCount = mcpServer.Status.HandshakeRetryCount + 1
+		if mcpServer.Status.ObservedGeneration == mcpServer.Generation {
+			handshakeRetryCount = mcpServer.Status.HandshakeRetryCount + 1
+		} else {
+			handshakeRetryCount = 1
+		}
 	}
 
 	status := acv1alpha1.MCPServerStatus().

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -253,6 +253,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		status := acv1alpha1.MCPServerStatus().
 			WithObservedGeneration(mcpServer.Generation).
 			WithServiceName(mcpServer.Name).
+			WithHandshakeRetryCount(0).
 			WithConditions(
 				conditionToAC(acceptedCondition),
 				conditionToAC(readyCondition),
@@ -290,6 +291,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			WithObservedGeneration(mcpServer.Generation).
 			WithDeploymentName(existingDeployment.Name).
 			WithServiceName(mcpServer.Name).
+			WithHandshakeRetryCount(0).
 			WithConditions(
 				conditionToAC(acceptedCondition),
 				conditionToAC(readyCondition),
@@ -328,10 +330,16 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	var serverInfo *mcpv1alpha1.MCPServerInfo
 	readyCondition, serverInfo = r.reconcileHandshake(ctx, mcpServer, mcpURL, readyCondition)
 
+	var handshakeRetryCount int32
+	if readyCondition.Reason == ReasonMCPEndpointUnavailable {
+		handshakeRetryCount = mcpServer.Status.HandshakeRetryCount + 1
+	}
+
 	status := acv1alpha1.MCPServerStatus().
 		WithObservedGeneration(mcpServer.Generation).
 		WithDeploymentName(existingDeployment.Name).
 		WithServiceName(mcpServer.Name).
+		WithHandshakeRetryCount(handshakeRetryCount).
 		WithAddress(acv1alpha1.MCPServerAddress().
 			WithURL(mcpURL)).
 		WithConditions(
@@ -382,15 +390,16 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// If MCP endpoint is not yet reachable, requeue with exponential backoff up to a max retry count.
 	if readyCondition.Status == metav1.ConditionFalse && readyCondition.Reason == ReasonMCPEndpointUnavailable {
-		retryCount := mcpHandshakeRetryCount(mcpServer.Status.Conditions)
+		retryCount := int(handshakeRetryCount)
 		if retryCount >= maxMCPHandshakeRetries {
 			logger.Info("MCP handshake retries exhausted, not requeuing",
 				"retries", retryCount, "max", maxMCPHandshakeRetries)
 			return ctrl.Result{}, nil
 		}
-		delay := mcpHandshakeBackoff(retryCount)
+		// retryCount is 1-based (already incremented); backoff expects 0-based
+		delay := mcpHandshakeBackoff(retryCount - 1)
 		logger.Info("MCP endpoint not yet reachable, requeuing with backoff",
-			"requeueAfter", delay, "retry", retryCount+1, "maxRetries", maxMCPHandshakeRetries)
+			"requeueAfter", delay, "retry", retryCount, "maxRetries", maxMCPHandshakeRetries)
 		return ctrl.Result{RequeueAfter: delay}, nil
 	}
 
@@ -522,28 +531,6 @@ func mcpHandshakeBackoff(retryCount int) time.Duration {
 		}
 	}
 	return delay
-}
-
-// mcpHandshakeRetryCount estimates how many consecutive MCP handshake failures
-// have occurred by computing elapsed time since the Ready condition last
-// transitioned to MCPEndpointUnavailable.
-func mcpHandshakeRetryCount(conditions []metav1.Condition) int {
-	existing := meta.FindStatusCondition(conditions, ConditionTypeReady)
-	if existing == nil || existing.Reason != ReasonMCPEndpointUnavailable {
-		return 0
-	}
-	elapsed := time.Since(existing.LastTransitionTime.Time)
-	// Walk the backoff schedule to count how many retries fit in the elapsed time.
-	total := time.Duration(0)
-	count := 0
-	for count < maxMCPHandshakeRetries {
-		total += mcpHandshakeBackoff(count)
-		if total > elapsed {
-			break
-		}
-		count++
-	}
-	return count
 }
 
 // isHTTPAuthError checks whether the error from the MCP SDK indicates an HTTP
@@ -1215,6 +1202,7 @@ func (r *MCPServerReconciler) reconcilePermanentValidationError(
 	status := acv1alpha1.MCPServerStatus().
 		WithObservedGeneration(mcpServer.Generation).
 		WithServiceName(mcpServer.Name).
+		WithHandshakeRetryCount(0).
 		WithConditions(
 			conditionToAC(acceptedCondition),
 			conditionToAC(readyCondition),

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -72,6 +72,16 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 		if err == nil {
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		}
+
+		deploy := &appsv1.Deployment{}
+		if err := k8sClient.Get(ctx, typeNamespacedName, deploy); err == nil {
+			Expect(k8sClient.Delete(ctx, deploy)).To(Succeed())
+		}
+
+		svc := &corev1.Service{}
+		if err := k8sClient.Get(ctx, typeNamespacedName, svc); err == nil {
+			Expect(k8sClient.Delete(ctx, svc)).To(Succeed())
+		}
 	})
 
 	It("should set MCPEndpointUnavailable when handshake fails", func() {
@@ -118,6 +128,9 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 		Expect(readyCondition.Reason).To(Equal(ReasonMCPEndpointUnavailable))
 		Expect(readyCondition.Message).To(ContainSubstring("MCP endpoint is not serving a valid MCP protocol"))
 		Expect(readyCondition.Message).To(ContainSubstring("connection refused"))
+
+		By("Verifying HandshakeRetryCount is incremented")
+		Expect(mcpServer.Status.HandshakeRetryCount).To(Equal(int32(1)))
 
 		By("Verifying requeue is set")
 		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
@@ -451,15 +464,13 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.RequeueAfter).NotTo(BeZero(), "should requeue on first failure")
 
-		By("Simulating exhausted retries by backdating the condition's LastTransitionTime")
+		By("Simulating exhausted retries via HandshakeRetryCount status field")
 		mcpServer := &mcpv1alpha1.MCPServer{}
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
 		Expect(readyCondition).NotTo(BeNil())
 		Expect(readyCondition.Reason).To(Equal(ReasonMCPEndpointUnavailable))
-		// Backdate to 20 minutes ago - well past the total backoff budget
-		readyCondition.LastTransitionTime = metav1.NewTime(time.Now().Add(-20 * time.Minute))
-		meta.SetStatusCondition(&mcpServer.Status.Conditions, *readyCondition)
+		mcpServer.Status.HandshakeRetryCount = int32(maxMCPHandshakeRetries)
 		Expect(k8sClient.Status().Update(ctx, mcpServer)).To(Succeed())
 
 		By("Reconciling after retries exhausted")
@@ -490,54 +501,101 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 		Expect(mcpHandshakeBackoff(100)).To(Equal(2 * time.Minute))
 	})
 
-	It("should count retries from condition timestamp", func() {
-		By("No existing condition returns 0")
-		Expect(mcpHandshakeRetryCount(nil)).To(Equal(0))
-
-		By("Condition with different reason returns 0")
-		conditions := []metav1.Condition{
-			{
-				Type:               ConditionTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             ReasonDeploymentUnavailable,
-				LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+	It("should increment HandshakeRetryCount on each failed handshake", func() {
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
+				return nil, fmt.Errorf("connection refused")
 			},
 		}
-		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(0))
 
-		By("Recently transitioned condition returns 0")
-		conditions = []metav1.Condition{
-			{
-				Type:               ConditionTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             ReasonMCPEndpointUnavailable,
-				LastTransitionTime: metav1.Now(),
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+		}
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("First handshake failure sets HandshakeRetryCount to 1")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		Expect(mcpServer.Status.HandshakeRetryCount).To(Equal(int32(1)))
+
+		By("Second handshake failure increments to 2")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		Expect(mcpServer.Status.HandshakeRetryCount).To(Equal(int32(2)))
+	})
+
+	It("should reset HandshakeRetryCount to 0 on successful handshake", func() {
+		failHandshake := true
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
+				if failHandshake {
+					return nil, fmt.Errorf("connection refused")
+				}
+				return &mcpv1alpha1.MCPServerInfo{Name: "test"}, nil
 			},
 		}
-		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(0))
 
-		By("Condition old enough for several retries returns correct count")
-		// After 75s (10+20+40=70s for 3 retries), count should be 3
-		conditions = []metav1.Condition{
-			{
-				Type:               ConditionTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             ReasonMCPEndpointUnavailable,
-				LastTransitionTime: metav1.NewTime(time.Now().Add(-75 * time.Second)),
-			},
-		}
-		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(3))
+		By("Initial reconciliation creates deployment")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
 
-		By("Very old condition returns max retries")
-		conditions = []metav1.Condition{
-			{
-				Type:               ConditionTypeReady,
-				Status:             metav1.ConditionFalse,
-				Reason:             ReasonMCPEndpointUnavailable,
-				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
-			},
+		By("Simulating deployment becoming available")
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name: resourceName, Namespace: "default",
+		}, deployment)).To(Succeed())
+		deployment.Status.Replicas = 1
+		deployment.Status.ReadyReplicas = 1
+		deployment.Status.Conditions = []appsv1.DeploymentCondition{
+			{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+			{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
 		}
-		Expect(mcpHandshakeRetryCount(conditions)).To(Equal(maxMCPHandshakeRetries))
+		Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+		By("Failed handshake sets retry count")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		Expect(mcpServer.Status.HandshakeRetryCount).To(Equal(int32(1)))
+
+		By("Successful handshake resets retry count to 0")
+		failHandshake = false
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		Expect(mcpServer.Status.HandshakeRetryCount).To(Equal(int32(0)))
 	})
 
 	It("should treat 401 Unauthorized as a reachable endpoint", func() {


### PR DESCRIPTION
The `mcpHandshakeRetryCount()` function estimated retries by computing elapsed time since the Ready condition's `LastTransitionTime`. This was fragile across controller restarts: if the controller was down for a long period, elapsed time grew while no retries actually happened, causing the controller to incorrectly exhaust the retry budget.

Add an explicit `HandshakeRetryCount` field to `MCPServerStatus` that is incremented on each failed MCP handshake and reset to 0 on success, spec change, or when reconciliation does not reach the handshake phase (deployment failure, service failure, validation failure). Delete the time-based estimation function.