### PR TITLE
fix: remove unnecessary RBAC verbs from controller ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,10 +26,8 @@ rules:
   - services
   verbs:
   - create
-  - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -46,10 +44,8 @@ rules:
   - deployments
   verbs:
   - create
-  - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -57,19 +53,9 @@ rules:
   resources:
   - mcpservers
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - mcp.x-k8s.io
-  resources:
-  - mcpservers/finalizers
-  verbs:
-  - update
 - apiGroups:
   - mcp.x-k8s.io
   resources:
@@ -77,4 +63,3 @@ rules:
   verbs:
   - get
   - patch
-  - update

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -159,11 +159,10 @@ type MCPServerReconciler struct {
 	APIReader client.Reader
 }
 
-// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers/finalizers,verbs=update
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers/status,verbs=get;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list


### PR DESCRIPTION
Drop unused verbs from the manager-role ClusterRole:

* mcpservers: reduce to get/list/watch (controller only reads the main resource, status and finalizers have separate RBAC entries)
* deployments/services: remove delete and patch (controller uses create/update, cleanup is handled by owner-reference)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Tightened access controls by reducing Kubernetes RBAC write permissions.
  * Core services and deployments no longer allow delete/patch operations.
  * MCP server permissions are now restricted to read-only actions (get/list/watch).
  * MCP server status updates are further restricted to get/patch (removing broader update capability).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->