### PR TITLE
Increase controller-manager memory limit to 512Mi

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -90,10 +90,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
         volumeMounts: []
       volumes: []
       serviceAccountName: controller-manager


### PR DESCRIPTION
## Summary

- Increase the controller-manager memory **limit** from 128Mi to **512Mi** and **request** from 64Mi to **128Mi** in `config/manager/manager.yaml`
- Addresses OOMKilled operator pods during MCPServer reconciliation reported in #230

The default 128Mi comes from the Kubebuilder scaffold and is too low for a controller-runtime operator that watches Deployments, Services, ConfigMaps, and Secrets. The suggested workaround in #230 (patch to 512Mi) matches the debug deployment profile already used in this repo (`config/manager-debug/increase_resources.yaml`).

## Reproduction notes

On a Kind cluster with the operator deployed at the default 128Mi limit:

- Created 35 MCPServers with storage mounts (ConfigMap + Secret + EmptyDir), a custom ServiceAccount, and 2 replicas each
- Triggered repeated ConfigMap updates to drive reconciliation storms
- Did not hit OOMKilled on Kind, but operator memory reached ~69Mi (~54% of the 128Mi limit) via cgroup metrics
- On OpenShift with platform overhead and larger workloads, exceeding 128Mi during reconciliation spikes is plausible

## Test plan

- [x] Built operator image and deployed to Kind with updated limits
- [x] Verified deployment spec shows `limits.memory: 512Mi` and `requests.memory: 128Mi`
- [x] Operator pod stays Running under MCPServer reconciliation load

Fixes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased controller-manager memory allocation to improve stability and performance: memory limit raised to 512Mi and memory request raised to 128Mi.
  * This adjustment reduces risk of memory-related restarts under load and provides more headroom for background processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->