### PR TITLE
fix(rbac): controller needs watch on pods to create informer

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -180,9 +180,10 @@ func main() {
 	}
 
 	if err := (&controller.MCPServerReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("mcpserver-controller"),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorder("mcpserver-controller"),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MCPServer")
 		os.Exit(1)

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -154,6 +154,7 @@ type MCPServerReconciler struct {
 	Scheme    *runtime.Scheme
 	Recorder  events.EventRecorder
 	MCPDialer func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) // nil = use real MCP handshake
+	APIReader client.Reader
 }
 
 // +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/mcpserver_controller_conditions.go
+++ b/internal/controller/mcpserver_controller_conditions.go
@@ -111,7 +111,7 @@ func (r *MCPServerReconciler) getPodFailureMessage(
 	}
 
 	podList := &corev1.PodList{}
-	if err := r.List(ctx, podList,
+	if err := r.APIReader.List(ctx, podList,
 		client.InNamespace(deployment.Namespace),
 		client.MatchingLabelsSelector{Selector: selector},
 	); err != nil {

--- a/internal/controller/mcpserver_controller_conditions_test.go
+++ b/internal/controller/mcpserver_controller_conditions_test.go
@@ -372,7 +372,7 @@ var _ = Describe("reconcileReadyCondition", func() {
 			Status: metav1.ConditionTrue,
 			Reason: ReasonValid,
 		}
-		reconciler = &MCPServerReconciler{Client: k8sClient}
+		reconciler = &MCPServerReconciler{Client: k8sClient, APIReader: k8sClient}
 	})
 
 	It("should return Initializing when deployment has no conditions and no ready replicas", func() {

--- a/internal/controller/mcpserver_controller_confighash_test.go
+++ b/internal/controller/mcpserver_controller_confighash_test.go
@@ -69,8 +69,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should not set config-hash annotation on deployment", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -145,8 +146,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should set config-hash annotation on deployment", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -223,8 +225,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should set config-hash annotation on deployment", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -297,8 +300,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should update the config-hash annotation when ConfigMap data changes", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			// First reconcile
@@ -396,8 +400,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should update the config-hash annotation when Secret data changes", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			// First reconcile
@@ -496,8 +501,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should produce the same hash on consecutive reconciles with unchanged data", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			// First reconcile
@@ -539,8 +545,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 			// config before reaching deployment creation, and a missing
 			// ConfigMap causes the MCPServer to be marked Invalid.
 			reconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -626,8 +633,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should set config-hash annotation on deployment", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -723,8 +731,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should set a single config-hash and update when ConfigMap changes", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -821,8 +830,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should set config-hash and update when BinaryData changes", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -918,8 +928,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should preserve external annotations when no spec changes occur", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			// Initial reconcile
@@ -1014,8 +1025,9 @@ var _ = Describe("MCPServer Controller - Config Hash", func() {
 
 		It("should remove the config-hash annotation when refs are removed", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			// Initial reconcile with refs

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -68,8 +68,9 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		deployment, err := reconciler.reconcileDeployment(ctx, mcpServer)
@@ -83,8 +84,9 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := reconciler.reconcileDeployment(ctx, mcpServer)
@@ -173,8 +175,9 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 			Build()
 
 		reconciler := &MCPServerReconciler{
-			Client: fakeClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    fakeClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling should not panic and should restore the containers")
@@ -224,8 +227,9 @@ var _ = Describe("MCPServer Controller - Deployment Reconciliation Failures", fu
 		})
 
 		deploymentFailureReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling with deployment creation failure")
@@ -255,8 +259,9 @@ var _ = Describe("MCPServer Controller - Deployment Reconciliation Failures", fu
 	It("should update status with DeploymentUnavailable when deployment update fails", func() {
 		By("Initial reconcile to create resources")
 		initialReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: typeNamespacedName,
@@ -284,8 +289,9 @@ var _ = Describe("MCPServer Controller - Deployment Reconciliation Failures", fu
 		})
 
 		deploymentFailureReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Updating MCPServer spec to trigger deployment reconciliation")
@@ -376,8 +382,9 @@ var _ = Describe("MCPServer Controller - Transient Validation Errors", func() {
 		})
 
 		transientReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling with transient ConfigMap validation failure")
@@ -412,8 +419,9 @@ var _ = Describe("MCPServer Controller - Transient Validation Errors", func() {
 		Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
 
 		initialReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: typeNamespacedName,
@@ -448,8 +456,9 @@ var _ = Describe("MCPServer Controller - Transient Validation Errors", func() {
 		})
 
 		transientReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling with transient failure")
@@ -506,8 +515,9 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 
 	It("should create deployment with resources", func() {
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -532,8 +542,9 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 
 	It("should update deployment when resources change", func() {
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling to create the initial deployment with resources")
@@ -584,8 +595,9 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 
 	It("should update deployment when resources are removed", func() {
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling to create the initial deployment with resources")
@@ -640,8 +652,9 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -677,8 +690,9 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -716,8 +730,9 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -756,8 +771,9 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -824,8 +840,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 
 	It("should create deployment with health probes", func() {
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -859,8 +876,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 
 	It("should update deployment when probes change", func() {
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling to create the initial deployment with probes")
@@ -928,8 +946,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 
 	It("should update deployment when probes are removed", func() {
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling to create the initial deployment with probes")
@@ -991,8 +1010,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1033,8 +1053,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1064,8 +1085,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1100,8 +1122,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1190,8 +1213,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		}()
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1232,8 +1256,9 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		}()
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		deployment, err := reconciler.reconcileDeployment(ctx, mcpServer)

--- a/internal/controller/mcpserver_controller_errors_test.go
+++ b/internal/controller/mcpserver_controller_errors_test.go
@@ -76,8 +76,9 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 		It("should recover from Failed to Pending when missing ConfigMap is created", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			By("First reconcile fails due to missing ConfigMap")
@@ -168,8 +169,9 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 		It("should recover from Failed to Pending when missing Secret is created", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			By("First reconcile fails due to missing Secret")
@@ -264,8 +266,9 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 		It("should recover from Failed to Pending when missing storage ConfigMap is created", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			By("First reconcile fails due to missing storage ConfigMap")
@@ -356,8 +359,9 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 		It("should recover from Failed to Pending when missing env valueFrom ConfigMap is created", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			By("First reconcile fails due to missing ConfigMap")
@@ -452,8 +456,9 @@ var _ = Describe("MCPServer Controller - Error Recovery", func() {
 
 		It("should recover from Failed to Pending when missing env valueFrom Secret is created", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			By("First reconcile fails due to missing Secret")
@@ -545,8 +550,9 @@ var _ = Describe("MCPServer Controller - Optimistic Locking Conflicts", func() {
 	It("should return conflict error when deployment update encounters optimistic locking conflict", func() {
 		By("Initial reconcile to create resources")
 		initialReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: typeNamespacedName,
@@ -579,8 +585,9 @@ var _ = Describe("MCPServer Controller - Optimistic Locking Conflicts", func() {
 		})
 
 		conflictReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling with conflict interceptor")
@@ -595,8 +602,9 @@ var _ = Describe("MCPServer Controller - Optimistic Locking Conflicts", func() {
 	It("should succeed on retry after conflict is resolved", func() {
 		By("Initial reconcile to create resources")
 		initialReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: typeNamespacedName,
@@ -631,8 +639,9 @@ var _ = Describe("MCPServer Controller - Optimistic Locking Conflicts", func() {
 		})
 
 		conflictReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("First reconcile fails with conflict")
@@ -659,8 +668,9 @@ var _ = Describe("MCPServer Controller - Optimistic Locking Conflicts", func() {
 	It("should return conflict error when service update encounters optimistic locking conflict", func() {
 		By("Initial reconcile to create resources")
 		initialReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: typeNamespacedName,
@@ -693,8 +703,9 @@ var _ = Describe("MCPServer Controller - Optimistic Locking Conflicts", func() {
 		})
 
 		conflictReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling with conflict interceptor")

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -92,6 +92,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return nil, fmt.Errorf("connection refused")
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -144,6 +145,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return nil, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -193,6 +195,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 				dialerCalled = true
 				return nil, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -240,6 +243,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 				dialerCalled = true
 				return nil, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Setting replicas to 0")
@@ -278,6 +282,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return nil, fmt.Errorf("MCP protocol error")
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -326,6 +331,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 					ProtocolVersion: "2025-03-26",
 				}, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -595,6 +601,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 				receivedCtx = ctx
 				return nil, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -636,6 +643,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return nil, fmt.Errorf("connection refused")
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -709,6 +717,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return nil, fmt.Errorf("connection refused")
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -759,6 +768,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 				}
 				return &mcpv1alpha1.MCPServerInfo{Name: "test"}, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -806,6 +816,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return nil, fmt.Errorf("POST %s: Unauthorized", url)
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Creating deployment and marking it available")
@@ -860,6 +871,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 					},
 				}, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -915,6 +927,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 					ProtocolVersion: "2025-06-18",
 				}, nil
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Initial reconciliation creates deployment")
@@ -967,6 +980,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 			MCPDialer: func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return nil, fmt.Errorf("POST %s: Forbidden", url)
 			},
+			APIReader: k8sClient,
 		}
 
 		By("Creating deployment and marking it available")

--- a/internal/controller/mcpserver_controller_helpers_test.go
+++ b/internal/controller/mcpserver_controller_helpers_test.go
@@ -145,7 +145,7 @@ var _ = Describe("findMCPServersForResource", func() {
 			WithIndex(&mcpv1alpha1.MCPServer{}, configMapIndexKey, extractConfigMapNames).
 			Build()
 
-		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme()}
+		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme(), APIReader: fakeClient}
 		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-config", Namespace: "default"},
 		}
@@ -189,7 +189,7 @@ var _ = Describe("findMCPServersForResource", func() {
 			WithIndex(&mcpv1alpha1.MCPServer{}, secretIndexKey, extractSecretNames).
 			Build()
 
-		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme()}
+		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme(), APIReader: fakeClient}
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
 		}
@@ -207,7 +207,7 @@ var _ = Describe("findMCPServersForResource", func() {
 			WithIndex(&mcpv1alpha1.MCPServer{}, configMapIndexKey, extractConfigMapNames).
 			Build()
 
-		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme()}
+		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme(), APIReader: fakeClient}
 		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: "unused-config", Namespace: "default"},
 		}
@@ -221,7 +221,7 @@ var _ = Describe("findMCPServersForResource", func() {
 			WithScheme(k8sClient.Scheme()).
 			Build()
 
-		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme()}
+		r := &MCPServerReconciler{Client: fakeClient, Scheme: k8sClient.Scheme(), APIReader: fakeClient}
 
 		requests := r.findMCPServersForResource(
 			context.Background(),

--- a/internal/controller/mcpserver_controller_ownership_test.go
+++ b/internal/controller/mcpserver_controller_ownership_test.go
@@ -70,8 +70,9 @@ var _ = Describe("MCPServer Controller - Owned Resource Cleanup", func() {
 
 		It("should set controller owner reference on created Deployment", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -96,8 +97,9 @@ var _ = Describe("MCPServer Controller - Owned Resource Cleanup", func() {
 
 		It("should set controller owner reference on created Service", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -122,8 +124,9 @@ var _ = Describe("MCPServer Controller - Owned Resource Cleanup", func() {
 
 		It("should preserve owner references across reconciliation updates", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			By("Reconciling to create initial resources")
@@ -228,8 +231,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 		It("should reject updating deployment when owned by another controller", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -309,8 +313,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 		It("should reject updating service when owned by another controller", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -387,8 +392,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 		It("should reject updating unowned deployment", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -466,8 +472,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 		It("should reject updating unowned service", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -564,8 +571,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 		It("should reject updating deployment with multiple non-controller owners", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -661,8 +669,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 		It("should reject updating service with multiple non-controller owners", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -725,8 +734,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 			By("Reconciling to create deployment")
 			reconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -843,8 +853,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 			By("Reconciling to create service")
 			reconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -942,8 +953,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 			By("Reconciling to create service")
 			reconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1025,8 +1037,9 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 			By("Reconciling to create deployment")
 			reconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,

--- a/internal/controller/mcpserver_controller_service_test.go
+++ b/internal/controller/mcpserver_controller_service_test.go
@@ -61,8 +61,9 @@ var _ = Describe("MCPServer Controller - Address URL", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -81,8 +82,9 @@ var _ = Describe("MCPServer Controller - Address URL", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -101,8 +103,9 @@ var _ = Describe("MCPServer Controller - Address URL", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -121,8 +124,9 @@ var _ = Describe("MCPServer Controller - Address URL", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -167,8 +171,9 @@ var _ = Describe("MCPServer Controller - Service Update", func() {
 			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -235,8 +240,9 @@ var _ = Describe("MCPServer Controller - reconcileService", func() {
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		err := reconciler.reconcileService(ctx, mcpServer)
@@ -257,8 +263,9 @@ var _ = Describe("MCPServer Controller - reconcileService", func() {
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		Expect(reconciler.reconcileService(ctx, mcpServer)).To(Succeed())
@@ -293,8 +300,9 @@ var _ = Describe("MCPServer Controller - Stateless Service", func() {
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		err := reconciler.reconcileService(ctx, mcpServer)
@@ -316,8 +324,9 @@ var _ = Describe("MCPServer Controller - Stateless Service", func() {
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		err := reconciler.reconcileService(ctx, mcpServer)
@@ -340,8 +349,9 @@ var _ = Describe("MCPServer Controller - Stateless Service", func() {
 		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		err := reconciler.reconcileService(ctx, mcpServer)
@@ -361,8 +371,9 @@ var _ = Describe("MCPServer Controller - Stateless Service", func() {
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling to create the service with ClientIP affinity")
@@ -398,8 +409,9 @@ var _ = Describe("MCPServer Controller - Stateless Service", func() {
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling to create the service with no session affinity")
@@ -468,8 +480,9 @@ var _ = Describe("MCPServer Controller - Service Reconciliation Failures", func(
 		})
 
 		serviceFailureReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Reconciling with service creation failure")
@@ -501,8 +514,9 @@ var _ = Describe("MCPServer Controller - Service Reconciliation Failures", func(
 	It("should update status with ServiceUnavailable when service update fails", func() {
 		By("Initial reconcile to create resources")
 		initialReconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: typeNamespacedName,
@@ -530,8 +544,9 @@ var _ = Describe("MCPServer Controller - Service Reconciliation Failures", func(
 		})
 
 		serviceFailureReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		By("Updating MCPServer spec to trigger service reconciliation")
@@ -620,8 +635,9 @@ var _ = Describe("MCPServer Controller - Server-Side Apply for Status", func() {
 		})
 
 		controllerReconciler := &MCPServerReconciler{
-			Client: interceptedClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -656,8 +672,9 @@ var _ = Describe("MCPServer Controller - Service ExtraLabels/ExtraAnnotations on
 		}()
 
 		reconciler := &MCPServerReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
 		}
 
 		err := reconciler.reconcileService(ctx, mcpServer)

--- a/internal/controller/mcpserver_controller_storage_test.go
+++ b/internal/controller/mcpserver_controller_storage_test.go
@@ -95,8 +95,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should create deployment with ConfigMap volume and mount", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -179,8 +180,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should create deployment with Secret volume and mount", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -291,8 +293,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should create deployment with multiple volumes and mounts with correct names", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -390,8 +393,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should create deployment with readOnly set to false", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -451,8 +455,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should create deployment with EmptyDir volume and mount", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -521,8 +526,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should create deployment with EmptyDir volume with sizeLimit", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -608,8 +614,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should create deployment with both ConfigMap and EmptyDir volumes", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -688,8 +695,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should set Accepted=False with 'ConfigMap not found' message", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -745,8 +753,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should set Accepted=False with 'Secret not found' message", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -806,8 +815,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should succeed reconciliation even when ConfigMap doesn't exist", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -869,8 +879,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should succeed reconciliation even when Secret doesn't exist", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -932,8 +943,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should set Accepted=False when ConfigMap name is empty", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -989,8 +1001,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 		It("should set Accepted=False when Secret name is empty", func() {
 			controllerReconciler := &MCPServerReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1022,8 +1035,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1062,8 +1076,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1102,8 +1117,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1145,8 +1161,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1188,8 +1205,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			optional := true
@@ -1228,8 +1246,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			optional := true
@@ -1268,8 +1287,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1318,8 +1338,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				}).Build()
 
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1379,8 +1400,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				}).Build()
 
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1437,8 +1459,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				}).Build()
 
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1493,8 +1516,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				}).Build()
 
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1553,8 +1577,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				}).Build()
 
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1613,8 +1638,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				}).Build()
 
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1673,8 +1699,9 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 				}).Build()
 
 			reconciler := &MCPServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:    fakeClient,
+				Scheme:    scheme,
+				APIReader: k8sClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -55,6 +55,7 @@ func newReconcilerForTestWithFakeEvents(cli client.Client, sch *runtime.Scheme) 
 		Scheme:    sch,
 		Recorder:  fr,
 		MCPDialer: testMCPDialerNoop,
+		APIReader: cli,
 	}, fr
 }
 

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -75,7 +75,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), APIReader: k8sClient}
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -122,7 +122,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), APIReader: k8sClient}
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -158,7 +158,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), APIReader: k8sClient}
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -200,7 +200,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
-		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		reconciler := &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), APIReader: k8sClient}
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -250,7 +250,7 @@ var _ = Describe("MCPServer Metrics", func() {
 			},
 		})
 
-		reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme()}
+		reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme(), APIReader: k8sClient}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: depFailNN})
 		Expect(err).To(HaveOccurred())
 
@@ -299,7 +299,7 @@ var _ = Describe("MCPServer Metrics", func() {
 			},
 		})
 
-		reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme()}
+		reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme(), APIReader: k8sClient}
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: svcFailNN})
 		Expect(err).To(HaveOccurred())
 


### PR DESCRIPTION
With the improved pod error informing, we now list pods, which goes through the controller runtime's cached client that sets up a watch. We need this rbac permission to prevent errors