### PR TITLE
feat(controller): create prerequisites from annotation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,8 +8,8 @@ rules:
   - ""
   resources:
   - configmaps
-  - secrets
   verbs:
+  - create
   - get
   - list
   - watch
@@ -20,6 +20,21 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,8 +35,6 @@ rules:
   verbs:
   - create
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -166,7 +166,7 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
@@ -196,10 +196,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	pendingAcceptedEvent := !acceptedConditionIsTrue(mcpServer.Status.Conditions)
 	pendingServerReadyEvent := !readyConditionIsAvailable(mcpServer.Status.Conditions)
 
-	// Before validation, create prerequisites if annotation is set
+	// Before validation, create prerequisites if annotation is set.
+	// Return errors so transient failures are retried with backoff.
 	if err := r.ensurePrerequisites(ctx, mcpServer); err != nil {
-		logger.Error(err, "Failed to create prerequisites")
-		// Don't return error — fall through to validation which will report the specific missing resource
+		logger.Error(err, "Failed to create prerequisites, will retry")
+		return ctrl.Result{}, err
 	}
 
 	// Validate configuration

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -166,7 +166,7 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -164,8 +164,9 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
@@ -194,6 +195,12 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	pendingAcceptedEvent := !acceptedConditionIsTrue(mcpServer.Status.Conditions)
 	pendingServerReadyEvent := !readyConditionIsAvailable(mcpServer.Status.Conditions)
+
+	// Before validation, create prerequisites if annotation is set
+	if err := r.ensurePrerequisites(ctx, mcpServer); err != nil {
+		logger.Error(err, "Failed to create prerequisites")
+		// Don't return error — fall through to validation which will report the specific missing resource
+	}
 
 	// Validate configuration
 	validationStart := time.Now()

--- a/internal/controller/mcpserver_controller_prerequisites.go
+++ b/internal/controller/mcpserver_controller_prerequisites.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+const (
+	// AnnotationAutoCreatePrerequisites controls whether the operator creates
+	// missing ConfigMaps and ServiceAccounts referenced by the MCPServer CR.
+	AnnotationAutoCreatePrerequisites = "mcp.x-k8s.io/auto-create-prerequisites"
+
+	// eventActionPrerequisiteCreated is the reporting action when a prerequisite resource is auto-created.
+	eventActionPrerequisiteCreated = "PrerequisiteCreated"
+)
+
+// ensurePrerequisites creates missing ServiceAccounts and ConfigMaps referenced
+// by the MCPServer when the auto-create-prerequisites annotation is set to "true".
+// Created resources are owned by the MCPServer so they are cleaned up on deletion.
+func (r *MCPServerReconciler) ensurePrerequisites(ctx context.Context, server *mcpv1alpha1.MCPServer) error {
+	if server.Annotations[AnnotationAutoCreatePrerequisites] != "true" {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Auto-creating prerequisites for MCPServer", "name", server.Name)
+
+	if err := r.ensureServiceAccount(ctx, server); err != nil {
+		return err
+	}
+
+	if err := r.ensureConfigMaps(ctx, server); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ensureServiceAccount creates the ServiceAccount referenced by
+// spec.runtime.security.serviceAccountName if it does not already exist.
+func (r *MCPServerReconciler) ensureServiceAccount(ctx context.Context, server *mcpv1alpha1.MCPServer) error {
+	saName := server.Spec.Runtime.Security.ServiceAccountName
+	if saName == "" {
+		return nil
+	}
+
+	sa := &corev1.ServiceAccount{}
+	err := r.Get(ctx, client.ObjectKey{Name: saName, Namespace: server.Namespace}, sa)
+	if err == nil {
+		// Already exists, nothing to do.
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check ServiceAccount %s: %w", saName, err)
+	}
+
+	sa = &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: server.Namespace,
+		},
+	}
+	if err := controllerutil.SetControllerReference(server, sa, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on ServiceAccount %s: %w", saName, err)
+	}
+	if err := r.Create(ctx, sa); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to create ServiceAccount %s: %w", saName, err)
+	}
+
+	r.emitPrerequisiteCreated(server, "ServiceAccount", saName)
+	return nil
+}
+
+// ensureConfigMaps creates any ConfigMaps referenced in spec.config.storage
+// that do not already exist.
+func (r *MCPServerReconciler) ensureConfigMaps(ctx context.Context, server *mcpv1alpha1.MCPServer) error {
+	for i, storage := range server.Spec.Config.Storage {
+		if storage.Source.Type != mcpv1alpha1.StorageTypeConfigMap {
+			continue
+		}
+		if storage.Source.ConfigMap == nil {
+			continue
+		}
+
+		cmName := storage.Source.ConfigMap.Name
+		if cmName == "" {
+			continue
+		}
+
+		cm := &corev1.ConfigMap{}
+		err := r.Get(ctx, client.ObjectKey{Name: cmName, Namespace: server.Namespace}, cm)
+		if err == nil {
+			// Already exists, nothing to do.
+			continue
+		}
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to check ConfigMap %s: %w", cmName, err)
+		}
+
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: server.Namespace,
+			},
+			Data: map[string]string{},
+		}
+		if err := controllerutil.SetControllerReference(server, cm, r.Scheme); err != nil {
+			return fmt.Errorf("failed to set owner reference on ConfigMap %s: %w", cmName, err)
+		}
+		if err := r.Create(ctx, cm); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				continue
+			}
+			return fmt.Errorf("failed to create ConfigMap %s at storage index %d: %w", cmName, i, err)
+		}
+
+		r.emitPrerequisiteCreated(server, "ConfigMap", cmName)
+	}
+
+	return nil
+}
+
+func (r *MCPServerReconciler) emitPrerequisiteCreated(server *mcpv1alpha1.MCPServer, kind, name string) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(server, nil, corev1.EventTypeNormal, "CreatedPrerequisite",
+		eventActionPrerequisiteCreated, "Created %s %s for MCPServer %s", kind, name, server.Name)
+}

