### PR TITLE
fix: retry on conflict in E2E tests to eliminate flaky failures

### DIFF
--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -861,8 +861,8 @@ func TestCustomMetadataUpdate(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func() {
-				server.Spec.ExtraLabels = map[string]string{"team": "beta", "tier": "backend"}
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+				s.Spec.ExtraLabels = map[string]string{"team": "beta", "tier": "backend"}
 			})
 			t.Log("updated MCPServer labels to {team:beta, tier:backend}")
 

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -861,14 +861,9 @@ func TestCustomMetadataUpdate(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
-				t.Fatalf("failed to get MCPServer: %v", err)
-			}
-
-			server.Spec.ExtraLabels = map[string]string{"team": "beta", "tier": "backend"}
-			if err := r.Update(ctx, server); err != nil {
-				t.Fatalf("failed to update MCPServer labels: %v", err)
-			}
+			f.UpdateWithRetry(ctx, t, r, server, func() {
+				server.Spec.ExtraLabels = map[string]string{"team": "beta", "tier": "backend"}
+			})
 			t.Log("updated MCPServer labels to {team:beta, tier:backend}")
 
 			return ctx

--- a/test/e2e/failure_scenarios_test.go
+++ b/test/e2e/failure_scenarios_test.go
@@ -424,8 +424,8 @@ func TestRecoveryFromImagePullFailure(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func() {
-				server.Spec.Source.ContainerImage.Ref = "quay.io/matzew/mcp-everything:latest"
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+				s.Spec.Source.ContainerImage.Ref = "quay.io/matzew/mcp-everything:latest"
 			})
 			t.Log("updated image to quay.io/matzew/mcp-everything:latest")
 

--- a/test/e2e/failure_scenarios_test.go
+++ b/test/e2e/failure_scenarios_test.go
@@ -424,14 +424,9 @@ func TestRecoveryFromImagePullFailure(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
-				t.Fatalf("failed to get MCPServer: %v", err)
-			}
-
-			server.Spec.Source.ContainerImage.Ref = "quay.io/matzew/mcp-everything:latest"
-			if err := r.Update(ctx, server); err != nil {
-				t.Fatalf("failed to update MCPServer image: %v", err)
-			}
+			f.UpdateWithRetry(ctx, t, r, server, func() {
+				server.Spec.Source.ContainerImage.Ref = "quay.io/matzew/mcp-everything:latest"
+			})
 			t.Log("updated image to quay.io/matzew/mcp-everything:latest")
 
 			f.WaitForMCPServerReconciledAndReady(ctx, t, r, server, 5*time.Minute)

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -275,16 +275,16 @@ func WaitForEndpointsReady(ctx context.Context, t *testing.T, cfg *envconf.Confi
 }
 
 // UpdateWithRetry performs a read-modify-write loop with automatic retry on
-// conflict. The mutate callback is called after each fresh Get so the caller
-// always modifies the latest resourceVersion.
-func UpdateWithRetry(ctx context.Context, t *testing.T, r *resources.Resources,
-	obj k8s.Object, mutate func()) {
+// conflict. The mutate callback receives the freshly-fetched object so the
+// caller always modifies the latest resourceVersion.
+func UpdateWithRetry[T k8s.Object](ctx context.Context, t *testing.T, r *resources.Resources,
+	obj T, mutate func(T)) {
 	t.Helper()
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := r.Get(ctx, obj.GetName(), obj.GetNamespace(), obj); err != nil {
 			return err
 		}
-		mutate()
+		mutate(obj)
 		return r.Update(ctx, obj)
 	})
 	if err != nil {

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -30,6 +30,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -271,4 +272,23 @@ func WaitForEndpointsReady(ctx context.Context, t *testing.T, cfg *envconf.Confi
 		t.Fatalf("endpoints for Service %s/%s never became ready: %v", namespace, name, err)
 	}
 	t.Logf("Service %s/%s has ready endpoints", namespace, name)
+}
+
+// UpdateWithRetry performs a read-modify-write loop with automatic retry on
+// conflict. The mutate callback is called after each fresh Get so the caller
+// always modifies the latest resourceVersion.
+func UpdateWithRetry(ctx context.Context, t *testing.T, r *resources.Resources,
+	obj k8s.Object, mutate func()) {
+	t.Helper()
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := r.Get(ctx, obj.GetName(), obj.GetNamespace(), obj); err != nil {
+			return err
+		}
+		mutate()
+		return r.Update(ctx, obj)
+	})
+	if err != nil {
+		t.Fatalf("failed to update %s/%s after retries: %v",
+			obj.GetNamespace(), obj.GetName(), err)
+	}
 }

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -118,14 +118,9 @@ func TestMCPServerUpdatePort(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
-				t.Fatalf("failed to get MCPServer: %v", err)
-			}
-
-			server.Spec.Config.Port = 3002
-			if err := r.Update(ctx, server); err != nil {
-				t.Fatalf("failed to update MCPServer port: %v", err)
-			}
+			f.UpdateWithRetry(ctx, t, r, server, func() {
+				server.Spec.Config.Port = 3002
+			})
 			t.Log("updated MCPServer port to 3002")
 
 			return ctx

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 )
 
