### PR TITLE
Split Go minimum version from preferred toolchain

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -46,16 +46,26 @@ module.exports = {
       "groupName": "sigs.k8s.io dependencies",
       "matchPackageNames": ["sigs.k8s.io/{/,}**"],
     },
-    // Keep Dockerfile golang image versions in sync with go.mod
+    // Keep the preferred Go toolchain and Dockerfile image in sync
     {
       "matchManagers": ["dockerfile"],
       "matchPackageNames": ["golang"],
       "groupName": "go version",
     },
-    // Group gomod go version updates with Dockerfile golang updates
+    // Keep go.mod's toolchain directive grouped with Dockerfile golang updates
     {
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
+      "matchDepTypes": ["toolchain"],
+      "groupName": "go version",
+    },
+    // Only bump the minimum supported Go version when adopting a new minor
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "matchUpdateTypes": ["minor"],
+      "rangeStrategy": "bump",
       "groupName": "go version",
     },
     // Group GitHub Actions updates together

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
## Summary

- separate the minimum supported Go version from the preferred build toolchain
- keep `go.mod` at `go 1.26.0` for compatibility, while using `toolchain go1.26.4` for the preferred compiler
- adjust Renovate so Go patch updates stay tied to the toolchain and Dockerfile, without rewriting the minimum supported version

## Why

Downstream soft forks do not always have the newest GoBuilder version available as soon as upstream starts using a new Go patch release. This change makes this repository easier to consume by allowing downstreams to continue building with an older but still compatible compiler, while upstream and anyone using the default build setup still get the latest compiler fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go version settings and pinned the Go toolchain for more consistent builds.
  * Refined update grouping so Go-related version changes are handled together more predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->