### PR TITLE
docs: update Go version and add missing fields to complete sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ For more examples, see the [examples/](./examples/) directory:
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 
 ### Building
 

--- a/config/samples/mcp_v1alpha1_mcpserver_complete.yaml
+++ b/config/samples/mcp_v1alpha1_mcpserver_complete.yaml
@@ -1,5 +1,5 @@
 # Complete MCPServer example showing all available fields.
-# Most fields are optional — see the API reference for details:
+# Most fields are optional - see the API reference for details:
 # https://mcp-lifecycle-operator.sigs.k8s.io/reference/
 apiVersion: mcp.x-k8s.io/v1alpha1
 kind: MCPServer
@@ -7,6 +7,16 @@ metadata:
   name: complete-example
   namespace: default
 spec:
+  # Extra labels applied to the Deployment, PodTemplate, and Service metadata.
+  # The operator-managed keys "app" and "mcp-server" cannot be overridden.
+  extraLabels:
+    team: platform
+    environment: production
+
+  # Extra annotations applied to the Deployment, PodTemplate, and Service metadata.
+  extraAnnotations:
+    prometheus.io/scrape: "true"
+
   # Source defines where the MCP server container image is located.
   source:
     type: ContainerImage
@@ -121,3 +131,10 @@ spec:
         periodSeconds: 10
         timeoutSeconds: 3
         failureThreshold: 2
+
+  # MCP protocol-specific configuration.
+  mcp:
+    # Whether the MCP server is stateless (no session state).
+    # When true, the Service uses SessionAffinity "None" for free load balancing.
+    # When false (default), the Service uses SessionAffinity "ClientIP".
+    stateless: false


### PR DESCRIPTION
Update the Go prerequisite from 1.25+ to 1.26+ in README.md, and add the missing extraLabels, extraAnnotations, and mcp sections to the complete MCPServer sample YAML so it covers all available API fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Development prerequisites updated to require Go 1.26+ (was Go 1.25+).

* **Configuration**
  * Example MCPServer manifests now show how to add operator-applied labels and annotations (including a Prometheus scrape example) and include a stateless option to control Service session affinity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->