### PR TITLE
docs: add versioned documentation with mike

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-patch-release.md
+++ b/.github/ISSUE_TEMPLATE/new-patch-release.md
@@ -48,6 +48,8 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
   ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
   with the changelog above; attach `dist/install.yaml` as a release asset
+- [ ] Verify the [Docs workflow](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/actions/workflows/docs.yaml)
+  succeeded and https://mcp-lifecycle-operator.sigs.k8s.io/ shows the new version as **latest**
 - [ ] Send announcement email to `dev@kubernetes.io` with subject:
   `[ANNOUNCE] mcp-lifecycle-operator v0.MINOR.PATCH is released`
 - [ ] Close this issue

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -55,6 +55,8 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
   ```
 - [ ] Create [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
   with the changelog above; attach `dist/install.yaml` as a release asset
+- [ ] Verify the [Docs workflow](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/actions/workflows/docs.yaml)
+  succeeded and https://mcp-lifecycle-operator.sigs.k8s.io/ shows the new version as **latest**
 - [ ] Send announcement email to `dev@kubernetes.io` with subject:
   `[ANNOUNCE] mcp-lifecycle-operator v0.MINOR.0 is released`
 - [ ] Close this issue

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   pull_request:
-    paths:
+    paths: &docs-paths
       - "site-src/**"
       - "mkdocs.yml"
       - "hack/mkdocs/**"
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+    paths: *docs-paths
   release:
     types: [published]
   workflow_dispatch:
@@ -28,6 +29,11 @@ on:
         description: "Set latest as the default site version"
         type: boolean
         default: true
+
+# Serialize gh-pages deploys; keep PR lint runs independent.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('docs-lint-pr-{0}', github.event.pull_request.number) || 'docs-deploy-gh-pages' }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,181 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - "site-src/**"
+      - "mkdocs.yml"
+      - "hack/mkdocs/**"
+      - "crd-ref-docs.yaml"
+      - "api/v1alpha1/**"
+      - ".github/workflows/docs.yaml"
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy (git tag, e.g. v0.1.0)"
+        required: true
+        type: string
+      update_latest:
+        description: "Update the latest alias to this version"
+        type: boolean
+        default: true
+      set_default:
+        description: "Set latest as the default site version"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: hack/mkdocs/image/requirements.txt
+
+      - name: Install docs dependencies
+        run: pip install -r hack/mkdocs/image/requirements.txt
+
+      - name: Build docs
+        run: |
+          make api-ref-docs
+          mkdocs build --strict
+
+  deploy-main:
+    name: Deploy main preview
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: hack/mkdocs/image/requirements.txt
+
+      - name: Install docs dependencies
+        run: pip install -r hack/mkdocs/image/requirements.txt
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy main preview
+        run: ./hack/mkdocs/deploy.sh main --title "main (preview)"
+
+  deploy-release:
+    name: Deploy release docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: hack/mkdocs/image/requirements.txt
+
+      - name: Install docs dependencies
+        run: pip install -r hack/mkdocs/image/requirements.txt
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy release docs
+        run: ./hack/mkdocs/deploy.sh "${{ github.event.release.tag_name }}" latest --set-default
+
+  deploy-manual:
+    name: Deploy docs (manual)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.version }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: hack/mkdocs/image/requirements.txt
+
+      - name: Install docs dependencies
+        run: pip install -r hack/mkdocs/image/requirements.txt
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy docs
+        env:
+          VERSION: ${{ inputs.version }}
+          UPDATE_LATEST: ${{ inputs.update_latest }}
+          SET_DEFAULT: ${{ inputs.set_default }}
+        run: |
+          ARGS=("${VERSION}")
+          if [[ "${UPDATE_LATEST}" == "true" ]]; then
+            ARGS+=(latest)
+          fi
+          if [[ "${SET_DEFAULT}" == "true" ]]; then
+            ARGS+=(--set-default)
+          fi
+          ./hack/mkdocs/deploy.sh "${ARGS[@]}"

--- a/Makefile
+++ b/Makefile
@@ -208,9 +208,18 @@ build-docs: api-ref-docs ## Build documentation site using Docker
 	$(CONTAINER_TOOL) run --rm -v $(shell pwd):/work -w /work mkdocs-builder build
 
 .PHONY: build-docs-netlify
-build-docs-netlify: api-ref-docs ## Build documentation site for Netlify deployment
+build-docs-netlify: api-ref-docs ## Build documentation site locally (same as mkdocs build)
 	pip3 install --user --break-system-packages -r hack/mkdocs/image/requirements.txt
 	python3 -m mkdocs build
+
+.PHONY: deploy-docs-main
+deploy-docs-main: ## Deploy main-branch docs preview to gh-pages via mike
+	./hack/mkdocs/deploy.sh main --title "main (preview)"
+
+.PHONY: deploy-docs-release
+deploy-docs-release: ## Deploy release docs to gh-pages (VERSION=v0.1.0)
+	@test -n "$(VERSION)" || (echo "VERSION is required, e.g. make deploy-docs-release VERSION=v0.1.0" && exit 1)
+	./hack/mkdocs/deploy.sh $(VERSION) latest --set-default
 
 .PHONY: live-docs
 live-docs: api-ref-docs ## Run live documentation server using Docker

--- a/hack/mkdocs/deploy.sh
+++ b/hack/mkdocs/deploy.sh
@@ -74,21 +74,21 @@ if [[ "${SET_DEFAULT}" == "true" ]]; then
 fi
 
 NETLIFY_CONFIG="${SCRIPT_ROOT}/hack/mkdocs/gh-pages-netlify.toml"
-NETLIFY_TMP="$(mktemp)"
-cp "${NETLIFY_CONFIG}" "${NETLIFY_TMP}"
+WORKTREE_DIR="$(mktemp -d)"
 
 echo "Ensuring Netlify configuration on gh-pages..."
 git fetch origin gh-pages
-git checkout gh-pages
-cp "${NETLIFY_TMP}" netlify.toml
-rm -f "${NETLIFY_TMP}"
+git worktree add -B gh-pages "${WORKTREE_DIR}" origin/gh-pages
+cp "${NETLIFY_CONFIG}" "${WORKTREE_DIR}/netlify.toml"
 
+pushd "${WORKTREE_DIR}" > /dev/null
 if ! git diff --quiet netlify.toml; then
   git add netlify.toml
   git commit -m "Ensure Netlify configuration for gh-pages publishing"
   git push origin gh-pages
 fi
+popd > /dev/null
 
-git checkout -
+git worktree remove "${WORKTREE_DIR}" --force
 
 echo "Documentation deployment complete."

--- a/hack/mkdocs/deploy.sh
+++ b/hack/mkdocs/deploy.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy a documentation version to gh-pages with mike.
+#
+# Usage:
+#   deploy.sh <version> [--title <title>] [--set-default] [alias...]
+#
+# Examples:
+#   deploy.sh v0.1.0 latest --set-default          # release (updates latest alias)
+#   deploy.sh main --title "main (preview)"        # main-branch preview
+
+set -euo pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${SCRIPT_ROOT}"
+
+VERSION="${1:?version required}"
+shift
+
+SET_DEFAULT=false
+TITLE=""
+UPDATE_ALIASES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --set-default)
+      SET_DEFAULT=true
+      shift
+      ;;
+    --title)
+      TITLE="${2:?title required with --title}"
+      shift 2
+      ;;
+    *)
+      UPDATE_ALIASES+=("$1")
+      shift
+      ;;
+  esac
+done
+
+echo "Generating API reference documentation..."
+make api-ref-docs
+
+MIKE_ARGS=(deploy --push "${VERSION}" --alias-type=redirect)
+
+if [[ -n "${TITLE}" ]]; then
+  MIKE_ARGS+=(-t "${TITLE}")
+fi
+
+if [[ ${#UPDATE_ALIASES[@]} -gt 0 ]]; then
+  MIKE_ARGS+=(--update-aliases "${UPDATE_ALIASES[@]}")
+fi
+
+echo "Deploying documentation version ${VERSION}..."
+mike "${MIKE_ARGS[@]}"
+
+if [[ "${SET_DEFAULT}" == "true" ]]; then
+  echo "Setting default version to latest..."
+  mike set-default --push latest
+fi
+
+NETLIFY_CONFIG="${SCRIPT_ROOT}/hack/mkdocs/gh-pages-netlify.toml"
+NETLIFY_TMP="$(mktemp)"
+cp "${NETLIFY_CONFIG}" "${NETLIFY_TMP}"
+
+echo "Ensuring Netlify configuration on gh-pages..."
+git fetch origin gh-pages
+git checkout gh-pages
+cp "${NETLIFY_TMP}" netlify.toml
+rm -f "${NETLIFY_TMP}"
+
+if ! git diff --quiet netlify.toml; then
+  git add netlify.toml
+  git commit -m "Ensure Netlify configuration for gh-pages publishing"
+  git push origin gh-pages
+fi
+
+git checkout -
+
+echo "Documentation deployment complete."

--- a/hack/mkdocs/gh-pages-netlify.toml
+++ b/hack/mkdocs/gh-pages-netlify.toml
@@ -1,0 +1,5 @@
+# Netlify publishes pre-built documentation from the gh-pages branch.
+# GitHub Actions builds versioned docs with mike; Netlify should not run a build.
+[build]
+  publish = "."
+  command = ""

--- a/hack/mkdocs/image/requirements.txt
+++ b/hack/mkdocs/image/requirements.txt
@@ -3,5 +3,6 @@ mkdocs-material~=9.5
 mkdocs-material-extensions~=1.3
 mkdocs-awesome-pages-plugin~=2.9
 mkdocs-mermaid2-plugin~=1.1
+mike~=2.1
 pymdown-extensions~=10.2
 markdown~=3.6

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,9 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
+  version:
+    provider: mike
+    default: latest
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/kubernetes-sigs/mcp-lifecycle-operator

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,10 @@ edit_uri: edit/main/site-src/
 site_dir: site
 docs_dir: site-src
 
+# Contributor README only; the site landing page is index.md.
+exclude_docs: |
+  README.md
+
 theme:
   name: material
   icon:

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,20 @@
 #   Build command: (empty)
 #   Publish directory: /
 #
-# Until Netlify is pointed at gh-pages, builds from main will fail intentionally.
+# Production deploys use the pre-built gh-pages branch (no build). Until Netlify's
+# production branch is switched to gh-pages, main-branch production builds fail
+# intentionally. PR deploy previews still build from the PR branch.
 [build]
   publish = "site"
   command = "echo 'Docs are published from gh-pages by GitHub Actions. Point Netlify production branch to gh-pages. See site-src/README.md.' && exit 1"
+
+[context.deploy-preview]
+  command = "make build-docs-netlify"
+  publish = "site"
+
+[context.branch-deploy]
+  command = "make build-docs-netlify"
+  publish = "site"
 
 [build.environment]
   PYTHON_VERSION = "3.12"

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,12 @@
 # Production deploys use the pre-built gh-pages branch (no build). Until Netlify's
 # production branch is switched to gh-pages, main-branch production builds fail
 # intentionally. PR deploy previews still build from the PR branch.
+#
+# Post-merge migration (in order):
+#   1. Merge this PR
+#   2. Run Actions -> Docs -> Deploy docs (manual) for v0.1.0 to bootstrap latest
+#   3. Switch Netlify production branch to gh-pages (empty build, publish /)
+# Until step 3, the last good production deploy stays live.
 [build]
   publish = "site"
   command = "echo 'Docs are published from gh-pages by GitHub Actions. Point Netlify production branch to gh-pages. See site-src/README.md.' && exit 1"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,15 @@
+# Documentation is versioned with mike and published from the gh-pages branch.
+# GitHub Actions builds docs in .github/workflows/docs.yaml.
+#
+# Netlify settings (required once):
+#   Production branch: gh-pages
+#   Build command: (empty)
+#   Publish directory: /
+#
+# Until Netlify is pointed at gh-pages, builds from main will fail intentionally.
 [build]
   publish = "site"
-  command = "make build-docs-netlify"
+  command = "echo 'Docs are published from gh-pages by GitHub Actions. Point Netlify production branch to gh-pages. See site-src/README.md.' && exit 1"
 
 [build.environment]
   PYTHON_VERSION = "3.12"

--- a/site-src/README.md
+++ b/site-src/README.md
@@ -67,28 +67,66 @@ make api-ref-docs
 
 This creates `site-src/reference/index.md` from the CRD types in `api/v1alpha1/`.
 
-**Note**: The generated `index.md` file is not committed to git - it's automatically generated during the build process (`make build-docs`, `make live-docs`, or `make build-docs-netlify`).
+**Note**: The generated `index.md` file is not committed to git - it's automatically generated during the build process (`make build-docs`, `make live-docs`, or CI).
+
+## Versioned Deployment
+
+Documentation is versioned with [mike](https://github.com/jimporter/mike) and published to the `gh-pages` branch. The live site at [mcp-lifecycle-operator.sigs.k8s.io](https://mcp-lifecycle-operator.sigs.k8s.io) uses a version selector:
+
+| Version | Source | Purpose |
+| ------- | ------ | ------- |
+| **latest** (default) | Git release tag | Matches [releases/latest](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/latest) install URLs |
+| **main** | `main` branch | Development preview for in-flight API and behavior |
+
+### How docs are published
+
+- **Releases**: `.github/workflows/docs.yaml` deploys automatically when a GitHub release is published. The release tag becomes a version; the `latest` alias is updated and set as the default.
+- **Main preview**: The same workflow deploys on every push to `main`.
+- **Manual redeploy**: Use **Actions → Docs → Run workflow** to redeploy a specific tag (useful for bootstrapping or fixing a broken version).
+
+### Netlify configuration
+
+Netlify publishes the pre-built `gh-pages` branch (no build step). One-time setup:
+
+1. **Production branch**: `gh-pages` (not `main`)
+2. **Build command**: (empty)
+3. **Publish directory**: `/`
+
+The `netlify.toml` on `gh-pages` is maintained automatically by `hack/mkdocs/deploy.sh`.
+
+### Local multi-version preview
+
+To preview deployed versions locally:
+
+```bash
+pip install -r hack/mkdocs/image/requirements.txt
+git fetch origin gh-pages
+mike serve
+```
+
+For day-to-day editing, use `make live-docs` or `./hack/mkdocs/local-serve.sh` (single-version preview from your working tree).
+
+## Deployment
+
+The website is deployed to Netlify from the **`gh-pages`** branch. Source changes on `main` trigger a GitHub Actions workflow that rebuilds the `main` preview version; release tags update the `latest` version.
+
+Netlify configuration: `netlify.toml` (on `gh-pages`; see [Versioned Deployment](#versioned-deployment))
 
 ## Technology Stack
 
 - **Static Site Generator**: MkDocs ~1.6
 - **Theme**: Material for MkDocs ~9.5
+- **Versioning**: [mike](https://github.com/jimporter/mike)
 - **Plugins**:
   - `awesome-pages`: Advanced navigation control
   - `mermaid2`: Diagram support
   - `search`: Full-text search
 
-## Deployment
-
-The website is deployed to Netlify automatically when changes are pushed to the main branch.
-
-Netlify configuration: `netlify.toml`
-
 ## Making Changes
 
 1. Edit content in `site-src/`
 2. Run `make live-docs` to preview changes
-3. Commit and push to trigger deployment
+3. Commit and push to `main` — the Docs workflow updates the **main** preview on gh-pages; release docs update when a GitHub release is published
 
 ## Content Guidelines
 

--- a/site-src/README.md
+++ b/site-src/README.md
@@ -86,7 +86,15 @@ Documentation is versioned with [mike](https://github.com/jimporter/mike) and pu
 
 ### Netlify configuration
 
-Netlify publishes the pre-built `gh-pages` branch (no build step). One-time setup:
+Netlify publishes the pre-built `gh-pages` branch (no build step). Complete these steps **in order** after the versioning PR merges:
+
+1. **Merge** the versioning PR to `main`
+2. **Bootstrap `latest`**: run **Actions → Docs → Deploy docs (manual)** with `v0.1.0` (or the current release tag)
+3. **Switch Netlify** production branch to `gh-pages` (build command empty, publish `/`)
+
+Until step 3, main-branch production Netlify builds fail by design; the last good production deploy stays live.
+
+Ongoing Netlify settings:
 
 1. **Production branch**: `gh-pages` (not `main`)
 2. **Build command**: (empty)

--- a/site-src/guides/index.md
+++ b/site-src/guides/index.md
@@ -15,7 +15,7 @@ Check out the [examples directory](https://github.com/kubernetes-sigs/mcp-lifecy
 
 ## Additional Resources
 
-- [API Reference](../reference/) - Complete API documentation
+- [API Reference](../reference/index.md) - Complete API documentation
 - [Metrics](../operating/metrics.md) - Prometheus metrics exposed by the operator
 - [Contributing Guide](../contributing/index.md) - How to contribute to the project
 - [SIG Apps](https://github.com/kubernetes/community/blob/main/sig-apps/README.md) - Join the community and attend meetings

--- a/site-src/guides/quickstart.md
+++ b/site-src/guides/quickstart.md
@@ -247,4 +247,4 @@ make uninstall
 - Explore more examples:
   - [kubernetes-mcp-server examples](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/tree/main/examples/kubernetes-mcp-server) - Basic, ConfigMap, and RBAC examples
   - [All examples](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/tree/main/examples)
-- Check the [API Reference](../reference/) for all configuration options
+- Check the [API Reference](../reference/index.md) for all configuration options

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -136,7 +136,7 @@ The operator watches for `MCPServer` resources and automatically:
 
 - **Get Started**: Follow the [Quickstart Guide](guides/quickstart.md)
 - **Examples**: Check out the [examples directory](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/tree/main/examples)
-- **API Reference**: See the [API documentation](reference/) for all available fields
+- **API Reference**: See the [API documentation](reference/index.md) for all available fields
 - **Complete Example**: See the [complete MCPServer sample](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/blob/main/config/samples/mcp_v1alpha1_mcpserver_complete.yaml) for a YAML with every field
 - **Contributing**: Read the [Contributing Guide](contributing/index.md) to get involved
 - **Community**: Join [SIG Apps](https://github.com/kubernetes/community/blob/main/sig-apps/README.md) meetings and discussions


### PR DESCRIPTION
## Summary

- Add versioned documentation using [mike](https://github.com/jimporter/mike): **latest** (default, aligned with `releases/latest`) and **main** (development preview)
- Add `.github/workflows/docs.yaml` to lint docs on PRs, deploy `main` preview on push, and deploy release docs on GitHub release publish
- Point Netlify publishing at the pre-built `gh-pages` branch (with one-time Netlify config change documented in `site-src/README.md`)
- Extend release issue templates with a docs deployment verification step

Closes #222

## Post-merge migration sequence

Complete these steps **in order** — merge alone does not finish the migration:

1. **Merge** this PR to `main`
2. **Bootstrap `latest`**: run **Actions → Docs → Deploy docs (manual)** with `v0.1.0` (or the current release tag)
3. **Switch Netlify** production branch to `gh-pages` (build command empty, publish `/`)

Until step 3, main-branch production Netlify builds fail by design (`netlify.toml` intentional `exit 1`); the last good production deploy stays live.

## Test plan

- [x] Docs workflow **Lint docs** job passes on this PR
- [ ] After merge: run **Docs → Deploy docs (manual)** workflow for `v0.1.0` to bootstrap the `latest` version on `gh-pages`
- [ ] Update Netlify production branch to `gh-pages` (build command empty, publish `/`)
- [ ] Verify https://mcp-lifecycle-operator.sigs.k8s.io/ shows version selector with `latest` and `main`
- [ ] Publish a test release and confirm `latest` updates automatically