### PR TITLE
fix(controller): return true on corrupted JSON in custom metadata change detection

### DIFF
--- a/internal/controller/custom_metadata.go
+++ b/internal/controller/custom_metadata.go
@@ -244,7 +244,7 @@ func deploymentLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv
 	vals, ok := deployment.Annotations[managedExtraLabels]
 	if ok {
 		if err := json.Unmarshal([]byte(vals), &currentLabels); err != nil {
-			return false
+			return true
 		}
 
 		if len(currentLabels) > 0 {
@@ -282,7 +282,7 @@ func deploymentAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *
 	vals, ok := deployment.Annotations[managedExtraAnnotations]
 	if ok {
 		if err := json.Unmarshal([]byte(vals), &currentAnnotations); err != nil {
-			return false
+			return true
 		}
 
 		if len(currentAnnotations) > 0 {
@@ -322,7 +322,7 @@ func serviceLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Serv
 	vals, ok := service.Annotations[managedExtraLabels]
 	if ok {
 		if err := json.Unmarshal([]byte(vals), &currentLabels); err != nil {
-			return false
+			return true
 		}
 
 		if len(currentLabels) > 0 {
@@ -357,7 +357,7 @@ func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1
 	vals, ok := service.Annotations[managedExtraAnnotations]
 	if ok {
 		if err := json.Unmarshal([]byte(vals), &currentAnnotations); err != nil {
-			return false
+			return true
 		}
 
 		if len(currentAnnotations) > 0 {

--- a/internal/controller/custom_metadata_test.go
+++ b/internal/controller/custom_metadata_test.go
@@ -781,6 +781,35 @@ func Test_deploymentLabelsChanged(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "corrupted JSON in managed labels annotation forces update",
+			args: &extraMetaArgs{
+				deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "webserver",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "not-valid-json",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									LabelKeyApp: "webserver",
+								},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -900,6 +929,35 @@ func Test_deploymentAnnotationsChanged(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "corrupted JSON in managed annotations annotation forces update",
+			args: &extraMetaArgs{
+				deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "webserver",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "not-valid-json",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									LabelKeyApp: "webserver",
+								},
+							},
+							Spec: corev1.PodSpec{},
+						},
+					},
+				},
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -985,6 +1043,25 @@ func Test_serviceLabelsChanged(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "corrupted JSON in managed labels annotation forces update",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "not-valid-json",
+						},
+					},
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -1064,6 +1141,25 @@ func Test_serviceAnnotationsChanged(t *testing.T) {
 						Annotations: map[string]string{
 							managedExtraAnnotations: "{\"department\":\"procurement\",\"env\": \"production\"}",
 							"department":            "procurement",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "corrupted JSON in managed annotations annotation forces update",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "not-valid-json",
 						},
 					},
 				},


### PR DESCRIPTION
The four `*Changed` functions (`deploymentLabelsChanged`, `deploymentAnnotationsChanged`, `serviceLabelsChanged` and `serviceAnnotationsChanged`) silently returned `false` when JSON unmarshal failed on the tracking annotation. This caused the controller to skip corrective updates when annotations contained corrupted JSON, leaving resources in an inconsistent state.

Return true instead to force a corrective update. The subsequent call to `applyCustomDeploymentMetadata/applyCustomServiceMetadata` already handles the unmarshal error properly and will surface it.