### PR TITLE
fix(controller): preserve Ready condition after verified handshake

### DIFF
--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -41,10 +41,6 @@ func (r *MCPServerReconciler) reconcileHandshake(
 ) (metav1.Condition, *mcpv1alpha1.MCPServerInfo) {
 	logger := log.FromContext(ctx)
 
-	if readyCondition.Status != metav1.ConditionTrue || readyCondition.Reason != ReasonAvailable {
-		return readyCondition, nil
-	}
-
 	existingReady := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeReady)
 	alreadyVerified := existingReady != nil &&
 		existingReady.Status == metav1.ConditionTrue &&
@@ -52,8 +48,15 @@ func (r *MCPServerReconciler) reconcileHandshake(
 		mcpServer.Status.ObservedGeneration == mcpServer.Generation &&
 		mcpServer.Status.ServerInfo != nil
 
+	// If the handshake was already verified for this generation, preserve
+	// Ready=True even if the Deployment has a transient status fluctuation
+	// (e.g. during rollout cleanup).
 	if alreadyVerified {
-		return readyCondition, mcpServer.Status.ServerInfo
+		return *existingReady, mcpServer.Status.ServerInfo
+	}
+
+	if readyCondition.Status != metav1.ConditionTrue || readyCondition.Reason != ReasonAvailable {
+		return readyCondition, nil
 	}
 
 	dialer := r.MCPDialer


### PR DESCRIPTION
After the MCP handshake succeeds, the Ready=True condition can flip back to False if the Deployment reports transient unavailability during rollout cleanup. This happens because the `alreadyVerified` check in `reconcileHandshake` only ran after the Deployment availability gate, so a brief Deployment status blip would skip the check entirely and set Ready=False.

The fix moves `alreadyVerified` before the availability gate, preserving Ready=True once the handshake is verified for the current generation. A spec change (generation bump) still resets verification and triggers a new handshake.