### PR TITLE
ci: add verify workflow for generated code

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,23 @@
+name: Verify
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-codegen:
+    name: Verify generated code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Verify generated code is up-to-date
+        run: make verify

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,16 @@ GOVULNCHECK_VERSION ?= v1.3.0
 govulncheck: ## Run govulncheck (https://go.dev/doc/security/vuln/) against the module.
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
+.PHONY: verify
+verify: manifests generate fmt ## Verify generated code and formatting are up-to-date.
+	@if [ -n "$$(git diff --name-only)" ]; then \
+		echo "ERROR: generated files are out of date. Run 'make manifests generate fmt' and commit the result."; \
+		git diff; \
+		exit 1; \
+	else \
+		echo "Generated code and formatting are up-to-date."; \
+	fi
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter
 	"$(GOLANGCI_LINT)" run

--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,9 @@ govulncheck: ## Run govulncheck (https://go.dev/doc/security/vuln/) against the 
 
 .PHONY: verify
 verify: manifests generate fmt ## Verify generated code and formatting are up-to-date.
-	@if [ -n "$$(git diff --name-only)" ]; then \
+	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "ERROR: generated files are out of date. Run 'make manifests generate fmt' and commit the result."; \
+		git status --porcelain; \
 		git diff; \
 		exit 1; \
 	else \


### PR DESCRIPTION
Currently there is no CI check that verifies generated code (CRDs, DeepCopy, RBAC, apply configurations) and formatting are up-to-date. This means a PR could be merged with stale generated files if a contributor forgets to run `make manifests generate fmt` after modifying the API types.

This PR addresses it and adds:
- A `make verify` target that runs `manifests`, `generate`, and `fmt`, then fails if the working tree is dirty (and prints the full diff for debugging)
- A `verify.yml` GitHub workflow that runs `make verify` on every PR.
