### PR TITLE
fix: replace wildcard verb with explicit RBAC verbs in admin role

### DIFF
--- a/config/rbac/mcpserver_admin_role.yaml
+++ b/config/rbac/mcpserver_admin_role.yaml
@@ -4,7 +4,7 @@
 # This rule is not used by the project mcp-lifecycle-operator itself.
 # It is provided to allow the cluster admin to help manage permissions for users.
 #
-# Grants full permissions ('*') over mcp.x-k8s.io.
+# Grants full CRUD permissions over mcp.x-k8s.io.
 # This role is intended for users authorized to modify roles and bindings within the cluster,
 # enabling them to delegate specific permissions to other users or groups as needed.
 
@@ -23,7 +23,14 @@ rules:
   resources:
   - mcpservers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - mcp.x-k8s.io
   resources:


### PR DESCRIPTION
## Summary
- Replaces the `*` wildcard verb in `mcpserver-admin-role` with explicit verbs (`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`, `deletecollection`) to follow the principle of least privilege.
- Updates the comment to reflect the change.

This is consistent with the approach taken in #239 for the controller ClusterRole.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP Server admin permissions configuration to use explicit access controls instead of blanket permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->