### PR TITLE
chore: set tag to v0.2.0

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: mcp-lifecycle-operator
-  newTag: latest
+  newTag: v0.2.0


### PR DESCRIPTION
set kustomization tag to `v0.2.0` for release 