### PR TITLE
fix: remove misleading doc about empty arguments array

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/serverconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/serverconfig.go
@@ -36,7 +36,6 @@ type ServerConfigApplyConfiguration struct {
 	// Use this to pass configuration flags to the server.
 	// Example: ["--config", "/etc/mcp-config/config.toml", "--verbose"]
 	// When not specified, the container image's default arguments (CMD/ENTRYPOINT) are used.
-	// An empty array [] is allowed and will override the container image's default arguments with no arguments.
 	// Empty strings within the array are not allowed.
 	Arguments []string `json:"arguments,omitempty"`
 	// Env is a list of environment variables to set in the MCP server container.

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -180,7 +180,6 @@ type ServerConfig struct {
 	// Use this to pass configuration flags to the server.
 	// Example: ["--config", "/etc/mcp-config/config.toml", "--verbose"]
 	// When not specified, the container image's default arguments (CMD/ENTRYPOINT) are used.
-	// An empty array [] is allowed and will override the container image's default arguments with no arguments.
 	// Empty strings within the array are not allowed.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self.all(arg, arg.size() > 0)",message="arguments must not contain empty strings"

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -81,7 +81,6 @@ spec:
                       Use this to pass configuration flags to the server.
                       Example: ["--config", "/etc/mcp-config/config.toml", "--verbose"]
                       When not specified, the container image's default arguments (CMD/ENTRYPOINT) are used.
-                      An empty array [] is allowed and will override the container image's default arguments with no arguments.
                       Empty strings within the array are not allowed.
                     items:
                       type: string


### PR DESCRIPTION
The doc comment claimed that `arguments: []` would override the container image's default arguments with no arguments. This is impossible because the Kubernetes container spec's `args` field uses `omitempty`, so empty arrays are normalized to nil after an API server round-trip (not only in the MCPServer CR, but also in the underlying Deployment which is out of our control). Remove the misleading claim and add tests covering nil vs provided arguments behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for the Arguments configuration field to clarify handling of empty array values and their interaction with container image defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->