### PR TITLE
build(deps): bump golang from 1.26.3 to 1.26.4 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
The govulncheck CI check is failing due to a vulnerability in `crypto/x509` (GO-2026-5037) e.g. [here](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/actions/runs/26897583351/job/79340790162?pr=225), which is fixed in Go 1.26.4. The Dockerfile was already bumped to 1.26.4 but `go.mod` still referenced 1.26.3.

This PR addresses it by bumping the Go version in `go.mod` to 1.26.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to the latest patch version for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->