### PR TITLE
docs: update RELEASE.md to reflect actual release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-patch-release.md
+++ b/.github/ISSUE_TEMPLATE/new-patch-release.md
@@ -33,7 +33,8 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
   ```bash
   git push upstream v0.MINOR.PATCH
   ```
-  This triggers Cloud Build to build and publish the staging image.
+  Note: the staging image is built by the postsubmit job when the pinning
+  PR merges to the release branch. The tag must point at that commit.
 - [ ] Submit PR to
   [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) updating
   `registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/images.yaml`

--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -40,7 +40,8 @@ assignees: aliok, ArangoGutierrez, matzew, mikebrow, mrunalp, soltysh
   ```bash
   git push upstream v0.MINOR.0
   ```
-  This triggers Cloud Build to build and publish the staging image.
+  Note: the staging image is built by the postsubmit job when the pinning
+  PR merges to the release branch. The tag must point at that commit.
 - [ ] Submit PR to
   [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) updating
   `registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/images.yaml`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,52 @@
 # Release Process
 
-The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
+The MCP Lifecycle Operator is released on an as-needed basis. The process is as follows:
 
-1. An issue is proposing a new release with a changelog since the last release
-1. All [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
-1. The release issue is closed
-1. An announcement email is sent to `dev@kubernetes.io` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`
+## Issue Templates
+
+Two GitHub issue templates are provided under `.github/ISSUE_TEMPLATE/`:
+
+- **new-release.md** - for major/minor releases (creates a release branch, runs
+  the full checklist)
+- **new-patch-release.md** - for patch releases (cherry-picks to an existing
+  release branch)
+
+See `docs/release-v0.1.0-issue.md` for a concrete example of a completed
+release issue.
+
+## Process
+
+1. Open a release issue using the appropriate template, filling in the changelog
+   since the previous release.
+1. All [OWNERS](OWNERS) must LGTM the release proposal.
+1. Create (or verify) the release branch `release-0.MINOR` and push it to
+   upstream.
+1. Verify the [postsubmit image-pushing job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-mcp-lifecycle-operator.yaml)
+   covers the release branch (the existing `^release-` pattern should match).
+1. Verify the Go version in the Prow job image matches `go.mod`.
+1. Pin the image tag in `config/manager/kustomization.yaml` on the release
+   branch (submit a PR against the release branch).
+1. Ensure all CI (lint, unit tests, e2e) passes on the release branch.
+1. An OWNER creates a signed tag and pushes it:
+   ```bash
+   git tag -s -m "mcp-lifecycle-operator release $VERSION" $VERSION
+   git push upstream $VERSION
+   ```
+   Pushing the tag triggers Cloud Build to build and publish the staging image.
+1. Submit a PR to
+   [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) updating
+   `registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/images.yaml` to
+   promote the container image to production.
+   Wait for merge and verify image availability:
+   ```bash
+   crane manifest registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:$VERSION
+   ```
+1. Generate the install manifest:
+   ```bash
+   IMG=registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:$VERSION make build-installer
+   ```
+1. Create a [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
+   with the changelog; attach `dist/install.yaml` as a release asset.
+1. Send an announcement email to `dev@kubernetes.io` with subject:
+   `[ANNOUNCE] mcp-lifecycle-operator $VERSION is released`
+1. Close the release issue.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,11 +4,11 @@ The MCP Lifecycle Operator is released on an as-needed basis. The process is as 
 
 ## Issue Templates
 
-Two GitHub issue templates are provided under `.github/ISSUE_TEMPLATE/`:
+Two GitHub issue templates are provided under [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/):
 
-- **new-release.md** - for major/minor releases (creates a release branch, runs
+- [**new-release.md**](.github/ISSUE_TEMPLATE/new-release.md) - for major/minor releases (creates a release branch, runs
   the full checklist)
-- **new-patch-release.md** - for patch releases (cherry-picks to an existing
+- [**new-patch-release.md**](.github/ISSUE_TEMPLATE/new-patch-release.md) - for patch releases (cherry-picks to an existing
   release branch)
 
 See `docs/release-v0.1.0-issue.md` for a concrete example of a completed
@@ -16,37 +16,8 @@ release issue.
 
 ## Process
 
-1. Open a release issue using the appropriate template, filling in the changelog
-   since the previous release.
-1. All [OWNERS](OWNERS) must LGTM the release proposal.
-1. Create (or verify) the release branch `release-0.MINOR` and push it to
-   upstream.
-1. Verify the [postsubmit image-pushing job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-mcp-lifecycle-operator.yaml)
-   covers the release branch (the existing `^release-` pattern should match).
-1. Verify the Go version in the Prow job image matches `go.mod`.
-1. Pin the image tag in `config/manager/kustomization.yaml` on the release
-   branch (submit a PR against the release branch).
-1. Ensure all CI (lint, unit tests, e2e) passes on the release branch.
-1. An OWNER creates a signed tag and pushes it:
-   ```bash
-   git tag -s -m "mcp-lifecycle-operator release $VERSION" $VERSION
-   git push upstream $VERSION
-   ```
-   Pushing the tag triggers Cloud Build to build and publish the staging image.
-1. Submit a PR to
-   [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io) updating
-   `registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/images.yaml` to
-   promote the container image to production.
-   Wait for merge and verify image availability:
-   ```bash
-   crane manifest registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:$VERSION
-   ```
-1. Generate the install manifest:
-   ```bash
-   IMG=registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:$VERSION make build-installer
-   ```
-1. Create a [GitHub release](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/releases/new)
-   with the changelog; attach `dist/install.yaml` as a release asset.
-1. Send an announcement email to `dev@kubernetes.io` with subject:
-   `[ANNOUNCE] mcp-lifecycle-operator $VERSION is released`
-1. Close the release issue.
+Open a release issue using the appropriate template above. The template
+contains the complete step-by-step checklist for the release, including branch
+management, CI verification, image promotion, and artifact generation.
+
+All [OWNERS](OWNERS) must LGTM the release proposal before proceeding.


### PR DESCRIPTION
Replace the boilerplate Kubernetes Template Project content with the real MCP Lifecycle Operator release process, referencing the issue templates, Cloud Build, image promotion, and install.yaml artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the prior release procedure with a new MCP Lifecycle Operator release process and step-by-step workflow.
  * Added standardized issue templates for major/minor and patch releases, including an example completed release issue.
  * Clarified that staging images are produced by the postsubmit image-pushing job after merges to the release branch and that the release tag must point to that same commit.
  * Require all OWNERS to LGTM release proposals before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->