### PR TITLE
docs: fix website documentation for introduction and quickstart

### DIFF
--- a/site-src/guides/quickstart.md
+++ b/site-src/guides/quickstart.md
@@ -6,7 +6,7 @@ This guide will walk you through deploying your first MCP server using the MCP L
 
 - Kubernetes cluster (v1.28+)
 - kubectl configured to access your cluster
-- Go 1.25+ (only needed for building from source)
+- Go 1.26+ (only needed for building from source)
 
 ## Installation
 

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -122,7 +122,7 @@ spec:
     stateless: true
 ```
 
-The `stateless` field indicates whether the MCP server maintains session state. When `true`, the generated Service allows requests to be freely load-balanced across replicas. When `false` or unset (the default), the Service uses `SessionAffinity: ClientIP` so a given client's requests are routed to the same pod.
+The `stateless` field indicates whether the MCP server maintains session state. When `true`, the generated Service uses `SessionAffinity: None`, allowing requests to be freely load-balanced across replicas. When `false` or unset (the default), the Service uses `SessionAffinity: ClientIP` so a given client's requests are routed to the same pod.
 
 ## Status and Discovery
 

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -35,7 +35,7 @@ spec:
     prometheus.io/scrape: "true"
 ```
 
-The operator-managed keys `app` and `mcp-server` cannot be overridden by `extraLabels`.
+The operator-managed keys `app` and `mcp-server` cannot be overridden by `extraLabels`. Annotations prefixed with `mcp.x-k8s.io/` cannot be overridden by `extraAnnotations`.
 
 #### Server Configuration
 

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -22,6 +22,21 @@ spec:
       ref: registry.io/mcp-server:v1.0.0
 ```
 
+#### Custom Labels and Annotations
+
+Add custom labels and annotations to the managed Deployment, PodTemplate, and Service:
+
+```yaml
+spec:
+  extraLabels:
+    team: platform
+    environment: production
+  extraAnnotations:
+    prometheus.io/scrape: "true"
+```
+
+The operator-managed keys `app` and `mcp-server` cannot be overridden by `extraLabels`.
+
 #### Server Configuration
 
 Configure the server's networking, arguments, environment variables, and storage mounts:
@@ -85,10 +100,29 @@ spec:
           port: 8080
     security:
       serviceAccountName: mcp-viewer
-      securityContext:
+      podSecurityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      securityContext:
+        allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
 ```
+
+#### MCP Protocol Configuration
+
+Configure MCP protocol-specific behavior:
+
+```yaml
+spec:
+  mcp:
+    stateless: true
+```
+
+The `stateless` field indicates whether the MCP server maintains session state. When `true`, the generated Service allows requests to be freely load-balanced across replicas. When `false` or unset (the default), the Service uses `SessionAffinity: ClientIP` so a given client's requests are routed to the same pod.
 
 ## Status and Discovery
 


### PR DESCRIPTION
- Fix security config YAML to show both podSecurityContext and securityContext matching the actual SecurityConfig API struct
- Add MCP Protocol Configuration section documenting the stateless field and its effect on Service session affinity
- Add Custom Labels and Annotations section documenting extraLabels and extraAnnotations fields
- Update Go version prerequisite from 1.25+ to 1.26+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Quickstart now requires Go 1.26+ when building from source.
  * Expanded MCPServer guide with instructions for adding custom labels and annotations (notes on protected keys).
  * Added an explicit MCP Protocol Configuration section explaining stateless mode and its load-balancing behavior versus the default session-affinity.
  * Included hardened runtime security recommendations (pod security context, strict container security settings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->