### PR TITLE
feat(api): add Replicas and ReadyReplicas fields to MCPServerStatus

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
@@ -45,6 +45,10 @@ type MCPServerStatusApplyConfiguration struct {
 	// failures for the current generation. Reset to 0 on success, spec change,
 	// or when reconciliation does not reach the handshake phase.
 	HandshakeRetryCount *int32 `json:"handshakeRetryCount,omitempty"`
+	// Replicas is the total number of desired pods targeted by the owned Deployment.
+	Replicas *int32 `json:"replicas,omitempty"`
+	// ReadyReplicas is the number of pods targeted by the owned Deployment with a Ready condition.
+	ReadyReplicas *int32 `json:"readyReplicas,omitempty"`
 	// Conditions represent the latest available observations of the MCPServer's state.
 	//
 	// Standard condition types:
@@ -119,6 +123,22 @@ func (b *MCPServerStatusApplyConfiguration) WithServerInfo(value *MCPServerInfoA
 // If called multiple times, the HandshakeRetryCount field is set to the value of the last call.
 func (b *MCPServerStatusApplyConfiguration) WithHandshakeRetryCount(value int32) *MCPServerStatusApplyConfiguration {
 	b.HandshakeRetryCount = &value
+	return b
+}
+
+// WithReplicas sets the Replicas field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Replicas field is set to the value of the last call.
+func (b *MCPServerStatusApplyConfiguration) WithReplicas(value int32) *MCPServerStatusApplyConfiguration {
+	b.Replicas = &value
+	return b
+}
+
+// WithReadyReplicas sets the ReadyReplicas field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ReadyReplicas field is set to the value of the last call.
+func (b *MCPServerStatusApplyConfiguration) WithReadyReplicas(value int32) *MCPServerStatusApplyConfiguration {
+	b.ReadyReplicas = &value
 	return b
 }
 

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -461,6 +461,14 @@ type MCPServerStatus struct {
 	// +optional
 	HandshakeRetryCount int32 `json:"handshakeRetryCount,omitempty"`
 
+	// Replicas is the total number of desired pods targeted by the owned Deployment.
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
+
+	// ReadyReplicas is the number of pods targeted by the owned Deployment with a Ready condition.
+	// +optional
+	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
+
 	// Conditions represent the latest available observations of the MCPServer's state.
 	//
 	// Standard condition types:

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -1670,6 +1670,16 @@ spec:
                   When observedGeneration matches metadata.generation, the status is up-to-date.
                 format: int64
                 type: integer
+              readyReplicas:
+                description: ReadyReplicas is the number of pods targeted by the owned
+                  Deployment with a Ready condition.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the total number of desired pods targeted
+                  by the owned Deployment.
+                format: int32
+                type: integer
               serverInfo:
                 description: |-
                   ServerInfo contains identity and capability information reported by the

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -248,6 +249,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			WithObservedGeneration(mcpServer.Generation).
 			WithServiceName(mcpServer.Name).
 			WithHandshakeRetryCount(0).
+			WithReplicas(mcpServer.Status.Replicas).
+			WithReadyReplicas(mcpServer.Status.ReadyReplicas).
 			WithConditions(
 				conditionToAC(acceptedCondition),
 				conditionToAC(readyCondition),
@@ -286,6 +289,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			WithDeploymentName(existingDeployment.Name).
 			WithServiceName(mcpServer.Name).
 			WithHandshakeRetryCount(0).
+			WithReplicas(ptr.Deref(existingDeployment.Spec.Replicas, 1)).
+			WithReadyReplicas(existingDeployment.Status.ReadyReplicas).
 			WithConditions(
 				conditionToAC(acceptedCondition),
 				conditionToAC(readyCondition),
@@ -346,6 +351,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		WithDeploymentName(existingDeployment.Name).
 		WithServiceName(mcpServer.Name).
 		WithHandshakeRetryCount(handshakeRetryCount).
+		WithReplicas(ptr.Deref(existingDeployment.Spec.Replicas, 1)).
+		WithReadyReplicas(existingDeployment.Status.ReadyReplicas).
 		WithAddress(acv1alpha1.MCPServerAddress().
 			WithURL(mcpURL)).
 		WithConditions(
@@ -452,6 +459,8 @@ func (r *MCPServerReconciler) reconcilePermanentValidationError(
 		WithObservedGeneration(mcpServer.Generation).
 		WithServiceName(mcpServer.Name).
 		WithHandshakeRetryCount(0).
+		WithReplicas(mcpServer.Status.Replicas).
+		WithReadyReplicas(mcpServer.Status.ReadyReplicas).
 		WithConditions(
 			conditionToAC(acceptedCondition),
 			conditionToAC(readyCondition),

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -751,6 +751,8 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 			Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+			Expect(mcpServer.Status.Replicas).To(Equal(int32(1)))
+			Expect(mcpServer.Status.ReadyReplicas).To(Equal(int32(1)))
 
 			By("Updating replicas to 3")
 			mcpServer.Spec.Runtime.Replicas = new(int32(3))
@@ -781,6 +783,10 @@ var _ = Describe("MCPServer Controller", func() {
 			// so Ready should remain True, not incorrectly flip to False
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 			Expect(readyCondition.Reason).To(Equal(ReasonAvailable))
+
+			By("Verifying Replicas and ReadyReplicas status fields")
+			Expect(mcpServer.Status.Replicas).To(Equal(int32(3)))
+			Expect(mcpServer.Status.ReadyReplicas).To(Equal(int32(1)))
 		})
 	})
 
@@ -849,6 +855,10 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(readyCondition.Reason).To(Equal(ReasonDeploymentUnavailable))
+
+			By("Verifying Replicas and ReadyReplicas reflect deployment state")
+			Expect(mcpServer.Status.Replicas).To(Equal(int32(1)))
+			Expect(mcpServer.Status.ReadyReplicas).To(Equal(int32(0)))
 		})
 
 		It("should NOT requeue when Deployment becomes available", func() {
@@ -1150,6 +1160,10 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(readyCondition).NotTo(BeNil())
 			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(readyCondition.Reason).To(Equal(ReasonConfigurationInvalid))
+
+			By("Verifying Replicas and ReadyReplicas are zero when no Deployment exists")
+			Expect(mcpServer.Status.Replicas).To(Equal(int32(0)))
+			Expect(mcpServer.Status.ReadyReplicas).To(Equal(int32(0)))
 		})
 
 		It("should skip validation when envFrom reference is optional", func() {


### PR DESCRIPTION
Add explicit status fields for programmatic observability of replica counts. Previously these were only available as text embedded in the Ready condition message string. The new fields align with Kubernetes Deployment status conventions.

Replicas reflects the desired pod count from the owned Deployment spec. ReadyReplicas reflects the actual ready pod count from Deployment status. Both fields are populated in all status update paths to prevent SSA with ForceOwnership from clearing them.