@@ -118,8 +119,8 @@ func TestMCPServerUpdatePort(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func() {
-				server.Spec.Config.Port = 3002
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+				s.Spec.Config.Port = 3002
 			})
 			t.Log("updated MCPServer port to 3002")
 

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -56,14 +56,9 @@ func TestImageUpdate(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
-				t.Fatalf("failed to get MCPServer: %v", err)
-			}
-
-			server.Spec.Source.ContainerImage.Ref = digestRef
-			if err := r.Update(ctx, server); err != nil {
-				t.Fatalf("failed to update MCPServer image: %v", err)
-			}
+			f.UpdateWithRetry(ctx, t, r, server, func() {
+				server.Spec.Source.ContainerImage.Ref = digestRef
+			})
 			t.Log("updated image to digest ref")
 
 			return ctx
@@ -120,25 +115,20 @@ func TestStorageAddition(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
-				t.Fatalf("failed to get MCPServer: %v", err)
-			}
-
-			server.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
-				{
-					Path:        "/etc/added-config",
-					Permissions: mcpv1alpha1.MountPermissionsReadOnly,
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeConfigMap,
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: "add-config"},
+			f.UpdateWithRetry(ctx, t, r, server, func() {
+				server.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+					{
+						Path:        "/etc/added-config",
+						Permissions: mcpv1alpha1.MountPermissionsReadOnly,
+						Source: mcpv1alpha1.StorageSource{
+							Type: mcpv1alpha1.StorageTypeConfigMap,
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "add-config"},
+							},
 						},
 					},
-				},
-			}
-			if err := r.Update(ctx, server); err != nil {
-				t.Fatalf("failed to update MCPServer storage: %v", err)
-			}
+				}
+			})
 			t.Log("added ConfigMap storage mount")
 
 			return ctx
@@ -223,14 +213,9 @@ func TestStorageRemoval(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
-				t.Fatalf("failed to get MCPServer: %v", err)
-			}
-
-			server.Spec.Config.Storage = nil
-			if err := r.Update(ctx, server); err != nil {
-				t.Fatalf("failed to update MCPServer storage: %v", err)
-			}
+			f.UpdateWithRetry(ctx, t, r, server, func() {
+				server.Spec.Config.Storage = nil
+			})
 			t.Log("removed storage mount")
 
 			return ctx
@@ -284,15 +269,10 @@ func TestReplicaDrift(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			dep := &appsv1.Deployment{}
-			if err := r.Get(ctx, server.Name, server.Namespace, dep); err != nil {
-				t.Fatalf("Deployment not found: %v", err)
-			}
-
-			dep.Spec.Replicas = ptr.To(int32(3))
-			if err := r.Update(ctx, dep); err != nil {
-				t.Fatalf("failed to scale Deployment: %v", err)
-			}
+			dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace}}
+			f.UpdateWithRetry(ctx, t, r, dep, func() {
+				dep.Spec.Replicas = ptr.To(int32(3))
+			})
 			t.Log("manually scaled Deployment to 3 replicas")
 
 			expectedReplicas := int32(1)
@@ -334,18 +314,13 @@ func TestServicePortDrift(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			svc := &corev1.Service{}
-			if err := r.Get(ctx, server.Name, server.Namespace, svc); err != nil {
-				t.Fatalf("Service not found: %v", err)
-			}
-
-			if len(svc.Spec.Ports) == 0 {
-				t.Fatal("expected at least one port in Service spec")
-			}
-			svc.Spec.Ports[0].Port = 9999
-			if err := r.Update(ctx, svc); err != nil {
-				t.Fatalf("failed to change Service port: %v", err)
-			}
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace}}
+			f.UpdateWithRetry(ctx, t, r, svc, func() {
+				if len(svc.Spec.Ports) == 0 {
+					t.Fatal("expected at least one port in Service spec")
+				}
+				svc.Spec.Ports[0].Port = 9999
+			})
 			t.Log("manually changed Service port to 9999")
 
 			expectedPort := server.Spec.Config.Port
