### PR TITLE
feat(controller): emit event when Deployment reconciliation fails

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -113,6 +113,8 @@ const (
 	eventActionMCPHandshakeFailed = "MCPHandshakeFailed"
 	// eventActionMCPHandshakeRetriesExhausted is the reporting action when handshake retries are exhausted.
 	eventActionMCPHandshakeRetriesExhausted = "MCPHandshakeRetriesExhausted"
+	// eventActionDeploymentReconcileFailed is the reporting action when Deployment reconciliation fails.
+	eventActionDeploymentReconcileFailed = "DeploymentReconcileFailed"
 
 	// requeueDelayMCPHandshake is the initial delay before requeuing when an MCP handshake fails.
 	requeueDelayMCPHandshake = 10 * time.Second
@@ -248,6 +250,10 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		recordCondition(mcpServer.Name, mcpServer.Namespace,
 			readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
+
+		if !duplicateDeploymentUnavailable(mcpServer.Status.Conditions, readyCondition.Message) {
+			r.emitDeploymentReconcileFailed(mcpServer, readyCondition.Message)
+		}
 
 		status := acv1alpha1.MCPServerStatus().
 			WithObservedGeneration(mcpServer.Generation).
@@ -501,6 +507,14 @@ func (r *MCPServerReconciler) emitServerReady(mcpServer *mcpv1alpha1.MCPServer) 
 		return
 	}
 	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, ReasonAvailable, eventActionServerReady, "MCPServer %s is ready; Ready=True", mcpServer.Name)
+}
+
+func (r *MCPServerReconciler) emitDeploymentReconcileFailed(mcpServer *mcpv1alpha1.MCPServer, message string) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, ReasonDeploymentUnavailable, eventActionDeploymentReconcileFailed,
+		"MCPServer %s: %s", mcpServer.Name, message)
 }
 
 func (r *MCPServerReconciler) emitMCPHandshakeFailed(mcpServer *mcpv1alpha1.MCPServer, message string) {

--- a/internal/controller/mcpserver_controller_conditions.go
+++ b/internal/controller/mcpserver_controller_conditions.go
@@ -290,3 +290,9 @@ func duplicateHandshakeUnavailable(conditions []metav1.Condition, message string
 	return prevReady != nil && prevReady.Status == metav1.ConditionFalse &&
 		prevReady.Reason == ReasonMCPEndpointUnavailable && prevReady.Message == message
 }
+
+func duplicateDeploymentUnavailable(conditions []metav1.Condition, message string) bool {
+	prevReady := meta.FindStatusCondition(conditions, ConditionTypeReady)
+	return prevReady != nil && prevReady.Status == metav1.ConditionFalse &&
+		prevReady.Reason == ReasonDeploymentUnavailable && prevReady.Message == message
+}

--- a/internal/controller/mcpserver_controller_conditions_test.go
+++ b/internal/controller/mcpserver_controller_conditions_test.go
@@ -687,4 +687,18 @@ var _ = Describe("status condition helpers", func() {
 			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonMCPEndpointUnavailable, Message: msg},
 		}, msg)).To(BeTrue())
 	})
+
+	It("duplicateDeploymentUnavailable returns true only for matching Ready=False DeploymentUnavailable message", func() {
+		msg := "Failed to reconcile Deployment: simulated failure"
+		Expect(duplicateDeploymentUnavailable(nil, msg)).To(BeFalse())
+		Expect(duplicateDeploymentUnavailable([]metav1.Condition{
+			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonMCPEndpointUnavailable, Message: msg},
+		}, msg)).To(BeFalse())
+		Expect(duplicateDeploymentUnavailable([]metav1.Condition{
+			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonDeploymentUnavailable, Message: "other"},
+		}, msg)).To(BeFalse())
+		Expect(duplicateDeploymentUnavailable([]metav1.Condition{
+			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonDeploymentUnavailable, Message: msg},
+		}, msg)).To(BeTrue())
+	})
 })

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -1140,5 +1142,99 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port.IntVal).To(Equal(int32(3000)))
 		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds).To(Equal(int32(15)))
 		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds).To(Equal(int32(20)))
+	})
+})
+
+var _ = Describe("MCPServer Controller - Deployment Reconcile Events", func() {
+	const resourceName = "test-deployment-events"
+
+	ctx := context.Background()
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	BeforeEach(func() {
+		resource := newTestMCPServer(resourceName)
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("should emit a Warning DeploymentReconcileFailed event only when deployment error message changes", func() {
+		failMsg := "simulated deployment creation failure"
+		reconciler, fr := newReconcilerForTestWithFakeEvents(k8sClient, k8sClient.Scheme())
+
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return fmt.Errorf("%s", failMsg)
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+		reconciler.Client = interceptedClient
+
+		By("First deployment reconcile failure — Warning event emitted once")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).To(HaveOccurred())
+
+		var deploymentFailedEvent string
+		Eventually(func(g Gomega) {
+			for _, ev := range drainEvents(fr.Events) {
+				if strings.Contains(ev, corev1.EventTypeWarning) && strings.Contains(ev, ReasonDeploymentUnavailable) {
+					deploymentFailedEvent = ev
+					break
+				}
+			}
+			g.Expect(deploymentFailedEvent).NotTo(BeEmpty())
+			g.Expect(deploymentFailedEvent).To(ContainSubstring(resourceName))
+			g.Expect(deploymentFailedEvent).To(ContainSubstring("Failed to reconcile Deployment"))
+			g.Expect(deploymentFailedEvent).To(ContainSubstring(failMsg))
+		}).Should(Succeed())
+
+		By("Second reconcile with same error — no duplicate deployment failed event")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).To(HaveOccurred())
+		Consistently(fr.Events, 300*time.Millisecond, 20*time.Millisecond).ShouldNot(Receive())
+
+		By("Change error message — second Warning event emitted")
+		failMsg = "simulated deployment ownership failure"
+		interceptedClient = interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.Deployment); ok {
+					return fmt.Errorf("%s", failMsg)
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+		reconciler.Client = interceptedClient
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).To(HaveOccurred())
+
+		var secondDeploymentFailedEvent string
+		Eventually(func(g Gomega) {
+			for _, ev := range drainEvents(fr.Events) {
+				if strings.Contains(ev, corev1.EventTypeWarning) && strings.Contains(ev, ReasonDeploymentUnavailable) {
+					secondDeploymentFailedEvent = ev
+					break
+				}
+			}
+			g.Expect(secondDeploymentFailedEvent).NotTo(BeEmpty())
+			g.Expect(secondDeploymentFailedEvent).To(ContainSubstring(resourceName))
+			g.Expect(secondDeploymentFailedEvent).To(ContainSubstring(failMsg))
+			g.Expect(secondDeploymentFailedEvent).NotTo(Equal(deploymentFailedEvent))
+		}).Should(Succeed())
 	})
 })


### PR DESCRIPTION
Summary
Part of [#109](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/109) (Kubernetes event coverage).

Emits a Warning event when Deployment reconciliation fails, using the same conventions as configuration invalid and handshake events (MCPServer name in message, dedupe on unchanged Ready message).


Event | Type | Reason | Action | When
-- | -- | -- | -- | --
Deployment reconcile failed | Warning | DeploymentUnavailable | DeploymentReconcileFailed | reconcileDeployment returns an error (ownership conflict, API failure, etc.)



<img width="3456" height="1708" alt="image" src="https://github.com/user-attachments/assets/2fffc880-b5db-4e30-b2d5-c2eb3d4135a0" />
