### PR TITLE
fix: set GOMEMLIMIT for container memory awareness

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,9 @@ spec:
         image: controller:latest
         name: manager
         ports: []
+        env:
+        - name: GOMEMLIMIT
+          value: "460MiB"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Set GOMEMLIMIT to 460MiB (90% of the 512Mi limit) so the Go GC stays within the cgroup memory budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated controller-manager memory resource allocation to optimize performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->