@@ -620,15 +595,10 @@ func TestConfigMapDataUpdateTriggersRestart(t *testing.T) {
 			ns := ctx.Value(f.NsKey).(string)
 			r := cfg.Client().Resources()
 
-			cm := &corev1.ConfigMap{}
-			if err := r.Get(ctx, "hash-config", ns, cm); err != nil {
-				t.Fatalf("failed to get ConfigMap: %v", err)
-			}
-
-			cm.Data["setting"] = "updated"
-			if err := r.Update(ctx, cm); err != nil {
-				t.Fatalf("failed to update ConfigMap: %v", err)
-			}
+			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "hash-config", Namespace: ns}}
+			f.UpdateWithRetry(ctx, t, r, cm, func() {
+				cm.Data["setting"] = "updated"
+			})
 			t.Log("updated ConfigMap data")
 
 			return ctx

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -56,8 +56,8 @@ func TestImageUpdate(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func() {
-				server.Spec.Source.ContainerImage.Ref = digestRef
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+				s.Spec.Source.ContainerImage.Ref = digestRef
 			})
 			t.Log("updated image to digest ref")
 
@@ -115,8 +115,8 @@ func TestStorageAddition(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func() {
-				server.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+				s.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
 					{
 						Path:        "/etc/added-config",
 						Permissions: mcpv1alpha1.MountPermissionsReadOnly,
@@ -213,8 +213,8 @@ func TestStorageRemoval(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func() {
-				server.Spec.Config.Storage = nil
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+				s.Spec.Config.Storage = nil
 			})
 			t.Log("removed storage mount")
 
@@ -270,8 +270,8 @@ func TestReplicaDrift(t *testing.T) {
 			r := cfg.Client().Resources()
 
 			dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace}}
-			f.UpdateWithRetry(ctx, t, r, dep, func() {
-				dep.Spec.Replicas = ptr.To(int32(3))
+			f.UpdateWithRetry(ctx, t, r, dep, func(d *appsv1.Deployment) {
+				d.Spec.Replicas = ptr.To(int32(3))
 			})
 			t.Log("manually scaled Deployment to 3 replicas")
 
@@ -315,11 +315,11 @@ func TestServicePortDrift(t *testing.T) {
 			r := cfg.Client().Resources()
 
 			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace}}
-			f.UpdateWithRetry(ctx, t, r, svc, func() {
-				if len(svc.Spec.Ports) == 0 {
+			f.UpdateWithRetry(ctx, t, r, svc, func(s *corev1.Service) {
+				if len(s.Spec.Ports) == 0 {
 					t.Fatal("expected at least one port in Service spec")
 				}
-				svc.Spec.Ports[0].Port = 9999
+				s.Spec.Ports[0].Port = 9999
 			})
 			t.Log("manually changed Service port to 9999")
 
@@ -596,8 +596,8 @@ func TestConfigMapDataUpdateTriggersRestart(t *testing.T) {
 			r := cfg.Client().Resources()
 
 			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "hash-config", Namespace: ns}}
-			f.UpdateWithRetry(ctx, t, r, cm, func() {
-				cm.Data["setting"] = "updated"
+			f.UpdateWithRetry(ctx, t, r, cm, func(c *corev1.ConfigMap) {
+				c.Data["setting"] = "updated"
 			})
 			t.Log("updated ConfigMap data")
 


### PR DESCRIPTION
- Add `UpdateWithRetry` helper to the E2E test framework wrapping `retry.RetryOnConflict`
- Replace all bare Get -> Update sequences in E2E tests with the new helper
- Fixes flaky `TestCustomMetadataUpdate` caused by a resource version race between the test client and the controller's reconciliation loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved end-to-end test stability by introducing automatic retry handling for common read-modify-write updates.
  * Updated multiple E2E scenarios to use the new retry-based update flow, including image changes, custom metadata/label updates, storage updates, replica/service drift induction, ConfigMap data updates, port updates, and recovery from image pull failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->