### PR TITLE
fix(controller): set API server defaults in desired Deployment spec

### DIFF
--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -235,22 +235,17 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 		container.Resources = *mcpServer.Spec.Runtime.Resources
 	}
 
-	// Apply health probes.
-	// User-specified probes are passed directly to the container spec without any
-	// transformation, providing full compatibility with the Kubernetes Probe API.
-	// This allows users to configure all probe types (httpGet, tcpSocket, exec, grpc)
-	// and all parameters (delays, periods, thresholds) using standard Kubernetes
-	// probe configuration.
+	// Apply health probes. Zero-valued timing fields are filled with Kubernetes
+	// API server defaults via withProbeDefaults so that DeepEqual comparisons in
+	// deploymentNeedsUpdate match the API-server-defaulted existing spec.
 	//
 	// When no readiness probe is specified, a default TCP socket probe is injected
-	// targeting the configured MCP port. This ensures that containers not listening
-	// on the expected port will not report as Ready. The controller-level MCP
-	// handshake provides the semantic protocol validation.
+	// targeting the configured MCP port.
 	if mcpServer.Spec.Runtime.Health.LivenessProbe != nil {
-		container.LivenessProbe = mcpServer.Spec.Runtime.Health.LivenessProbe
+		container.LivenessProbe = withProbeDefaults(mcpServer.Spec.Runtime.Health.LivenessProbe)
 	}
 	if mcpServer.Spec.Runtime.Health.ReadinessProbe != nil {
-		container.ReadinessProbe = mcpServer.Spec.Runtime.Health.ReadinessProbe
+		container.ReadinessProbe = withProbeDefaults(mcpServer.Spec.Runtime.Health.ReadinessProbe)
 	} else {
 		container.ReadinessProbe = defaultMCPReadinessProbe(mcpServer.Spec.Config.Port)
 	}
@@ -287,7 +282,14 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 	if mcpServer.Spec.Runtime.Security.ServiceAccountName != "" {
 		deployment.Spec.Template.Spec.ServiceAccountName = mcpServer.Spec.Runtime.Security.ServiceAccountName
 	}
-	deployment.Spec.Template.Spec.SecurityContext = mcpServer.Spec.Runtime.Security.PodSecurityContext
+	// Default to an empty PodSecurityContext so the desired spec matches the
+	// API server default. Without this, nil vs &PodSecurityContext{} causes
+	// deploymentNeedsUpdate to return true on every reconciliation.
+	if mcpServer.Spec.Runtime.Security.PodSecurityContext != nil {
+		deployment.Spec.Template.Spec.SecurityContext = mcpServer.Spec.Runtime.Security.PodSecurityContext
+	} else {
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	}
 
 	return deployment, nil
 }
@@ -368,11 +370,32 @@ func defaultContainerSecurityContext() *corev1.SecurityContext {
 // a GET probe would reject valid MCP servers that do not serve GET.
 // The controller-level MCP handshake provides the semantic protocol validation.
 func defaultMCPReadinessProbe(port int32) *corev1.Probe {
-	return &corev1.Probe{
+	return withProbeDefaults(&corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			TCPSocket: &corev1.TCPSocketAction{
 				Port: intstr.FromInt32(port),
 			},
 		},
+	})
+}
+
+// withProbeDefaults fills in zero-valued probe timing fields with the
+// Kubernetes API server defaults. Without this, DeepEqual in
+// deploymentNeedsUpdate flags a diff between the desired spec and the
+// API-server-defaulted existing spec on every reconciliation.
+func withProbeDefaults(probe *corev1.Probe) *corev1.Probe {
+	out := *probe
+	if out.FailureThreshold == 0 {
+		out.FailureThreshold = 3
 	}
+	if out.PeriodSeconds == 0 {
+		out.PeriodSeconds = 10
+	}
+	if out.SuccessThreshold == 0 {
+		out.SuccessThreshold = 1
+	}
+	if out.TimeoutSeconds == 0 {
+		out.TimeoutSeconds = 1
+	}
+	return &out
 }

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -1127,8 +1127,40 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		Expect(probe).NotTo(BeNil())
 		Expect(probe.TCPSocket).NotTo(BeNil())
 		Expect(probe.TCPSocket.Port.IntVal).To(Equal(int32(8080)))
