### PR TITLE
fix(mcp): don't leak mcp connections

### DIFF
--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -116,6 +116,9 @@ func (r *MCPServerReconciler) verifyMCPEndpoint(ctx context.Context, url string)
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = session.Close()
+	}()
 
 	return extractServerInfo(session.InitializeResult()), nil
 }


### PR DESCRIPTION
We currently leak the client connections from the handshake (never close them).