### PR TITLE
fix(controller): filter reserved annotation keys from ExtraAnnotations

### DIFF
--- a/internal/controller/custom_metadata.go
+++ b/internal/controller/custom_metadata.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,6 +21,8 @@ var reservedLabelKeys = map[string]bool{
 	LabelKeyMCPServer: true,
 }
 
+const reservedAnnotationPrefix = "mcp.x-k8s.io/"
+
 func filterReservedKeys(m map[string]string) map[string]string {
 	if len(m) == 0 {
 		return m
@@ -27,6 +30,20 @@ func filterReservedKeys(m map[string]string) map[string]string {
 	filtered := make(map[string]string, len(m))
 	for k, v := range m {
 		if reservedLabelKeys[k] {
+			continue
+		}
+		filtered[k] = v
+	}
+	return filtered
+}
+
+func filterReservedAnnotationKeys(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return m
+	}
+	filtered := make(map[string]string, len(m))
+	for k, v := range m {
+		if strings.HasPrefix(k, reservedAnnotationPrefix) {
 			continue
 		}
 		filtered[k] = v
@@ -73,6 +90,8 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		delete(deployment.Annotations, managedExtraLabels)
 	}
 
+	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
+
 	currentAnnotations := make(map[string]string)
 	if managedAnnotations, ok := deployment.Annotations[managedExtraAnnotations]; ok {
 		if err := json.Unmarshal([]byte(managedAnnotations), &currentAnnotations); err != nil {
@@ -80,7 +99,7 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		}
 	}
 
-	if !maps.Equal(mcpServer.Spec.ExtraAnnotations, currentAnnotations) {
+	if !maps.Equal(effectiveAnnotations, currentAnnotations) {
 		for key := range currentAnnotations {
 			delete(deployment.Annotations, key)
 			delete(deployment.Spec.Template.Annotations, key)
@@ -89,7 +108,7 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 	}
 
 	if len(effectiveLabels) == 0 &&
-		len(mcpServer.Spec.ExtraAnnotations) == 0 &&
+		len(effectiveAnnotations) == 0 &&
 		len(currentLabels) == 0 &&
 		len(currentAnnotations) == 0 {
 		return nil
@@ -116,13 +135,13 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		}
 	}
 
-	if mcpServer.Spec.ExtraAnnotations != nil {
+	if len(effectiveAnnotations) > 0 {
 		if deployment.Annotations == nil {
 			deployment.Annotations = make(map[string]string)
 		}
 		if err := mergeMaps(
 			deployment.Annotations,
-			mcpServer.Spec.ExtraAnnotations,
+			effectiveAnnotations,
 		); err != nil {
 			return fmt.Errorf("appending deployment annotations failed; %w", err)
 		}
@@ -131,7 +150,7 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		}
 		if err := mergeMaps(
 			deployment.Spec.Template.Annotations,
-			mcpServer.Spec.ExtraAnnotations,
+			effectiveAnnotations,
 		); err != nil {
 			return fmt.Errorf("appending pod template annotations failed; %w", err)
 		}
@@ -149,7 +168,7 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		deployment.Annotations[managedExtraLabels] = string(extraLabelsByte)
 	}
 
-	extraAnnotationsByte, err := json.Marshal(mcpServer.Spec.ExtraAnnotations)
+	extraAnnotationsByte, err := json.Marshal(effectiveAnnotations)
 	if err != nil {
 		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
 	}
@@ -177,6 +196,8 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 		delete(service.Annotations, managedExtraLabels)
 	}
 
+	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
+
 	currentAnnotations := make(map[string]string)
 	if managedAnnotations, ok := service.Annotations[managedExtraAnnotations]; ok {
 		if err := json.Unmarshal([]byte(managedAnnotations), &currentAnnotations); err != nil {
@@ -184,7 +205,7 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 		}
 	}
 
-	if !maps.Equal(mcpServer.Spec.ExtraAnnotations, currentAnnotations) {
+	if !maps.Equal(effectiveAnnotations, currentAnnotations) {
 		for key := range currentAnnotations {
 			delete(service.Annotations, key)
 		}
@@ -192,7 +213,7 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 	}
 
 	if len(effectiveLabels) == 0 &&
-		len(mcpServer.Spec.ExtraAnnotations) == 0 &&
+		len(effectiveAnnotations) == 0 &&
 		len(currentLabels) == 0 &&
 		len(currentAnnotations) == 0 {
 		return nil
@@ -212,8 +233,8 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 		}
 	}
 
-	if mcpServer.Spec.ExtraAnnotations != nil {
-		if err := mergeMaps(service.Annotations, mcpServer.Spec.ExtraAnnotations); err != nil {
+	if len(effectiveAnnotations) > 0 {
+		if err := mergeMaps(service.Annotations, effectiveAnnotations); err != nil {
 			return fmt.Errorf("appending service annotations failed; %w", err)
 		}
 	}
@@ -226,7 +247,7 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 		service.Annotations[managedExtraLabels] = string(extraLabelsByte)
 	}
 
-	extraAnnotationsByte, err := json.Marshal(mcpServer.Spec.ExtraAnnotations)
+	extraAnnotationsByte, err := json.Marshal(effectiveAnnotations)
 	if err != nil {
 		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
 	}
@@ -278,6 +299,8 @@ func deploymentLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv
 }
 
 func deploymentAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv1.Deployment) bool {
+	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
+
 	var currentAnnotations map[string]string
 	vals, ok := deployment.Annotations[managedExtraAnnotations]
 	if ok {
@@ -286,12 +309,12 @@ func deploymentAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *
 		}
 
 		if len(currentAnnotations) > 0 {
-			if len(mcpServer.Spec.ExtraAnnotations) != 0 &&
-				!maps.Equal(currentAnnotations, mcpServer.Spec.ExtraAnnotations) {
+			if len(effectiveAnnotations) != 0 &&
+				!maps.Equal(currentAnnotations, effectiveAnnotations) {
 				return true
 			}
 
-			if len(mcpServer.Spec.ExtraAnnotations) == 0 {
+			if len(effectiveAnnotations) == 0 {
 				return true
 			}
 
@@ -308,7 +331,7 @@ func deploymentAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *
 	}
 
 	if len(currentAnnotations) == 0 &&
-		len(mcpServer.Spec.ExtraAnnotations) != 0 {
+		len(effectiveAnnotations) != 0 {
 		return true
 	}
 
@@ -353,6 +376,8 @@ func serviceLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Serv
 }
 
 func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Service) bool {
+	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
+
 	var currentAnnotations map[string]string
 	vals, ok := service.Annotations[managedExtraAnnotations]
 	if ok {
@@ -361,12 +386,12 @@ func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1
 		}
 
 		if len(currentAnnotations) > 0 {
-			if len(mcpServer.Spec.ExtraAnnotations) != 0 &&
-				!maps.Equal(currentAnnotations, mcpServer.Spec.ExtraAnnotations) {
+			if len(effectiveAnnotations) != 0 &&
+				!maps.Equal(currentAnnotations, effectiveAnnotations) {
 				return true
 			}
 
-			if len(mcpServer.Spec.ExtraAnnotations) == 0 {
+			if len(effectiveAnnotations) == 0 {
 				return true
 			}
 
@@ -381,7 +406,7 @@ func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1
 	}
 
 	if len(currentAnnotations) == 0 &&
-		len(mcpServer.Spec.ExtraAnnotations) != 0 {
+		len(effectiveAnnotations) != 0 {
 		return true
 	}
 

--- a/internal/controller/custom_metadata.go
+++ b/internal/controller/custom_metadata.go
@@ -51,24 +51,13 @@ func filterReservedAnnotationKeys(m map[string]string) map[string]string {
 	return filtered
 }
 
-// mergeMaps is a custom function aimed at merging maps
-// It will merge maps with exception of attempts to override
-// application defined map keys
+// mergeMaps merges all entries from src into dst.
+// Callers are responsible for filtering reserved keys before calling.
 func mergeMaps(dst, src map[string]string) error {
 	if dst == nil {
 		return ErrNilMap
 	}
-	if len(src) == 0 {
-		return nil
-	}
-
-	for k, v := range src {
-		if reservedLabelKeys[k] {
-			continue
-		}
-
-		dst[k] = v
-	}
+	maps.Copy(dst, src)
 	return nil
 }
 
@@ -120,7 +109,7 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		}
 		if err := mergeMaps(
 			deployment.Labels,
-			mcpServer.Spec.ExtraLabels,
+			effectiveLabels,
 		); err != nil {
 			return fmt.Errorf("appending deployment labels failed; %w", err)
 		}
@@ -129,7 +118,7 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		}
 		if err := mergeMaps(
 			deployment.Spec.Template.Labels,
-			mcpServer.Spec.ExtraLabels,
+			effectiveLabels,
 		); err != nil {
 			return fmt.Errorf("appending pod template labels failed; %w", err)
 		}
@@ -228,7 +217,7 @@ func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev
 	}
 
 	if len(effectiveLabels) > 0 {
-		if err := mergeMaps(service.Labels, mcpServer.Spec.ExtraLabels); err != nil {
+		if err := mergeMaps(service.Labels, effectiveLabels); err != nil {
 			return fmt.Errorf("appending service labels failed; %w", err)
 		}
 	}

--- a/internal/controller/custom_metadata_test.go
+++ b/internal/controller/custom_metadata_test.go
@@ -55,7 +55,7 @@ func Test_mergeMaps(t *testing.T) {
 			},
 		},
 		{
-			name: "overwriting known app labels should fail",
+			name: "overwriting existing keys in dst",
 			args: struct {
 				dst map[string]string
 				src map[string]string
@@ -70,7 +70,7 @@ func Test_mergeMaps(t *testing.T) {
 			},
 			want: want{
 				m: map[string]string{
-					LabelKeyApp: "web",
+					LabelKeyApp: "proxy",
 					"env":       "production",
 				},
 				wantErr: false,
@@ -132,7 +132,8 @@ func Test_mergeMaps(t *testing.T) {
 			},
 			want: want{
 				m: map[string]string{
-					"env": "production",
+					LabelKeyApp: "web",
+					"env":       "production",
 				},
 				wantErr: false,
 			},
@@ -192,7 +193,7 @@ func Test_filterReservedAnnotationKeys(t *testing.T) {
 		{
 			name: "filter config-hash annotation",
 			in: map[string]string{
-				"department":          "finance",
+				"department":               "finance",
 				"mcp.x-k8s.io/config-hash": "abc123",
 			},
 			want: map[string]string{"department": "finance"},
@@ -208,7 +209,7 @@ func Test_filterReservedAnnotationKeys(t *testing.T) {
 			name: "filter managed-extra-annotations annotation",
 			in: map[string]string{
 				"mcp.x-k8s.io/managed-extra-annotations": "{\"x\":\"y\"}",
-				"cost-center": "engineering",
+				"cost-center":                            "engineering",
 			},
 			want: map[string]string{"cost-center": "engineering"},
 		},
@@ -216,10 +217,10 @@ func Test_filterReservedAnnotationKeys(t *testing.T) {
 			name: "filter all mcp.x-k8s.io/ prefixed keys",
 			in: map[string]string{
 				"mcp.x-k8s.io/config-hash":               "abc",
-				"mcp.x-k8s.io/managed-extra-labels":       "{}",
-				"mcp.x-k8s.io/managed-extra-annotations":  "{}",
-				"mcp.x-k8s.io/some-future-annotation":     "val",
-				"safe-annotation": "ok",
+				"mcp.x-k8s.io/managed-extra-labels":      "{}",
+				"mcp.x-k8s.io/managed-extra-annotations": "{}",
+				"mcp.x-k8s.io/some-future-annotation":    "val",
+				"safe-annotation":                        "ok",
 			},
 			want: map[string]string{"safe-annotation": "ok"},
 		},
@@ -606,7 +607,7 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 				mcp: &mcpv1alpha1.MCPServer{
 					Spec: mcpv1alpha1.MCPServerSpec{
 						ExtraAnnotations: map[string]string{
-							"department":                              "finance",
+							"department":                             "finance",
 							"mcp.x-k8s.io/config-hash":               "malicious-hash",
 							"mcp.x-k8s.io/managed-extra-labels":      "malicious",
 							"mcp.x-k8s.io/managed-extra-annotations": "malicious",
@@ -1060,7 +1061,7 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 				mcp: &mcpv1alpha1.MCPServer{
 					Spec: mcpv1alpha1.MCPServerSpec{
 						ExtraAnnotations: map[string]string{
-							"cost-center":                             "engineering",
+							"cost-center":                            "engineering",
 							"mcp.x-k8s.io/config-hash":               "malicious-hash",
 							"mcp.x-k8s.io/managed-extra-labels":      "malicious",
 							"mcp.x-k8s.io/managed-extra-annotations": "malicious",

--- a/internal/controller/custom_metadata_test.go
+++ b/internal/controller/custom_metadata_test.go
@@ -168,6 +168,73 @@ func Test_mergeMaps(t *testing.T) {
 	}
 }
 
+func Test_filterReservedAnnotationKeys(t *testing.T) {
+	tt := []struct {
+		name string
+		in   map[string]string
+		want map[string]string
+	}{
+		{
+			name: "nil map",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty map",
+			in:   map[string]string{},
+			want: map[string]string{},
+		},
+		{
+			name: "no reserved keys",
+			in:   map[string]string{"department": "finance", "env": "prod"},
+			want: map[string]string{"department": "finance", "env": "prod"},
+		},
+		{
+			name: "filter config-hash annotation",
+			in: map[string]string{
+				"department":          "finance",
+				"mcp.x-k8s.io/config-hash": "abc123",
+			},
+			want: map[string]string{"department": "finance"},
+		},
+		{
+			name: "filter managed-extra-labels annotation",
+			in: map[string]string{
+				"mcp.x-k8s.io/managed-extra-labels": "{\"team\":\"platform\"}",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "filter managed-extra-annotations annotation",
+			in: map[string]string{
+				"mcp.x-k8s.io/managed-extra-annotations": "{\"x\":\"y\"}",
+				"cost-center": "engineering",
+			},
+			want: map[string]string{"cost-center": "engineering"},
+		},
+		{
+			name: "filter all mcp.x-k8s.io/ prefixed keys",
+			in: map[string]string{
+				"mcp.x-k8s.io/config-hash":               "abc",
+				"mcp.x-k8s.io/managed-extra-labels":       "{}",
+				"mcp.x-k8s.io/managed-extra-annotations":  "{}",
+				"mcp.x-k8s.io/some-future-annotation":     "val",
+				"safe-annotation": "ok",
+			},
+			want: map[string]string{"safe-annotation": "ok"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterReservedAnnotationKeys(tc.in)
+			if !maps.Equal(got, tc.want) {
+				t.Errorf("wanted %v but got %v", tc.want, got)
+			}
+		})
+	}
+}
+
 func Test_applyCustomDeploymentMetadata(t *testing.T) {
 	deployment := func() *appsv1.Deployment {
 		return &appsv1.Deployment{
@@ -527,6 +594,51 @@ func Test_applyCustomDeploymentMetadata(t *testing.T) {
 							},
 							Annotations: map[string]string{
 								"cost-center": "engineering",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "reserved annotation keys in ExtraAnnotations are filtered out",
+			args: extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraAnnotations: map[string]string{
+							"department":                              "finance",
+							"mcp.x-k8s.io/config-hash":               "malicious-hash",
+							"mcp.x-k8s.io/managed-extra-labels":      "malicious",
+							"mcp.x-k8s.io/managed-extra-annotations": "malicious",
+						},
+					},
+				},
+				deployment: deployment(),
+			},
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "web",
+					Labels: map[string]string{
+						LabelKeyApp: "web",
+					},
+					Annotations: map[string]string{
+						"department":                             "finance",
+						"mcp.x-k8s.io/managed-extra-annotations": "{\"department\":\"finance\"}",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							LabelKeyApp: "web",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								LabelKeyApp: "web",
+							},
+							Annotations: map[string]string{
+								"department": "finance",
 							},
 						},
 					},
@@ -938,6 +1050,39 @@ func Test_applyCustomServiceMetadata(t *testing.T) {
 					Annotations: map[string]string{
 						"department":                             "finance",
 						"mcp.x-k8s.io/managed-extra-annotations": "{\"department\":\"finance\"}",
+					},
+				},
+			},
+		},
+		{
+			name: "reserved annotation keys in ExtraAnnotations are filtered out",
+			args: extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraAnnotations: map[string]string{
+							"cost-center":                             "engineering",
+							"mcp.x-k8s.io/config-hash":               "malicious-hash",
+							"mcp.x-k8s.io/managed-extra-labels":      "malicious",
+							"mcp.x-k8s.io/managed-extra-annotations": "malicious",
+						},
+					},
+				},
+				service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "webserver",
+						},
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelKeyApp: "webserver",
+					},
+					Annotations: map[string]string{
+						"cost-center":                            "engineering",
+						"mcp.x-k8s.io/managed-extra-annotations": "{\"cost-center\":\"engineering\"}",
 					},
 				},
 			},


### PR DESCRIPTION
`ExtraAnnotations` with the `mcp.x-k8s.io/` prefix could overwrite operator-managed annotations:

- `mcp.x-k8s.io/config-hash` stored on the pod template to trigger rolling updates when ConfigMap/Secret data changes. Overwriting it could cause missed or spurious rolling updates.
- `mcp.x-k8s.io/managed-extra-labels` / `mcp.x-k8s.io/managed-extra-annotations` store JSON of currently applied custom metadata so the controller can detect drift and clean up removed keys. Overwriting them could cause the controller to fail to remove stale metadata or incorrectly delete valid entries.

This PR addresses it by filtering out any annotation key prefixed with `mcp.x-k8s.io/` before applying `ExtraAnnotations` to Deployments and Services (same as `ExtraLabels` already filters reserved label keys).

Additionally, `mergeMaps` is refactored to be a pure merge function, with all reserved key filtering moved to callers.