### PR TITLE
fix: pin kind version and verify checksum in E2E workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -23,11 +23,15 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install the latest version of kind
+      - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-$(go env GOARCH)
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+          KIND_VERSION=v0.32.0
+          KIND_BINARY="kind-linux-$(go env GOARCH)"
+          curl -Lo "./${KIND_BINARY}" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BINARY}"
+          curl -Lo "./${KIND_BINARY}.sha256sum" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/${KIND_BINARY}.sha256sum"
+          sha256sum -c "./${KIND_BINARY}.sha256sum"
+          chmod +x "./${KIND_BINARY}"
+          sudo mv "./${KIND_BINARY}" /usr/local/bin/kind
 
       - name: Verify kind installation
         run: kind version


### PR DESCRIPTION
Pin kind to v0.32.0 and verify the download against the official sha256 checksum.