### PR TITLE
build: bump Go toolchain to 1.26.4 for stdlib vuln fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
Update go.mod to Go 1.26.4 so govulncheck passes for GO-2026-5037, GO-2026-5038, and GO-2026-5039 in the standard library.