### PR TITLE
fix(controller): cancel context before closing MCP session

### DIFF
--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -95,7 +95,6 @@ func (r *MCPServerReconciler) reconcileHandshake(
 // MCP servers do not handle gracefully).
 func (r *MCPServerReconciler) verifyMCPEndpoint(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) {
 	connCtx, connCancel := context.WithCancel(ctx)
-	defer connCancel()
 
 	mcpClient := mcp.NewClient(
 		&mcp.Implementation{
@@ -114,9 +113,14 @@ func (r *MCPServerReconciler) verifyMCPEndpoint(ctx context.Context, url string)
 
 	session, err := mcpClient.Connect(connCtx, transport, nil)
 	if err != nil {
+		connCancel()
 		return nil, err
 	}
+	// Cancel the connection context before closing the session. session.Close
+	// blocks until the reader goroutine exits; cancelling the context causes
+	// the reader to return immediately instead of waiting on the HTTP stream.
 	defer func() {
+		connCancel()
 		_ = session.Close()
 	}()
 


### PR DESCRIPTION
In #202, a memory leak was closed. Anyhow since then, e2e tests that perform MCP handshakes are ~7x slower (e.g. TestStorageSecret: 8s -> 54s).

The root cause seems the defer ordering in `verifyMCPEndpoint`: `session.Close()` runs before `connCancel()` in the defer stack. This means the connection context is still active when `streamableClientConn.Close()` sends an HTTP DELETE to the server:

```go
req, err := http.NewRequestWithContext(c.ctx, http.MethodDelete, c.url, nil)
c.client.Do(req) // blocks until server responds or 10s HTTP timeout
```

Since the context is still active, the DELETE blocks for the full HTTP client timeout (10s) on every handshake.

The fix cancels the connection context before calling `session.Close()`. This causes the DELETE request to return immediately (context cancelled), while `session.Close()` still properly releases local resources (session state, jsonrpc2 connection, goroutines). The HTTP DELETE is not essential for a short-lived verification handshake. This is consistent with the original design noted in the function comment:

> *"It uses a dedicated context for the connection so that cancelling it tears down the transport without sending an HTTP DELETE to the server (which some MCP servers do not handle gracefully)."*