### PR TITLE
ci: increase e2e test timeout to 1 hour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ deploy-test-e2e: setup-test-e2e manifests generate ## Build and deploy the opera
 
 .PHONY: test-e2e
 test-e2e: ## Run the e2e tests (requires operator already deployed, see deploy-test-e2e).
-	go test -tags=e2e ./test/e2e/ -v -count=1 -timeout 10m
+	go test -tags=e2e ./test/e2e/ -v -count=1 -timeout 1h
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests


### PR DESCRIPTION
e2e tests are running into the 10 minute timeout (e.g. [here](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/actions/runs/26573984430/job/78288211497?pr=207) or [here](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/actions/runs/26532811349/job/78153713613)). This PR increases the timeout