### PR TITLE
ci: declare contents: read on lint, test, test-e2e

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run on Ubuntu

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   test-e2e:
     name: Run on Ubuntu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run on Ubuntu


### PR DESCRIPTION
These three workflows came from the kubebuilder v4.11.1 scaffold and inherit the org default `GITHUB_TOKEN` scope. All three are read-only:

- `lint.yml` — `golangci/golangci-lint-action`.
- `test.yml` — `go test ./...`.
- `test-e2e.yml` — `kind` + `make test-e2e`.

Adding a top-level `permissions: contents: read` pins the token to read-only. YAML validated with `yaml.safe_load` on each file.