### PR TITLE
fix(controller): sync base managed labels on Deployment update

### DIFF
--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -110,6 +110,7 @@ func (r *MCPServerReconciler) reconcileDeployment(
 	if needsUpdate {
 		logger.Info("Updating Deployment", "name", existingDeployment.Name)
 		existingDeployment.Spec.Replicas = deployment.Spec.Replicas
+		existingDeployment.Spec.Template.Labels = deployment.Spec.Template.Labels
 		existingDeployment.Spec.Template.Annotations = deployment.Spec.Template.Annotations
 		existingDeployment.Spec.Template.Spec = deployment.Spec.Template.Spec
 		if err := applyCustomDeploymentMetadata(mcpServer, existingDeployment); err != nil {
@@ -162,6 +163,7 @@ func deploymentNeedsUpdate(mcpServer *mcpv1alpha1.MCPServer, existing, desired *
 		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].ReadinessProbe, newPodSpec.Containers[0].ReadinessProbe) ||
 		oldPodSpec.ServiceAccountName != newPodSpec.ServiceAccountName ||
 		!equality.Semantic.DeepEqual(existing.Spec.Replicas, desired.Spec.Replicas) ||
+		!equality.Semantic.DeepEqual(existing.Spec.Template.Labels, desired.Spec.Template.Labels) ||
 		!equality.Semantic.DeepEqual(existing.Spec.Template.Annotations, desired.Spec.Template.Annotations) ||
 		deploymentAnnotationsChanged(mcpServer, existing) ||
 		deploymentLabelsChanged(mcpServer, existing) ||

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -135,6 +135,80 @@ var _ = Describe("MCPServer Controller - reconcileDeployment", func() {
 		Expect(deploymentNeedsUpdate(mcpServer, existingDeployment, desiredDeployment, false)).To(BeFalse())
 	})
 
+	It("should detect drift when base managed labels are removed from template", func() {
+		mcpServer := newTestMCPServer("test-label-drift")
+		labels := managedWorkloadLabels("test-label-drift")
+
+		existing := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"leftover": "true"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: ManagedWorkloadName, Image: "docker.io/library/test-image:latest"},
+						},
+					},
+				},
+			},
+		}
+
+		desired := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: ManagedWorkloadName, Image: "docker.io/library/test-image:latest"},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(deploymentNeedsUpdate(mcpServer, existing, desired, false)).To(BeTrue())
+	})
+
+	It("should not detect drift when base managed labels match", func() {
+		mcpServer := newTestMCPServer("test-label-match")
+		labels := managedWorkloadLabels("test-label-match")
+
+		existing := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: ManagedWorkloadName, Image: "docker.io/library/test-image:latest"},
+						},
+					},
+				},
+			},
+		}
+
+		desired := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: ManagedWorkloadName, Image: "docker.io/library/test-image:latest"},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(deploymentNeedsUpdate(mcpServer, existing, desired, false)).To(BeFalse())
+	})
+
 	It("should recover when existing deployment has empty containers list", func() {
 		By("Setting up a fake client with a deployment that has no containers")
 		mcpServer := newTestMCPServer("test-empty-containers")


### PR DESCRIPTION
The Deployment update path syncs `Template.Annotations` and `Template.Spec` from the desired state but skips `Template.Labels`. If the base managed labels (`app`, `mcp-server`) are removed externally, the controller does not detect or restore them, which can break selector matching for newly created pods.

This PR addresses it by adding `Template.Labels` to both the sync and the drift-detection logic in `deploymentNeedsUpdate`.