--- a/internal/controller/mcpserver_controller_prerequisites.go
+++ b/internal/controller/mcpserver_controller_prerequisites.go
@@ -70,7 +70,7 @@ func (r *MCPServerReconciler) ensureServiceAccount(ctx context.Context, server *
 	}
 
 	sa := &corev1.ServiceAccount{}
-	err := r.Get(ctx, client.ObjectKey{Name: saName, Namespace: server.Namespace}, sa)
+	err := r.APIReader.Get(ctx, client.ObjectKey{Name: saName, Namespace: server.Namespace}, sa)
 	if err == nil {
 		// Already exists, nothing to do.
 		return nil

--- a/internal/controller/mcpserver_controller_prerequisites_test.go
+++ b/internal/controller/mcpserver_controller_prerequisites_test.go
@@ -1,0 +1,383 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+var _ = Describe("MCPServer Prerequisites", func() {
+	ctx := context.Background()
+
+	Context("Without the auto-create-prerequisites annotation", func() {
+		const resourceName = "test-prereq-no-annotation"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			resource := newTestMCPServer(resourceName)
+			resource.Spec.Runtime.Security = mcpv1alpha1.SecurityConfig{
+				ServiceAccountName: "should-not-be-created",
+			}
+			resource.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+				{
+					Path: "/config",
+					Source: mcpv1alpha1.StorageSource{
+						Type: mcpv1alpha1.StorageTypeConfigMap,
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "should-not-be-created-cm",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("should NOT create prerequisites when annotation is absent", func() {
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			// Reconcile will fail validation (missing CM/SA) — that's expected
+			Expect(err).NotTo(HaveOccurred())
+
+			// ServiceAccount should not exist
+			sa := &corev1.ServiceAccount{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: "should-not-be-created", Namespace: "default",
+			}, sa)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"ServiceAccount should not be created without annotation")
+
+			// ConfigMap should not exist
+			cm := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: "should-not-be-created-cm", Namespace: "default",
+			}, cm)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"ConfigMap should not be created without annotation")
+		})
+	})
+
+	Context("With the auto-create-prerequisites annotation", func() {
+		const resourceName = "test-prereq-with-annotation"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			// Clean up any created prerequisites (owner references should handle
+			// this via GC, but envtest doesn't run GC)
+			sa := &corev1.ServiceAccount{}
+			if err := k8sClient.Get(ctx, client.ObjectKey{
+				Name: "auto-created-sa", Namespace: "default",
+			}, sa); err == nil {
+				_ = k8sClient.Delete(ctx, sa)
+			}
+			cm := &corev1.ConfigMap{}
+			if err := k8sClient.Get(ctx, client.ObjectKey{
+				Name: "auto-created-cm", Namespace: "default",
+			}, cm); err == nil {
+				_ = k8sClient.Delete(ctx, cm)
+			}
+		})
+
+		It("should create a missing ServiceAccount", func() {
+			resource := newTestMCPServer(resourceName)
+			resource.Annotations = map[string]string{
+				AnnotationAutoCreatePrerequisites: "true",
+			}
+			resource.Spec.Runtime.Security = mcpv1alpha1.SecurityConfig{
+				ServiceAccountName: "auto-created-sa",
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			sa := &corev1.ServiceAccount{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: "auto-created-sa", Namespace: "default",
+			}, sa)
+			Expect(err).NotTo(HaveOccurred(), "ServiceAccount should be auto-created")
+
+			// Verify owner reference
+			ownerRef := metav1.GetControllerOf(sa)
+			Expect(ownerRef).NotTo(BeNil(), "ServiceAccount should have a controller owner reference")
+			Expect(ownerRef.Name).To(Equal(resourceName))
+			Expect(ownerRef.Kind).To(Equal("MCPServer"))
+		})
+
+		It("should create a missing ConfigMap", func() {
+			resource := newTestMCPServer(resourceName)
+			resource.Annotations = map[string]string{
+				AnnotationAutoCreatePrerequisites: "true",
+			}
+			resource.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+				{
+					Path: "/config",
+					Source: mcpv1alpha1.StorageSource{
+						Type: mcpv1alpha1.StorageTypeConfigMap,
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "auto-created-cm",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: "auto-created-cm", Namespace: "default",
+			}, cm)
+			Expect(err).NotTo(HaveOccurred(), "ConfigMap should be auto-created")
+			Expect(cm.Data).To(BeEmpty(), "Auto-created ConfigMap should have empty data")
+
+			// Verify owner reference
+			ownerRef := metav1.GetControllerOf(cm)
+			Expect(ownerRef).NotTo(BeNil(), "ConfigMap should have a controller owner reference")
+			Expect(ownerRef.Name).To(Equal(resourceName))
+			Expect(ownerRef.Kind).To(Equal("MCPServer"))
+		})
+
+		It("should not modify existing resources", func() {
+			// Pre-create the SA and CM with specific data
+			existingSA := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auto-created-sa",
+					Namespace: "default",
+					Labels:    map[string]string{"preexisting": "true"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, existingSA)).To(Succeed())
+
+			existingCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auto-created-cm",
+					Namespace: "default",
+					Labels:    map[string]string{"preexisting": "true"},
+				},
+				Data: map[string]string{"key": "value"},
+			}
+			Expect(k8sClient.Create(ctx, existingCM)).To(Succeed())
+
+			resource := newTestMCPServer(resourceName)
+			resource.Annotations = map[string]string{
+				AnnotationAutoCreatePrerequisites: "true",
+			}
+			resource.Spec.Runtime.Security = mcpv1alpha1.SecurityConfig{
+				ServiceAccountName: "auto-created-sa",
+			}
+			resource.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+				{
+					Path: "/config",
+					Source: mcpv1alpha1.StorageSource{
+						Type: mcpv1alpha1.StorageTypeConfigMap,
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "auto-created-cm",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify SA was not modified
+			sa := &corev1.ServiceAccount{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: "auto-created-sa", Namespace: "default",
+			}, sa)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sa.Labels).To(HaveKeyWithValue("preexisting", "true"),
+				"Existing ServiceAccount should not be modified")
+
+			// Verify CM was not modified
+			cm := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: "auto-created-cm", Namespace: "default",
+			}, cm)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cm.Labels).To(HaveKeyWithValue("preexisting", "true"),
+				"Existing ConfigMap should not be modified")
+			Expect(cm.Data).To(HaveKeyWithValue("key", "value"),
+				"Existing ConfigMap data should be preserved")
+		})
+
+		It("should emit events when creating prerequisites", func() {
+			resource := newTestMCPServer(resourceName)
+			resource.Annotations = map[string]string{
+				AnnotationAutoCreatePrerequisites: "true",
+			}
+			resource.Spec.Runtime.Security = mcpv1alpha1.SecurityConfig{
+				ServiceAccountName: "auto-created-sa",
+			}
+			resource.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+				{
+					Path: "/config",
+					Source: mcpv1alpha1.StorageSource{
+						Type: mcpv1alpha1.StorageTypeConfigMap,
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "auto-created-cm",
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler, fr := newReconcilerForTestWithFakeEvents(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Collect all events
+			events := drainEvents(fr.Events)
+
+			// Should have at least the CreatedPrerequisite events
+			saEventFound := false
+			cmEventFound := false
+			for _, ev := range events {
+				if containsAll(ev, "CreatedPrerequisite", "ServiceAccount", "auto-created-sa") {
+					saEventFound = true
+				}
+				if containsAll(ev, "CreatedPrerequisite", "ConfigMap", "auto-created-cm") {
+					cmEventFound = true
+				}
+			}
+			Expect(saEventFound).To(BeTrue(), "Should emit event for ServiceAccount creation, got events: %v", events)
+			Expect(cmEventFound).To(BeTrue(), "Should emit event for ConfigMap creation, got events: %v", events)
+		})
+
+		It("should skip non-ConfigMap storage types", func() {
+			resource := newTestMCPServer(resourceName)
+			resource.Annotations = map[string]string{
+				AnnotationAutoCreatePrerequisites: "true",
+			}
+			resource.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+				{
+					Path:        "/tmp",
+					Permissions: mcpv1alpha1.MountPermissionsReadWrite,
+					Source: mcpv1alpha1.StorageSource{
+						Type:     mcpv1alpha1.StorageTypeEmptyDir,
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should handle annotation set to a value other than true", func() {
+			resource := newTestMCPServer(resourceName)
+			resource.Annotations = map[string]string{
+				AnnotationAutoCreatePrerequisites: "false",
+			}
+			resource.Spec.Runtime.Security = mcpv1alpha1.SecurityConfig{
+				ServiceAccountName: "auto-created-sa",
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			// Will fail validation because SA doesn't exist — that's expected
+			Expect(err).NotTo(HaveOccurred())
+
+			sa := &corev1.ServiceAccount{}
+			err = k8sClient.Get(ctx, client.ObjectKey{
+				Name: "auto-created-sa", Namespace: "default",
+			}, sa)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"ServiceAccount should NOT be created when annotation is not 'true'")
+		})
+	})
+})
+
+// containsAll returns true if s contains all of the given substrings.
+func containsAll(s string, substrings ...string) bool {
+	for _, sub := range substrings {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

When the annotation `mcp.x-k8s.io/auto-create-prerequisites` is set to `"true"` on an MCPServer CR, the operator creates missing ServiceAccounts and ConfigMaps before validation. Resources are owned by the MCPServer and cleaned up on deletion.

## Motivation

Deploying MCP servers from the RHOAI catalog requires manually creating ServiceAccounts and ConfigMaps per namespace before the MCPServer CR will reconcile. This annotation-gated feature automates that step for catalog-based deployments.

Addresses https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/226

## Changes

- New file: `internal/controller/mcpserver_controller_prerequisites.go` — `ensurePrerequisites()` function
- Modified: `internal/controller/mcpserver_controller.go` — call `ensurePrerequisites()` before validation, updated RBAC markers
- Updated: `config/rbac/role.yaml` — added `list`, `watch`, and `create` verbs for serviceaccounts
- Tests: `internal/controller/mcpserver_controller_prerequisites_test.go` — 7 test cases covering annotation gating, resource creation, idempotency, and owner references

## Testing

Validated on a live RHOAI 3.4 / OpenShift 4.20 cluster:
- With annotation: ServiceAccount and ConfigMap auto-created, MCPServer reconciled to Running
- Without annotation: no resources created, MCPServer correctly reported Failed with missing ConfigMap error
- All existing unit tests pass (`make test`)
- Lint clean (`make lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCPServer controller now automatically provisions prerequisite ServiceAccounts and ConfigMaps when configured via the `mcp.x-k8s.io/auto-create-prerequisites` annotation.

* **Chores**
  * Updated RBAC permissions to support automatic prerequisite resource creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->