-		Expect(probe.InitialDelaySeconds).To(BeZero(), "should use Kubernetes default")
-		Expect(probe.PeriodSeconds).To(BeZero(), "should use Kubernetes default")
+		Expect(probe.InitialDelaySeconds).To(BeZero())
+		Expect(probe.PeriodSeconds).NotTo(BeZero())
+		Expect(probe.TimeoutSeconds).NotTo(BeZero())
+		Expect(probe.SuccessThreshold).NotTo(BeZero())
+		Expect(probe.FailureThreshold).NotTo(BeZero())
+	})
+
+	It("should fill zero-valued timing fields on user-provided probes", func() {
+		probe := withProbeDefaults(&corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromInt(8080)},
+			},
+		})
+		Expect(probe.FailureThreshold).NotTo(BeZero())
+		Expect(probe.PeriodSeconds).NotTo(BeZero())
+		Expect(probe.SuccessThreshold).NotTo(BeZero())
+		Expect(probe.TimeoutSeconds).NotTo(BeZero())
+		Expect(probe.HTTPGet.Path).To(Equal("/healthz"))
+	})
+
+	It("should preserve user-set timing fields on probes", func() {
+		probe := withProbeDefaults(&corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(8080)},
+			},
+			PeriodSeconds:       30,
+			FailureThreshold:    5,
+			InitialDelaySeconds: 10,
+		})
+		Expect(probe.PeriodSeconds).To(Equal(int32(30)))
+		Expect(probe.FailureThreshold).To(Equal(int32(5)))
+		Expect(probe.InitialDelaySeconds).To(Equal(int32(10)))
+		Expect(probe.SuccessThreshold).NotTo(BeZero())
+		Expect(probe.TimeoutSeconds).NotTo(BeZero())
 	})
 
 	It("should use provided port in default readiness probe", func() {
@@ -1232,6 +1264,27 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 		By("Verifying tracking annotations are set")
 		Expect(createdDeployment.Annotations).To(HaveKey(managedExtraLabels))
 		Expect(createdDeployment.Annotations).To(HaveKey(managedExtraAnnotations))
+	})
+
+	It("should default PodSecurityContext to empty when not specified", func() {
+		mcpServer := newTestMCPServer("test-pod-sc-default")
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+		deployment, err := reconciler.createDeployment(mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+		Expect(*deployment.Spec.Template.Spec.SecurityContext).To(Equal(corev1.PodSecurityContext{}))
+	})
+
+	It("should use provided PodSecurityContext when specified", func() {
+		mcpServer := newTestMCPServer("test-pod-sc-custom")
+		mcpServer.Spec.Runtime.Security.PodSecurityContext = &corev1.PodSecurityContext{
+			RunAsNonRoot: new(true),
+		}
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+		deployment, err := reconciler.createDeployment(mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+		Expect(*deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
`deploymentNeedsUpdate` returns true on every reconciliation because the desired Deployment spec differs from the existing one after the API server applies its defaults in two places:

- `PodSecurityContext`: `nil` in desired vs empty struct from API server
- `ReadinessProbe`: missing `FailureThreshold`/`PeriodSeconds`/etc. fields that the API server adds as defaults

This PR sets these values explicitly in the desired spec so that the `DeepEqual` comparisons in `deploymentNeedsUpdate` match what the API server returns, avoiding unnecessary updates.

Hint: Switching the comparisons to `DeepDerivative` was considered but rejected: `DeepDerivative` ignores zero/nil values in the desired spec, which would also hide intentional removals.