### PR TITLE
fix(controller): apply ExtraLabels/ExtraAnnotations on initial resource creation

### DIFF
--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -59,6 +59,9 @@ func (r *MCPServerReconciler) reconcileDeployment(
 	err = r.Get(ctx, client.ObjectKey{Name: deployment.Name, Namespace: deployment.Namespace}, existingDeployment)
 	if err != nil && apierrors.IsNotFound(err) {
 		logger.Info("Creating Deployment", "name", deployment.Name)
+		if err := applyCustomDeploymentMetadata(mcpServer, deployment); err != nil {
+			return nil, fmt.Errorf("applying custom metadata failed; %w", err)
+		}
 		if err := r.Create(ctx, deployment); err != nil {
 			logger.Error(err, "Failed to create Deployment")
 			return nil, err

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -1141,4 +1141,56 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds).To(Equal(int32(15)))
 		Expect(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds).To(Equal(int32(20)))
 	})
+
+	It("should apply ExtraLabels and ExtraAnnotations on initial Deployment creation", func() {
+		mcpServer := newTestMCPServer("test-extra-metadata-create")
+		mcpServer.Spec.ExtraLabels = map[string]string{
+			"team": "platform",
+			"env":  "staging",
+		}
+		mcpServer.Spec.ExtraAnnotations = map[string]string{
+			"example.com/owner": "team-a",
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-extra-metadata-create", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		deployment, err := reconciler.reconcileDeployment(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment).NotTo(BeNil())
+
+		createdDeployment := &appsv1.Deployment{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-extra-metadata-create",
+			Namespace: "default",
+		}, createdDeployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying ExtraLabels on Deployment metadata")
+		Expect(createdDeployment.Labels).To(HaveKeyWithValue("team", "platform"))
+		Expect(createdDeployment.Labels).To(HaveKeyWithValue("env", "staging"))
+
+		By("Verifying ExtraLabels on PodTemplate metadata")
+		Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue("team", "platform"))
+		Expect(createdDeployment.Spec.Template.Labels).To(HaveKeyWithValue("env", "staging"))
+
+		By("Verifying ExtraAnnotations on Deployment metadata")
+		Expect(createdDeployment.Annotations).To(HaveKeyWithValue("example.com/owner", "team-a"))
+
+		By("Verifying ExtraAnnotations on PodTemplate metadata")
+		Expect(createdDeployment.Spec.Template.Annotations).To(HaveKeyWithValue("example.com/owner", "team-a"))
+
+		By("Verifying tracking annotations are set")
+		Expect(createdDeployment.Annotations).To(HaveKey(managedExtraLabels))
+		Expect(createdDeployment.Annotations).To(HaveKey(managedExtraAnnotations))
+	})
 })

--- a/internal/controller/mcpserver_controller_service.go
+++ b/internal/controller/mcpserver_controller_service.go
@@ -49,6 +49,9 @@ func (r *MCPServerReconciler) reconcileService(
 	err := r.Get(ctx, client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, existingService)
 	if err != nil && apierrors.IsNotFound(err) {
 		logger.Info("Creating Service", "name", service.Name)
+		if err := applyCustomServiceMetadata(mcpServer, service); err != nil {
+			return fmt.Errorf("applying custom metadata failed; %w", err)
+		}
 		if err := r.Create(ctx, service); err != nil {
 			logger.Error(err, "Failed to create Service")
 			return err

--- a/internal/controller/mcpserver_controller_service_test.go
+++ b/internal/controller/mcpserver_controller_service_test.go
@@ -634,3 +634,51 @@ var _ = Describe("MCPServer Controller - Server-Side Apply for Status", func() {
 		Expect(patchCalled).To(BeFalse(), "status should not use SubResourcePatch")
 	})
 })
+
+var _ = Describe("MCPServer Controller - Service ExtraLabels/ExtraAnnotations on creation", func() {
+	ctx := context.Background()
+
+	It("should apply ExtraLabels and ExtraAnnotations on initial Service creation", func() {
+		mcpServer := newTestMCPServer("test-svc-extra-metadata")
+		mcpServer.Spec.ExtraLabels = map[string]string{
+			"team": "platform",
+			"env":  "staging",
+		}
+		mcpServer.Spec.ExtraAnnotations = map[string]string{
+			"example.com/owner": "team-a",
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-svc-extra-metadata", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		err := reconciler.reconcileService(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		createdService := &corev1.Service{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-svc-extra-metadata",
+			Namespace: "default",
+		}, createdService)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying ExtraLabels on Service metadata")
+		Expect(createdService.Labels).To(HaveKeyWithValue("team", "platform"))
+		Expect(createdService.Labels).To(HaveKeyWithValue("env", "staging"))
+
+		By("Verifying ExtraAnnotations on Service metadata")
+		Expect(createdService.Annotations).To(HaveKeyWithValue("example.com/owner", "team-a"))
+
+		By("Verifying tracking annotations are set")
+		Expect(createdService.Annotations).To(HaveKey(managedExtraLabels))
+		Expect(createdService.Annotations).To(HaveKey(managedExtraAnnotations))
+	})
+})


### PR DESCRIPTION
`ExtraLabels` and `ExtraAnnotations` were only applied during the update path, requiring an extra reconciliation cycle after initial creation.
This PR addresses it by setting it on the create of the Deployment/Service already