### PR TITLE
feat: reconcile NetworkPolicy per MCPServer operand

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -34,7 +34,7 @@ resources:
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
 # be able to communicate with the Webhook Server.
-#- ../network-policy
+- ../network-policy
 
 # Uncomment the patches line if you enable Metrics
 patches:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -63,3 +63,13 @@ rules:
   verbs:
   - get
   - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -28,9 +28,10 @@ const ManagedWorkloadName = "mcp-server"
 
 // ReconcilePhase is the value for the "phase" label on mcpserver_reconcile_phase_duration_seconds.
 const (
-	ReconcilePhaseValidation = "validation"
-	ReconcilePhaseDeployment = "deployment"
-	ReconcilePhaseService    = "service"
+	ReconcilePhaseValidation    = "validation"
+	ReconcilePhaseDeployment    = "deployment"
+	ReconcilePhaseService       = "service"
+	ReconcilePhaseNetworkPolicy = "networkpolicy"
 )
 
 // MetricReasonReconcileError is the `reason` label on deployment/service failure counters

--- a/internal/controller/custom_metadata.go
+++ b/internal/controller/custom_metadata.go
@@ -10,6 +10,7 @@ import (
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 var ErrNilMap = errors.New("destination map not initialized")
@@ -392,6 +393,157 @@ func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1
 			}
 		}
 
+	}
+
+	if len(currentAnnotations) == 0 &&
+		len(effectiveAnnotations) != 0 {
+		return true
+	}
+
+	return false
+}
+
+func applyCustomNetworkPolicyMetadata(mcpServer *mcpv1alpha1.MCPServer, netpol *networkingv1.NetworkPolicy) error {
+	currentLabels := make(map[string]string)
+	if managedLabels, ok := netpol.Annotations[managedExtraLabels]; ok {
+		if err := json.Unmarshal([]byte(managedLabels), &currentLabels); err != nil {
+			return fmt.Errorf("retrieving current custom labels failed; %w", err)
+		}
+	}
+
+	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
+
+	if !maps.Equal(effectiveLabels, currentLabels) {
+		for key := range currentLabels {
+			delete(netpol.Labels, key)
+		}
+		delete(netpol.Annotations, managedExtraLabels)
+	}
+
+	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
+
+	currentAnnotations := make(map[string]string)
+	if managedAnnotations, ok := netpol.Annotations[managedExtraAnnotations]; ok {
+		if err := json.Unmarshal([]byte(managedAnnotations), &currentAnnotations); err != nil {
+			return fmt.Errorf("retrieving current custom annotations failed; %w", err)
+		}
+	}
+
+	if !maps.Equal(effectiveAnnotations, currentAnnotations) {
+		for key := range currentAnnotations {
+			delete(netpol.Annotations, key)
+		}
+		delete(netpol.Annotations, managedExtraAnnotations)
+	}
+
+	if len(effectiveLabels) == 0 &&
+		len(effectiveAnnotations) == 0 &&
+		len(currentLabels) == 0 &&
+		len(currentAnnotations) == 0 {
+		return nil
+	}
+
+	if netpol.Labels == nil {
+		netpol.Labels = make(map[string]string)
+	}
+
+	if netpol.Annotations == nil {
+		netpol.Annotations = make(map[string]string)
+	}
+
+	if len(effectiveLabels) > 0 {
+		if err := mergeMaps(netpol.Labels, effectiveLabels); err != nil {
+			return fmt.Errorf("appending networkpolicy labels failed; %w", err)
+		}
+	}
+
+	if len(effectiveAnnotations) > 0 {
+		if err := mergeMaps(netpol.Annotations, effectiveAnnotations); err != nil {
+			return fmt.Errorf("appending networkpolicy annotations failed; %w", err)
+		}
+	}
+
+	extraLabelsByte, err := json.Marshal(effectiveLabels)
+	if err != nil {
+		return fmt.Errorf("marshaling .spec.extraLabels failed; %w", err)
+	}
+	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != jsonNull {
+		netpol.Annotations[managedExtraLabels] = string(extraLabelsByte)
+	}
+
+	extraAnnotationsByte, err := json.Marshal(effectiveAnnotations)
+	if err != nil {
+		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
+	}
+	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != jsonNull {
+		netpol.Annotations[managedExtraAnnotations] = string(extraAnnotationsByte)
+	}
+
+	return nil
+}
+
+func networkPolicyLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, netpol *networkingv1.NetworkPolicy) bool {
+	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
+
+	var currentLabels map[string]string
+	vals, ok := netpol.Annotations[managedExtraLabels]
+	if ok {
+		if err := json.Unmarshal([]byte(vals), &currentLabels); err != nil {
+			return true
+		}
+
+		if len(currentLabels) > 0 {
+			if len(effectiveLabels) != 0 &&
+				!maps.Equal(currentLabels, effectiveLabels) {
+				return true
+			}
+
+			if len(effectiveLabels) == 0 {
+				return true
+			}
+
+			for k := range currentLabels {
+				if _, ok := netpol.Labels[k]; !ok {
+					return true
+				}
+			}
+		}
+	}
+
+	if len(currentLabels) == 0 &&
+		len(effectiveLabels) != 0 {
+		return true
+	}
+
+	return false
+}
+
+func networkPolicyAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, netpol *networkingv1.NetworkPolicy) bool {
+	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
+
+	var currentAnnotations map[string]string
+	vals, ok := netpol.Annotations[managedExtraAnnotations]
+	if ok {
+		if err := json.Unmarshal([]byte(vals), &currentAnnotations); err != nil {
+			return true
+		}
+
+		if len(currentAnnotations) > 0 {
+			if len(effectiveAnnotations) != 0 &&
+				!maps.Equal(currentAnnotations, effectiveAnnotations) {
+				return true
+			}
+
+			if len(effectiveAnnotations) == 0 {
+				return true
+			}
+
+			for k := range currentAnnotations {
+				if _, ok := netpol.Annotations[k]; !ok {
+					return true
+				}
+			}
+		}
 	}
 
 	if len(currentAnnotations) == 0 &&

--- a/internal/controller/custom_metadata.go
+++ b/internal/controller/custom_metadata.go
@@ -9,8 +9,7 @@ import (
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var ErrNilMap = errors.New("destination map not initialized")
@@ -62,39 +61,48 @@ func mergeMaps(dst, src map[string]string) error {
 	return nil
 }
 
-func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv1.Deployment) error {
+func applyCustomObjectMetadata(mcpServer *mcpv1alpha1.MCPServer, obj client.Object) error {
+	annotations := obj.GetAnnotations()
+
 	currentLabels := make(map[string]string)
-	if managedLabels, ok := deployment.Annotations[managedExtraLabels]; ok {
-		if err := json.Unmarshal([]byte(managedLabels), &currentLabels); err != nil {
-			return fmt.Errorf("retrieving current custom labels failed; %w", err)
+	if annotations != nil {
+		if managedLabels, ok := annotations[managedExtraLabels]; ok {
+			if err := json.Unmarshal([]byte(managedLabels), &currentLabels); err != nil {
+				return fmt.Errorf("retrieving current custom labels failed; %w", err)
+			}
 		}
 	}
 
 	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
 
 	if !maps.Equal(effectiveLabels, currentLabels) {
+		labels := obj.GetLabels()
 		for key := range currentLabels {
-			delete(deployment.Labels, key)
-			delete(deployment.Spec.Template.Labels, key)
+			delete(labels, key)
 		}
-		delete(deployment.Annotations, managedExtraLabels)
+		if annotations != nil {
+			delete(annotations, managedExtraLabels)
+		}
 	}
 
 	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
 
 	currentAnnotations := make(map[string]string)
-	if managedAnnotations, ok := deployment.Annotations[managedExtraAnnotations]; ok {
-		if err := json.Unmarshal([]byte(managedAnnotations), &currentAnnotations); err != nil {
-			return fmt.Errorf("retrieving current custom annotations failed; %w", err)
+	if annotations != nil {
+		if managedAnnotations, ok := annotations[managedExtraAnnotations]; ok {
+			if err := json.Unmarshal([]byte(managedAnnotations), &currentAnnotations); err != nil {
+				return fmt.Errorf("retrieving current custom annotations failed; %w", err)
+			}
 		}
 	}
 
 	if !maps.Equal(effectiveAnnotations, currentAnnotations) {
 		for key := range currentAnnotations {
-			delete(deployment.Annotations, key)
-			delete(deployment.Spec.Template.Annotations, key)
+			delete(annotations, key)
 		}
-		delete(deployment.Annotations, managedExtraAnnotations)
+		if annotations != nil {
+			delete(annotations, managedExtraAnnotations)
+		}
 	}
 
 	if len(effectiveLabels) == 0 &&
@@ -104,452 +112,209 @@ func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment 
 		return nil
 	}
 
+	if obj.GetLabels() == nil {
+		obj.SetLabels(make(map[string]string))
+	}
+	if obj.GetAnnotations() == nil {
+		obj.SetAnnotations(make(map[string]string))
+	}
+
 	if len(effectiveLabels) > 0 {
-		if deployment.Labels == nil {
-			deployment.Labels = make(map[string]string)
+		if err := mergeMaps(obj.GetLabels(), effectiveLabels); err != nil {
+			return fmt.Errorf("appending labels failed; %w", err)
 		}
-		if err := mergeMaps(
-			deployment.Labels,
-			effectiveLabels,
-		); err != nil {
-			return fmt.Errorf("appending deployment labels failed; %w", err)
+	}
+
+	if len(effectiveAnnotations) > 0 {
+		if err := mergeMaps(obj.GetAnnotations(), effectiveAnnotations); err != nil {
+			return fmt.Errorf("appending annotations failed; %w", err)
 		}
+	}
+
+	extraLabelsByte, err := json.Marshal(effectiveLabels)
+	if err != nil {
+		return fmt.Errorf("marshaling .spec.extraLabels failed; %w", err)
+	}
+	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != jsonNull {
+		obj.GetAnnotations()[managedExtraLabels] = string(extraLabelsByte)
+	}
+
+	extraAnnotationsByte, err := json.Marshal(effectiveAnnotations)
+	if err != nil {
+		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
+	}
+	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != jsonNull {
+		obj.GetAnnotations()[managedExtraAnnotations] = string(extraAnnotationsByte)
+	}
+
+	return nil
+}
+
+func applyCustomDeploymentMetadata(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv1.Deployment) error {
+	var oldLabels map[string]string
+	if v, ok := deployment.Annotations[managedExtraLabels]; ok {
+		_ = json.Unmarshal([]byte(v), &oldLabels)
+	}
+	var oldAnnotations map[string]string
+	if v, ok := deployment.Annotations[managedExtraAnnotations]; ok {
+		_ = json.Unmarshal([]byte(v), &oldAnnotations)
+	}
+
+	if err := applyCustomObjectMetadata(mcpServer, deployment); err != nil {
+		return err
+	}
+
+	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
+	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
+
+	if !maps.Equal(effectiveLabels, oldLabels) {
+		for key := range oldLabels {
+			delete(deployment.Spec.Template.Labels, key)
+		}
+	}
+	if len(effectiveLabels) > 0 {
 		if deployment.Spec.Template.Labels == nil {
 			deployment.Spec.Template.Labels = make(map[string]string)
 		}
-		if err := mergeMaps(
-			deployment.Spec.Template.Labels,
-			effectiveLabels,
-		); err != nil {
+		if err := mergeMaps(deployment.Spec.Template.Labels, effectiveLabels); err != nil {
 			return fmt.Errorf("appending pod template labels failed; %w", err)
 		}
 	}
 
+	if !maps.Equal(effectiveAnnotations, oldAnnotations) {
+		for key := range oldAnnotations {
+			delete(deployment.Spec.Template.Annotations, key)
+		}
+	}
 	if len(effectiveAnnotations) > 0 {
-		if deployment.Annotations == nil {
-			deployment.Annotations = make(map[string]string)
-		}
-		if err := mergeMaps(
-			deployment.Annotations,
-			effectiveAnnotations,
-		); err != nil {
-			return fmt.Errorf("appending deployment annotations failed; %w", err)
-		}
 		if deployment.Spec.Template.Annotations == nil {
 			deployment.Spec.Template.Annotations = make(map[string]string)
 		}
-		if err := mergeMaps(
-			deployment.Spec.Template.Annotations,
-			effectiveAnnotations,
-		); err != nil {
+		if err := mergeMaps(deployment.Spec.Template.Annotations, effectiveAnnotations); err != nil {
 			return fmt.Errorf("appending pod template annotations failed; %w", err)
 		}
 	}
 
-	if deployment.Annotations == nil {
-		deployment.Annotations = make(map[string]string)
-	}
-
-	extraLabelsByte, err := json.Marshal(effectiveLabels)
-	if err != nil {
-		return fmt.Errorf("marshaling .spec.extraLabels failed; %w", err)
-	}
-	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != jsonNull {
-		deployment.Annotations[managedExtraLabels] = string(extraLabelsByte)
-	}
-
-	extraAnnotationsByte, err := json.Marshal(effectiveAnnotations)
-	if err != nil {
-		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
-	}
-	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != jsonNull {
-		deployment.Annotations[managedExtraAnnotations] = string(extraAnnotationsByte)
-	}
-
 	return nil
 }
 
-func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Service) error {
-	currentLabels := make(map[string]string)
-	if managedLabels, ok := service.Annotations[managedExtraLabels]; ok {
-		if err := json.Unmarshal([]byte(managedLabels), &currentLabels); err != nil {
-			return fmt.Errorf("retrieving current custom labels failed; %w", err)
-		}
-	}
+func applyCustomServiceMetadata(mcpServer *mcpv1alpha1.MCPServer, obj client.Object) error {
+	return applyCustomObjectMetadata(mcpServer, obj)
+}
 
+func applyCustomNetworkPolicyMetadata(mcpServer *mcpv1alpha1.MCPServer, obj client.Object) error {
+	return applyCustomObjectMetadata(mcpServer, obj)
+}
+
+func objectLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, obj client.Object, extraLabelMaps ...map[string]string) bool {
 	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
 
-	if !maps.Equal(effectiveLabels, currentLabels) {
-		for key := range currentLabels {
-			delete(service.Labels, key)
+	var currentLabels map[string]string
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		vals, ok := annotations[managedExtraLabels]
+		if ok {
+			if err := json.Unmarshal([]byte(vals), &currentLabels); err != nil {
+				return true
+			}
+
+			if len(currentLabels) > 0 {
+				if len(effectiveLabels) != 0 &&
+					!maps.Equal(currentLabels, effectiveLabels) {
+					return true
+				}
+
+				if len(effectiveLabels) == 0 {
+					return true
+				}
+
+				labels := obj.GetLabels()
+				for k := range currentLabels {
+					if _, ok := labels[k]; !ok {
+						return true
+					}
+					for _, m := range extraLabelMaps {
+						if _, ok := m[k]; !ok {
+							return true
+						}
+					}
+				}
+			}
 		}
-		delete(service.Annotations, managedExtraLabels)
 	}
 
+	if len(currentLabels) == 0 &&
+		len(effectiveLabels) != 0 {
+		return true
+	}
+
+	return false
+}
+
+func objectAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, obj client.Object, extraAnnotationMaps ...map[string]string) bool {
 	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
 
-	currentAnnotations := make(map[string]string)
-	if managedAnnotations, ok := service.Annotations[managedExtraAnnotations]; ok {
-		if err := json.Unmarshal([]byte(managedAnnotations), &currentAnnotations); err != nil {
-			return fmt.Errorf("retrieving current custom annotations failed; %w", err)
+	var currentAnnotations map[string]string
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		vals, ok := annotations[managedExtraAnnotations]
+		if ok {
+			if err := json.Unmarshal([]byte(vals), &currentAnnotations); err != nil {
+				return true
+			}
+
+			if len(currentAnnotations) > 0 {
+				if len(effectiveAnnotations) != 0 &&
+					!maps.Equal(currentAnnotations, effectiveAnnotations) {
+					return true
+				}
+
+				if len(effectiveAnnotations) == 0 {
+					return true
+				}
+
+				for k := range currentAnnotations {
+					if _, ok := annotations[k]; !ok {
+						return true
+					}
+					for _, m := range extraAnnotationMaps {
+						if _, ok := m[k]; !ok {
+							return true
+						}
+					}
+				}
+			}
 		}
 	}
 
-	if !maps.Equal(effectiveAnnotations, currentAnnotations) {
-		for key := range currentAnnotations {
-			delete(service.Annotations, key)
-		}
-		delete(service.Annotations, managedExtraAnnotations)
+	if len(currentAnnotations) == 0 &&
+		len(effectiveAnnotations) != 0 {
+		return true
 	}
 
-	if len(effectiveLabels) == 0 &&
-		len(effectiveAnnotations) == 0 &&
-		len(currentLabels) == 0 &&
-		len(currentAnnotations) == 0 {
-		return nil
-	}
-
-	if service.Labels == nil {
-		service.Labels = make(map[string]string)
-	}
-
-	if service.Annotations == nil {
-		service.Annotations = make(map[string]string)
-	}
-
-	if len(effectiveLabels) > 0 {
-		if err := mergeMaps(service.Labels, effectiveLabels); err != nil {
-			return fmt.Errorf("appending service labels failed; %w", err)
-		}
-	}
-
-	if len(effectiveAnnotations) > 0 {
-		if err := mergeMaps(service.Annotations, effectiveAnnotations); err != nil {
-			return fmt.Errorf("appending service annotations failed; %w", err)
-		}
-	}
-
-	extraLabelsByte, err := json.Marshal(effectiveLabels)
-	if err != nil {
-		return fmt.Errorf("marshaling .spec.extraLabels failed; %w", err)
-	}
-	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != jsonNull {
-		service.Annotations[managedExtraLabels] = string(extraLabelsByte)
-	}
-
-	extraAnnotationsByte, err := json.Marshal(effectiveAnnotations)
-	if err != nil {
-		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
-	}
-	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != jsonNull {
-		service.Annotations[managedExtraAnnotations] = string(extraAnnotationsByte)
-	}
-
-	return nil
+	return false
 }
 
 func deploymentLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv1.Deployment) bool {
-	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
-
-	var currentLabels map[string]string
-	vals, ok := deployment.Annotations[managedExtraLabels]
-	if ok {
-		if err := json.Unmarshal([]byte(vals), &currentLabels); err != nil {
-			return true
-		}
-
-		if len(currentLabels) > 0 {
-			if len(effectiveLabels) != 0 &&
-				!maps.Equal(currentLabels, effectiveLabels) {
-				return true
-			}
-
-			if len(effectiveLabels) == 0 {
-				return true
-			}
-
-			// check if current labels and .spec.ExtraLabels match
-			for k := range currentLabels {
-				if _, ok := deployment.Labels[k]; !ok {
-					return true
-				}
-				if _, ok := deployment.Spec.Template.Labels[k]; !ok {
-					return true
-				}
-			}
-		}
-	}
-
-	if len(currentLabels) == 0 &&
-		len(effectiveLabels) != 0 {
-		return true
-	}
-
-	return false
+	return objectLabelsChanged(mcpServer, deployment, deployment.Spec.Template.Labels)
 }
 
 func deploymentAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, deployment *appsv1.Deployment) bool {
-	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
-
-	var currentAnnotations map[string]string
-	vals, ok := deployment.Annotations[managedExtraAnnotations]
-	if ok {
-		if err := json.Unmarshal([]byte(vals), &currentAnnotations); err != nil {
-			return true
-		}
-
-		if len(currentAnnotations) > 0 {
-			if len(effectiveAnnotations) != 0 &&
-				!maps.Equal(currentAnnotations, effectiveAnnotations) {
-				return true
-			}
-
-			if len(effectiveAnnotations) == 0 {
-				return true
-			}
-
-			// check if current annotations and .spec.ExtraAnnotations match
-			for k := range currentAnnotations {
-				if _, ok := deployment.Annotations[k]; !ok {
-					return true
-				}
-				if _, ok := deployment.Spec.Template.Annotations[k]; !ok {
-					return true
-				}
-			}
-		}
-	}
-
-	if len(currentAnnotations) == 0 &&
-		len(effectiveAnnotations) != 0 {
-		return true
-	}
-
-	return false
+	return objectAnnotationsChanged(mcpServer, deployment, deployment.Spec.Template.Annotations)
 }
 
-func serviceLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Service) bool {
-	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
-
-	var currentLabels map[string]string
-	vals, ok := service.Annotations[managedExtraLabels]
-	if ok {
-		if err := json.Unmarshal([]byte(vals), &currentLabels); err != nil {
-			return true
-		}
-
-		if len(currentLabels) > 0 {
-			if len(effectiveLabels) != 0 &&
-				!maps.Equal(currentLabels, effectiveLabels) {
-				return true
-			}
-
-			if len(effectiveLabels) == 0 {
-				return true
-			}
-
-			// check if current labels and .spec.ExtraLabels match
-			for k := range currentLabels {
-				if _, ok := service.Labels[k]; !ok {
-					return true
-				}
-			}
-		}
-	}
-
-	if len(currentLabels) == 0 &&
-		len(effectiveLabels) != 0 {
-		return true
-	}
-
-	return false
+func serviceLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, obj client.Object) bool {
+	return objectLabelsChanged(mcpServer, obj)
 }
 
-func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, service *corev1.Service) bool {
-	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
-
-	var currentAnnotations map[string]string
-	vals, ok := service.Annotations[managedExtraAnnotations]
-	if ok {
-		if err := json.Unmarshal([]byte(vals), &currentAnnotations); err != nil {
-			return true
-		}
-
-		if len(currentAnnotations) > 0 {
-			if len(effectiveAnnotations) != 0 &&
-				!maps.Equal(currentAnnotations, effectiveAnnotations) {
-				return true
-			}
-
-			if len(effectiveAnnotations) == 0 {
-				return true
-			}
-
-			// check if current annotations and .spec.ExtraAnnotations match
-			for k := range currentAnnotations {
-				if _, ok := service.Annotations[k]; !ok {
-					return true
-				}
-			}
-		}
-
-	}
-
-	if len(currentAnnotations) == 0 &&
-		len(effectiveAnnotations) != 0 {
-		return true
-	}
-
-	return false
+func serviceAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, obj client.Object) bool {
+	return objectAnnotationsChanged(mcpServer, obj)
 }
 
-func applyCustomNetworkPolicyMetadata(mcpServer *mcpv1alpha1.MCPServer, netpol *networkingv1.NetworkPolicy) error {
-	currentLabels := make(map[string]string)
-	if managedLabels, ok := netpol.Annotations[managedExtraLabels]; ok {
-		if err := json.Unmarshal([]byte(managedLabels), &currentLabels); err != nil {
-			return fmt.Errorf("retrieving current custom labels failed; %w", err)
-		}
-	}
-
-	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
-
-	if !maps.Equal(effectiveLabels, currentLabels) {
-		for key := range currentLabels {
-			delete(netpol.Labels, key)
-		}
-		delete(netpol.Annotations, managedExtraLabels)
-	}
-
-	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
-
-	currentAnnotations := make(map[string]string)
-	if managedAnnotations, ok := netpol.Annotations[managedExtraAnnotations]; ok {
-		if err := json.Unmarshal([]byte(managedAnnotations), &currentAnnotations); err != nil {
-			return fmt.Errorf("retrieving current custom annotations failed; %w", err)
-		}
-	}
-
-	if !maps.Equal(effectiveAnnotations, currentAnnotations) {
-		for key := range currentAnnotations {
-			delete(netpol.Annotations, key)
-		}
-		delete(netpol.Annotations, managedExtraAnnotations)
-	}
-
-	if len(effectiveLabels) == 0 &&
-		len(effectiveAnnotations) == 0 &&
-		len(currentLabels) == 0 &&
-		len(currentAnnotations) == 0 {
-		return nil
-	}
-
-	if netpol.Labels == nil {
-		netpol.Labels = make(map[string]string)
-	}
-
-	if netpol.Annotations == nil {
-		netpol.Annotations = make(map[string]string)
-	}
-
-	if len(effectiveLabels) > 0 {
-		if err := mergeMaps(netpol.Labels, effectiveLabels); err != nil {
-			return fmt.Errorf("appending networkpolicy labels failed; %w", err)
-		}
-	}
-
-	if len(effectiveAnnotations) > 0 {
-		if err := mergeMaps(netpol.Annotations, effectiveAnnotations); err != nil {
-			return fmt.Errorf("appending networkpolicy annotations failed; %w", err)
-		}
-	}
-
-	extraLabelsByte, err := json.Marshal(effectiveLabels)
-	if err != nil {
-		return fmt.Errorf("marshaling .spec.extraLabels failed; %w", err)
-	}
-	if len(extraLabelsByte) != 0 && string(extraLabelsByte) != jsonNull {
-		netpol.Annotations[managedExtraLabels] = string(extraLabelsByte)
-	}
-
-	extraAnnotationsByte, err := json.Marshal(effectiveAnnotations)
-	if err != nil {
-		return fmt.Errorf("marshaling .spec.extraAnnotations failed; %w", err)
-	}
-	if len(extraAnnotationsByte) != 0 && string(extraAnnotationsByte) != jsonNull {
-		netpol.Annotations[managedExtraAnnotations] = string(extraAnnotationsByte)
-	}
-
-	return nil
+func networkPolicyLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, obj client.Object) bool {
+	return objectLabelsChanged(mcpServer, obj)
 }
 
-func networkPolicyLabelsChanged(mcpServer *mcpv1alpha1.MCPServer, netpol *networkingv1.NetworkPolicy) bool {
-	effectiveLabels := filterReservedKeys(mcpServer.Spec.ExtraLabels)
-
-	var currentLabels map[string]string
-	vals, ok := netpol.Annotations[managedExtraLabels]
-	if ok {
-		if err := json.Unmarshal([]byte(vals), &currentLabels); err != nil {
-			return true
-		}
-
-		if len(currentLabels) > 0 {
-			if len(effectiveLabels) != 0 &&
-				!maps.Equal(currentLabels, effectiveLabels) {
-				return true
-			}
-
-			if len(effectiveLabels) == 0 {
-				return true
-			}
-
-			for k := range currentLabels {
-				if _, ok := netpol.Labels[k]; !ok {
-					return true
-				}
-			}
-		}
-	}
-
-	if len(currentLabels) == 0 &&
-		len(effectiveLabels) != 0 {
-		return true
-	}
-
-	return false
-}
-
-func networkPolicyAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, netpol *networkingv1.NetworkPolicy) bool {
-	effectiveAnnotations := filterReservedAnnotationKeys(mcpServer.Spec.ExtraAnnotations)
-
-	var currentAnnotations map[string]string
-	vals, ok := netpol.Annotations[managedExtraAnnotations]
-	if ok {
-		if err := json.Unmarshal([]byte(vals), &currentAnnotations); err != nil {
-			return true
-		}
-
-		if len(currentAnnotations) > 0 {
-			if len(effectiveAnnotations) != 0 &&
-				!maps.Equal(currentAnnotations, effectiveAnnotations) {
-				return true
-			}
-
-			if len(effectiveAnnotations) == 0 {
-				return true
-			}
-
-			for k := range currentAnnotations {
-				if _, ok := netpol.Annotations[k]; !ok {
-					return true
-				}
-			}
-		}
-	}
-
-	if len(currentAnnotations) == 0 &&
-		len(effectiveAnnotations) != 0 {
-		return true
-	}
-
-	return false
+func networkPolicyAnnotationsChanged(mcpServer *mcpv1alpha1.MCPServer, obj client.Object) bool {
+	return objectAnnotationsChanged(mcpServer, obj)
 }

--- a/internal/controller/custom_metadata_test.go
+++ b/internal/controller/custom_metadata_test.go
@@ -8,6 +8,7 @@ import (
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -17,9 +18,10 @@ type want struct {
 }
 
 type extraMetaArgs struct {
-	mcp        *mcpv1alpha1.MCPServer
-	deployment *appsv1.Deployment
-	service    *corev1.Service
+	mcp           *mcpv1alpha1.MCPServer
+	deployment    *appsv1.Deployment
+	service       *corev1.Service
+	networkPolicy *networkingv1.NetworkPolicy
 }
 
 func Test_mergeMaps(t *testing.T) {
@@ -1942,6 +1944,346 @@ func Test_serviceAnnotationsChanged(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			got := serviceAnnotationsChanged(tc.args.mcp, tc.args.service)
+			if got != tc.want {
+				t.Errorf("wanted metadata changed to be %t but, got %t\n", tc.want, got)
+			}
+		})
+	}
+}
+
+func Test_networkPolicyLabelsChanged(t *testing.T) {
+	tt := []struct {
+		name string
+		args *extraMetaArgs
+		want bool
+	}{
+		{
+			name: "no custom metadata provided",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraLabels: map[string]string{},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "custom metadata matches .spec.extraLabels",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraLabels: map[string]string{
+							"department": "procurement",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp:  "mariadb-mcp",
+							"department": "procurement",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "{\"department\":\"procurement\"}",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "networkpolicy missing custom labels defined in .spec.extraLabels",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraLabels: map[string]string{
+							"department": "procurement",
+							"env":        "production",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp:  "mariadb-mcp",
+							"department": "procurement",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "{\"department\":\"procurement\",\"env\": \"production\"}",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "corrupted JSON in managed labels annotation forces update",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "not-valid-json",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "label tracked but missing from networkpolicy.Labels",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraLabels: map[string]string{
+							"department": "procurement",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "{\"department\":\"procurement\"}",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "spec labels changed from tracked labels",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraLabels: map[string]string{
+							"department": "engineering",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp:  "mariadb-mcp",
+							"department": "procurement",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "{\"department\":\"procurement\"}",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "all spec labels removed but tracked labels exist",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp:  "mariadb-mcp",
+							"department": "procurement",
+						},
+						Annotations: map[string]string{
+							managedExtraLabels: "{\"department\":\"procurement\"}",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := networkPolicyLabelsChanged(tc.args.mcp, tc.args.networkPolicy)
+			if got != tc.want {
+				t.Errorf("wanted metadata changed to be %t but, got %t\n", tc.want, got)
+			}
+		})
+	}
+}
+
+func Test_networkPolicyAnnotationsChanged(t *testing.T) {
+	tt := []struct {
+		name string
+		args *extraMetaArgs
+		want bool
+	}{
+		{
+			name: "no custom metadata provided",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "custom metadata matches .spec.extraAnnotations",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraAnnotations: map[string]string{
+							"department": "procurement",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "{\"department\":\"procurement\"}",
+							"department":            "procurement",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "networkpolicy missing custom annotations defined in .spec.extraAnnotations",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraAnnotations: map[string]string{
+							"department": "procurement",
+							"env":        "production",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "{\"department\":\"procurement\",\"env\": \"production\"}",
+							"department":            "procurement",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "corrupted JSON in managed annotations annotation forces update",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "not-valid-json",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "annotation tracked but missing from networkpolicy.Annotations",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraAnnotations: map[string]string{
+							"department": "procurement",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "{\"department\":\"procurement\"}",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "spec annotations changed from tracked annotations",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{
+						ExtraAnnotations: map[string]string{
+							"department": "engineering",
+						},
+					},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "{\"department\":\"procurement\"}",
+							"department":            "procurement",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "all spec annotations removed but tracked annotations exist",
+			args: &extraMetaArgs{
+				mcp: &mcpv1alpha1.MCPServer{
+					Spec: mcpv1alpha1.MCPServerSpec{},
+				},
+				networkPolicy: &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelKeyApp: "mariadb-mcp",
+						},
+						Annotations: map[string]string{
+							managedExtraAnnotations: "{\"department\":\"procurement\"}",
+							"department":            "procurement",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := networkPolicyAnnotationsChanged(tc.args.mcp, tc.args.networkPolicy)
 			if got != tc.want {
 				t.Errorf("wanted metadata changed to be %t but, got %t\n", tc.want, got)
 			}

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -287,7 +287,13 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	serviceStart := time.Now()
 	if err := r.reconcileService(ctx, mcpServer); err != nil {
 		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
-		return r.handleServiceFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err)
+		return r.handleResourceFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err, resourceFailureParams{
+			counter:     serviceFailuresTotal,
+			reason:      ReasonServiceUnavailable,
+			resource:    "Service",
+			isDuplicate: duplicateServiceUnavailable,
+			emitEvent:   r.emitServiceReconcileFailed,
+		})
 	}
 
 	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
@@ -296,7 +302,13 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	networkPolicyStart := time.Now()
 	if err := r.reconcileNetworkPolicy(ctx, mcpServer); err != nil {
 		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
-		return r.handleNetworkPolicyFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err)
+		return r.handleResourceFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err, resourceFailureParams{
+			counter:     networkPolicyFailuresTotal,
+			reason:      ReasonNetworkPolicyUnavailable,
+			resource:    "NetworkPolicy",
+			isDuplicate: duplicateNetworkPolicyUnavailable,
+			emitEvent:   r.emitNetworkPolicyReconcileFailed,
+		})
 	}
 	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
 
@@ -511,69 +523,25 @@ func (r *MCPServerReconciler) emitServiceReconcileFailed(mcpServer *mcpv1alpha1.
 		"MCPServer %s: %s", mcpServer.Name, message)
 }
 
-func (r *MCPServerReconciler) handleServiceFailure(
-	ctx context.Context,
-	mcpServer *mcpv1alpha1.MCPServer,
-	existingDeployment *appsv1.Deployment,
-	acceptedCondition metav1.Condition,
-	reconcileErr error,
-) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
-	serviceFailuresTotal.With(prometheus.Labels{
-		"name":      mcpServer.Name,
-		"namespace": mcpServer.Namespace,
-		"reason":    MetricReasonReconcileError,
-	}).Inc()
-
-	readyCondition := newCondition(
-		ConditionTypeReady,
-		metav1.ConditionFalse,
-		ReasonServiceUnavailable,
-		fmt.Sprintf("Failed to reconcile Service: %v", reconcileErr),
-		mcpServer.Generation,
-	)
-	preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
-
-	recordCondition(mcpServer.Name, mcpServer.Namespace,
-		readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
-
-	if !duplicateServiceUnavailable(mcpServer.Status.Conditions, readyCondition.Message) {
-		r.emitServiceReconcileFailed(mcpServer, readyCondition.Message)
-	}
-
-	status := acv1alpha1.MCPServerStatus().
-		WithObservedGeneration(mcpServer.Generation).
-		WithDeploymentName(existingDeployment.Name).
-		WithServiceName(mcpServer.Name).
-		WithHandshakeRetryCount(0).
-		WithReplicas(ptr.Deref(existingDeployment.Spec.Replicas, 1)).
-		WithReadyReplicas(existingDeployment.Status.ReadyReplicas).
-		WithConditions(
-			conditionToAC(acceptedCondition),
-			conditionToAC(readyCondition),
-		)
-
-	if statusErr := r.applyStatus(ctx, mcpServer, status); statusErr != nil {
-		logger.Error(statusErr, "Failed to update MCPServer status")
-		return ctrl.Result{}, statusErr
-	}
-	if IsOwnershipConflict(reconcileErr) {
-		return ctrl.Result{}, nil
-	}
-	return ctrl.Result{}, reconcileErr
+type resourceFailureParams struct {
+	counter     *prometheus.CounterVec
+	reason      string
+	resource    string
+	isDuplicate func([]metav1.Condition, string) bool
+	emitEvent   func(*mcpv1alpha1.MCPServer, string)
 }
 
-func (r *MCPServerReconciler) handleNetworkPolicyFailure(
+func (r *MCPServerReconciler) handleResourceFailure(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
 	existingDeployment *appsv1.Deployment,
 	acceptedCondition metav1.Condition,
 	reconcileErr error,
+	params resourceFailureParams,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	networkPolicyFailuresTotal.With(prometheus.Labels{
+	params.counter.With(prometheus.Labels{
 		"name":      mcpServer.Name,
 		"namespace": mcpServer.Namespace,
 		"reason":    MetricReasonReconcileError,
@@ -582,8 +550,8 @@ func (r *MCPServerReconciler) handleNetworkPolicyFailure(
 	readyCondition := newCondition(
 		ConditionTypeReady,
 		metav1.ConditionFalse,
-		ReasonNetworkPolicyUnavailable,
-		fmt.Sprintf("Failed to reconcile NetworkPolicy: %v", reconcileErr),
+		params.reason,
+		fmt.Sprintf("Failed to reconcile %s: %v", params.resource, reconcileErr),
 		mcpServer.Generation,
 	)
 	preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
@@ -591,8 +559,8 @@ func (r *MCPServerReconciler) handleNetworkPolicyFailure(
 	recordCondition(mcpServer.Name, mcpServer.Namespace,
 		readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
 
-	if !duplicateNetworkPolicyUnavailable(mcpServer.Status.Conditions, readyCondition.Message) {
-		r.emitNetworkPolicyReconcileFailed(mcpServer, readyCondition.Message)
+	if !params.isDuplicate(mcpServer.Status.Conditions, readyCondition.Message) {
+		params.emitEvent(mcpServer, readyCondition.Message)
 	}
 
 	status := acv1alpha1.MCPServerStatus().

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -287,48 +287,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	serviceStart := time.Now()
 	if err := r.reconcileService(ctx, mcpServer); err != nil {
 		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
-		serviceFailuresTotal.With(prometheus.Labels{
-			"name":      mcpServer.Name,
-			"namespace": mcpServer.Namespace,
-			"reason":    MetricReasonReconcileError,
-		}).Inc()
-		// Service reconciliation failed - update status
-		readyCondition := newCondition(
-			ConditionTypeReady,
-			metav1.ConditionFalse,
-			ReasonServiceUnavailable,
-			fmt.Sprintf("Failed to reconcile Service: %v", err),
-			mcpServer.Generation,
-		)
-		preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
-
-		recordCondition(mcpServer.Name, mcpServer.Namespace,
-			readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
-
-		if !duplicateServiceUnavailable(mcpServer.Status.Conditions, readyCondition.Message) {
-			r.emitServiceReconcileFailed(mcpServer, readyCondition.Message)
-		}
-
-		status := acv1alpha1.MCPServerStatus().
-			WithObservedGeneration(mcpServer.Generation).
-			WithDeploymentName(existingDeployment.Name).
-			WithServiceName(mcpServer.Name).
-			WithHandshakeRetryCount(0).
-			WithReplicas(ptr.Deref(existingDeployment.Spec.Replicas, 1)).
-			WithReadyReplicas(existingDeployment.Status.ReadyReplicas).
-			WithConditions(
-				conditionToAC(acceptedCondition),
-				conditionToAC(readyCondition),
-			)
-
-		if statusErr := r.applyStatus(ctx, mcpServer, status); statusErr != nil {
-			logger.Error(statusErr, "Failed to update MCPServer status")
-			return ctrl.Result{}, statusErr
-		}
-		if IsOwnershipConflict(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return r.handleServiceFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err)
 	}
 
 	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
@@ -337,8 +296,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	networkPolicyStart := time.Now()
 	if err := r.reconcileNetworkPolicy(ctx, mcpServer); err != nil {
 		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
-		r.handleNetworkPolicyFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err)
-		return ctrl.Result{}, err
+		return r.handleNetworkPolicyFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err)
 	}
 	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
 
@@ -553,13 +511,66 @@ func (r *MCPServerReconciler) emitServiceReconcileFailed(mcpServer *mcpv1alpha1.
 		"MCPServer %s: %s", mcpServer.Name, message)
 }
 
+func (r *MCPServerReconciler) handleServiceFailure(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+	existingDeployment *appsv1.Deployment,
+	acceptedCondition metav1.Condition,
+	reconcileErr error,
+) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	serviceFailuresTotal.With(prometheus.Labels{
+		"name":      mcpServer.Name,
+		"namespace": mcpServer.Namespace,
+		"reason":    MetricReasonReconcileError,
+	}).Inc()
+
+	readyCondition := newCondition(
+		ConditionTypeReady,
+		metav1.ConditionFalse,
+		ReasonServiceUnavailable,
+		fmt.Sprintf("Failed to reconcile Service: %v", reconcileErr),
+		mcpServer.Generation,
+	)
+	preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+	recordCondition(mcpServer.Name, mcpServer.Namespace,
+		readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
+
+	if !duplicateServiceUnavailable(mcpServer.Status.Conditions, readyCondition.Message) {
+		r.emitServiceReconcileFailed(mcpServer, readyCondition.Message)
+	}
+
+	status := acv1alpha1.MCPServerStatus().
+		WithObservedGeneration(mcpServer.Generation).
+		WithDeploymentName(existingDeployment.Name).
+		WithServiceName(mcpServer.Name).
+		WithHandshakeRetryCount(0).
+		WithReplicas(ptr.Deref(existingDeployment.Spec.Replicas, 1)).
+		WithReadyReplicas(existingDeployment.Status.ReadyReplicas).
+		WithConditions(
+			conditionToAC(acceptedCondition),
+			conditionToAC(readyCondition),
+		)
+
+	if statusErr := r.applyStatus(ctx, mcpServer, status); statusErr != nil {
+		logger.Error(statusErr, "Failed to update MCPServer status")
+		return ctrl.Result{}, statusErr
+	}
+	if IsOwnershipConflict(reconcileErr) {
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, reconcileErr
+}
+
 func (r *MCPServerReconciler) handleNetworkPolicyFailure(
 	ctx context.Context,
 	mcpServer *mcpv1alpha1.MCPServer,
 	existingDeployment *appsv1.Deployment,
 	acceptedCondition metav1.Condition,
 	reconcileErr error,
-) {
+) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	networkPolicyFailuresTotal.With(prometheus.Labels{
@@ -596,9 +607,14 @@ func (r *MCPServerReconciler) handleNetworkPolicyFailure(
 			conditionToAC(readyCondition),
 		)
 
-	if err := r.applyStatus(ctx, mcpServer, status); err != nil {
-		logger.Error(err, "Failed to update MCPServer status")
+	if statusErr := r.applyStatus(ctx, mcpServer, status); statusErr != nil {
+		logger.Error(statusErr, "Failed to update MCPServer status")
+		return ctrl.Result{}, statusErr
 	}
+	if IsOwnershipConflict(reconcileErr) {
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, reconcileErr
 }
 
 func (r *MCPServerReconciler) emitNetworkPolicyReconcileFailed(mcpServer *mcpv1alpha1.MCPServer, message string) {

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,13 +77,14 @@ const (
 
 // Reasons for Ready condition.
 const (
-	ReasonAvailable              = "Available"
-	ReasonConfigurationInvalid   = "ConfigurationInvalid"
-	ReasonDeploymentUnavailable  = "DeploymentUnavailable"
-	ReasonServiceUnavailable     = "ServiceUnavailable"
-	ReasonScaledToZero           = "ScaledToZero"
-	ReasonInitializing           = "Initializing"
-	ReasonMCPEndpointUnavailable = "MCPEndpointUnavailable"
+	ReasonAvailable                = "Available"
+	ReasonConfigurationInvalid     = "ConfigurationInvalid"
+	ReasonDeploymentUnavailable    = "DeploymentUnavailable"
+	ReasonServiceUnavailable       = "ServiceUnavailable"
+	ReasonNetworkPolicyUnavailable = "NetworkPolicyUnavailable"
+	ReasonScaledToZero             = "ScaledToZero"
+	ReasonInitializing             = "Initializing"
+	ReasonMCPEndpointUnavailable   = "MCPEndpointUnavailable"
 )
 
 // Container waiting reasons from Kubernetes pod status.
@@ -117,6 +119,8 @@ const (
 	eventActionDeploymentReconcileFailed = "DeploymentReconcileFailed"
 	// eventActionServiceReconcileFailed is the reporting action when Service reconciliation fails.
 	eventActionServiceReconcileFailed = "ServiceReconcileFailed"
+	// eventActionNetworkPolicyReconcileFailed is the reporting action when NetworkPolicy reconciliation fails.
+	eventActionNetworkPolicyReconcileFailed = "NetworkPolicyReconcileFailed"
 
 	// requeueDelayMCPHandshake is the initial delay before requeuing when an MCP handshake fails.
 	requeueDelayMCPHandshake = 10 * time.Second
@@ -166,6 +170,7 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
@@ -326,9 +331,18 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// Determine Ready condition based on deployment status
 	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
 
+	// Reconcile NetworkPolicy
+	networkPolicyStart := time.Now()
+	if err := r.reconcileNetworkPolicy(ctx, mcpServer); err != nil {
+		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
+		r.handleNetworkPolicyFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err)
+		return ctrl.Result{}, err
+	}
+	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
+
+	// Determine Ready condition based on deployment status
 	readyCondition := r.reconcileReadyCondition(
 		ctx,
 		existingDeployment,
@@ -539,6 +553,62 @@ func (r *MCPServerReconciler) emitServiceReconcileFailed(mcpServer *mcpv1alpha1.
 		"MCPServer %s: %s", mcpServer.Name, message)
 }
 
+func (r *MCPServerReconciler) handleNetworkPolicyFailure(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+	existingDeployment *appsv1.Deployment,
+	acceptedCondition metav1.Condition,
+	reconcileErr error,
+) {
+	logger := log.FromContext(ctx)
+
+	networkPolicyFailuresTotal.With(prometheus.Labels{
+		"name":      mcpServer.Name,
+		"namespace": mcpServer.Namespace,
+		"reason":    MetricReasonReconcileError,
+	}).Inc()
+
+	readyCondition := newCondition(
+		ConditionTypeReady,
+		metav1.ConditionFalse,
+		ReasonNetworkPolicyUnavailable,
+		fmt.Sprintf("Failed to reconcile NetworkPolicy: %v", reconcileErr),
+		mcpServer.Generation,
+	)
+	preserveLastTransitionTime(&readyCondition, mcpServer.Status.Conditions)
+
+	recordCondition(mcpServer.Name, mcpServer.Namespace,
+		readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
+
+	if !duplicateNetworkPolicyUnavailable(mcpServer.Status.Conditions, readyCondition.Message) {
+		r.emitNetworkPolicyReconcileFailed(mcpServer, readyCondition.Message)
+	}
+
+	status := acv1alpha1.MCPServerStatus().
+		WithObservedGeneration(mcpServer.Generation).
+		WithDeploymentName(existingDeployment.Name).
+		WithServiceName(mcpServer.Name).
+		WithHandshakeRetryCount(0).
+		WithReplicas(ptr.Deref(existingDeployment.Spec.Replicas, 1)).
+		WithReadyReplicas(existingDeployment.Status.ReadyReplicas).
+		WithConditions(
+			conditionToAC(acceptedCondition),
+			conditionToAC(readyCondition),
+		)
+
+	if err := r.applyStatus(ctx, mcpServer, status); err != nil {
+		logger.Error(err, "Failed to update MCPServer status")
+	}
+}
+
+func (r *MCPServerReconciler) emitNetworkPolicyReconcileFailed(mcpServer *mcpv1alpha1.MCPServer, message string) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, ReasonNetworkPolicyUnavailable, eventActionNetworkPolicyReconcileFailed,
+		"MCPServer %s: %s", mcpServer.Name, message)
+}
+
 func (r *MCPServerReconciler) emitMCPHandshakeFailed(mcpServer *mcpv1alpha1.MCPServer, message string) {
 	if r.Recorder == nil {
 		return
@@ -600,6 +670,7 @@ func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		))).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&networkingv1.NetworkPolicy{}).
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.findMCPServersForConfigMap),

--- a/internal/controller/mcpserver_controller_conditions.go
+++ b/internal/controller/mcpserver_controller_conditions.go
@@ -302,3 +302,9 @@ func duplicateServiceUnavailable(conditions []metav1.Condition, message string) 
 	return prevReady != nil && prevReady.Status == metav1.ConditionFalse &&
 		prevReady.Reason == ReasonServiceUnavailable && prevReady.Message == message
 }
+
+func duplicateNetworkPolicyUnavailable(conditions []metav1.Condition, message string) bool {
+	prevReady := meta.FindStatusCondition(conditions, ConditionTypeReady)
+	return prevReady != nil && prevReady.Status == metav1.ConditionFalse &&
+		prevReady.Reason == ReasonNetworkPolicyUnavailable && prevReady.Message == message
+}

--- a/internal/controller/mcpserver_controller_conditions_test.go
+++ b/internal/controller/mcpserver_controller_conditions_test.go
@@ -715,4 +715,18 @@ var _ = Describe("status condition helpers", func() {
 			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonServiceUnavailable, Message: msg},
 		}, msg)).To(BeTrue())
 	})
+
+	It("duplicateNetworkPolicyUnavailable returns true only for matching Ready=False NetworkPolicyUnavailable message", func() {
+		msg := "Failed to reconcile NetworkPolicy: simulated failure"
+		Expect(duplicateNetworkPolicyUnavailable(nil, msg)).To(BeFalse())
+		Expect(duplicateNetworkPolicyUnavailable([]metav1.Condition{
+			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonServiceUnavailable, Message: msg},
+		}, msg)).To(BeFalse())
+		Expect(duplicateNetworkPolicyUnavailable([]metav1.Condition{
+			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonNetworkPolicyUnavailable, Message: "other"},
+		}, msg)).To(BeFalse())
+		Expect(duplicateNetworkPolicyUnavailable([]metav1.Condition{
+			{Type: ConditionTypeReady, Status: metav1.ConditionFalse, Reason: ReasonNetworkPolicyUnavailable, Message: msg},
+		}, msg)).To(BeTrue())
+	})
 })

--- a/internal/controller/mcpserver_controller_networkpolicy.go
+++ b/internal/controller/mcpserver_controller_networkpolicy.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+func (r *MCPServerReconciler) reconcileNetworkPolicy(
+	ctx context.Context,
+	mcpServer *mcpv1alpha1.MCPServer,
+) error {
+	logger := log.FromContext(ctx)
+
+	netpol := r.createNetworkPolicy(mcpServer)
+	if err := controllerutil.SetControllerReference(mcpServer, netpol, r.Scheme); err != nil {
+		logger.Error(err, "Failed to set controller reference for NetworkPolicy")
+		return err
+	}
+
+	existingNetpol := &networkingv1.NetworkPolicy{}
+	err := r.Get(ctx, client.ObjectKey{Name: netpol.Name, Namespace: netpol.Namespace}, existingNetpol)
+	if err != nil && apierrors.IsNotFound(err) {
+		logger.Info("Creating NetworkPolicy", "name", netpol.Name)
+		if err := applyCustomNetworkPolicyMetadata(mcpServer, netpol); err != nil {
+			return fmt.Errorf("applying custom metadata failed; %w", err)
+		}
+		if err := r.Create(ctx, netpol); err != nil {
+			logger.Error(err, "Failed to create NetworkPolicy")
+			return err
+		}
+		return nil
+	} else if err != nil {
+		logger.Error(err, "Failed to get NetworkPolicy")
+		return err
+	}
+
+	if err := r.validateOwnership(existingNetpol, mcpServer); err != nil {
+		logger.Error(err, "NetworkPolicy ownership validation failed")
+		return err
+	}
+
+	oldOwnerUID := ""
+	if oldOwner := metav1.GetControllerOf(existingNetpol); oldOwner != nil {
+		oldOwnerUID = string(oldOwner.UID)
+	}
+
+	if err := controllerutil.SetControllerReference(mcpServer, existingNetpol, r.Scheme); err != nil {
+		logger.Error(err, "Failed to set controller reference for existing NetworkPolicy")
+		return err
+	}
+
+	ownershipChanged := false
+	if newOwner := metav1.GetControllerOf(existingNetpol); newOwner != nil {
+		ownershipChanged = oldOwnerUID != string(newOwner.UID)
+	}
+
+	needsUpdate := !equality.Semantic.DeepEqual(netpol.Spec, existingNetpol.Spec) ||
+		networkPolicyLabelsChanged(mcpServer, existingNetpol) ||
+		networkPolicyAnnotationsChanged(mcpServer, existingNetpol) ||
+		ownershipChanged
+	if needsUpdate {
+		logger.Info("Updating NetworkPolicy", "name", existingNetpol.Name)
+		existingNetpol.Labels = netpol.Labels
+		if err := applyCustomNetworkPolicyMetadata(mcpServer, existingNetpol); err != nil {
+			return fmt.Errorf("applying custom networkpolicy metadata; %w", err)
+		}
+		existingNetpol.Spec = netpol.Spec
+		if err := r.Update(ctx, existingNetpol); err != nil {
+			logger.Error(err, "Failed to update NetworkPolicy")
+			return err
+		}
+	} else {
+		logger.Info("NetworkPolicy already exists and is up to date", "name", netpol.Name)
+	}
+
+	return nil
+}
+
+func (r *MCPServerReconciler) createNetworkPolicy(mcpServer *mcpv1alpha1.MCPServer) *networkingv1.NetworkPolicy {
+	labels := managedWorkloadLabels(mcpServer.Name)
+	port := intstr.FromInt32(mcpServer.Spec.Config.Port)
+	protocol := corev1.ProtocolTCP
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mcpServer.Name,
+			Namespace: mcpServer.Namespace,
+			Labels:    labels,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: managedWorkloadSelector(mcpServer.Name),
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Port:     &port,
+							Protocol: &protocol,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/mcpserver_controller_networkpolicy.go
+++ b/internal/controller/mcpserver_controller_networkpolicy.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -88,7 +89,10 @@ func (r *MCPServerReconciler) reconcileNetworkPolicy(
 		ownershipChanged
 	if needsUpdate {
 		logger.Info("Updating NetworkPolicy", "name", existingNetpol.Name)
-		existingNetpol.Labels = netpol.Labels
+		if existingNetpol.Labels == nil {
+			existingNetpol.Labels = make(map[string]string)
+		}
+		maps.Copy(existingNetpol.Labels, netpol.Labels)
 		if err := applyCustomNetworkPolicyMetadata(mcpServer, existingNetpol); err != nil {
 			return fmt.Errorf("applying custom networkpolicy metadata; %w", err)
 		}

--- a/internal/controller/mcpserver_controller_networkpolicy_test.go
+++ b/internal/controller/mcpserver_controller_networkpolicy_test.go
@@ -1,0 +1,571 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+var _ = Describe("MCPServer Controller - reconcileNetworkPolicy", func() {
+	const resourceName = "test-reconcile-netpol"
+
+	ctx := context.Background()
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	BeforeEach(func() {
+		resource := newTestMCPServer(resourceName)
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("should create a NetworkPolicy when none exists", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		err := reconciler.reconcileNetworkPolicy(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		netpol := &networkingv1.NetworkPolicy{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      resourceName,
+			Namespace: "default",
+		}, netpol)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying name and labels")
+		Expect(netpol.Name).To(Equal(resourceName))
+		Expect(netpol.Labels).To(HaveKeyWithValue("mcp-server", resourceName))
+
+		By("Verifying podSelector targets MCP server pods")
+		Expect(netpol.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("mcp-server", resourceName))
+
+		By("Verifying only Ingress policyType is set")
+		Expect(netpol.Spec.PolicyTypes).To(HaveLen(1))
+		Expect(netpol.Spec.PolicyTypes[0]).To(Equal(networkingv1.PolicyTypeIngress))
+
+		By("Verifying ingress allows only the configured port")
+		Expect(netpol.Spec.Ingress).To(HaveLen(1))
+		Expect(netpol.Spec.Ingress[0].Ports).To(HaveLen(1))
+		Expect(netpol.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(8080))
+		Expect(*netpol.Spec.Ingress[0].Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+
+		By("Verifying ingress From is empty (all sources allowed on MCP port)")
+		Expect(netpol.Spec.Ingress[0].From).To(BeEmpty())
+
+		By("Verifying owner reference is set")
+		Expect(netpol.OwnerReferences).To(HaveLen(1))
+		Expect(netpol.OwnerReferences[0].Name).To(Equal(resourceName))
+	})
+
+	It("should not error when NetworkPolicy already exists", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		Expect(reconciler.reconcileNetworkPolicy(ctx, mcpServer)).To(Succeed())
+		Expect(reconciler.reconcileNetworkPolicy(ctx, mcpServer)).To(Succeed())
+	})
+})
+
+var _ = Describe("MCPServer Controller - NetworkPolicy Update", func() {
+	Context("When port changes", func() {
+		const resourceName = "test-netpol-update"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("should update the NetworkPolicy ingress port when config.port changes", func() {
+			resource := newTestMCPServer(resourceName)
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			controllerReconciler := &MCPServerReconciler{
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: k8sClient,
+			}
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the initial NetworkPolicy port")
+			netpol := &networkingv1.NetworkPolicy{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, netpol)).To(Succeed())
+			Expect(netpol.Spec.Ingress).To(HaveLen(1))
+			Expect(netpol.Spec.Ingress[0].Ports).To(HaveLen(1))
+			Expect(netpol.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(8080))
+
+			By("Updating the port in the MCPServer spec")
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+			mcpServer.Spec.Config.Port = 9090
+			Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+			By("Reconciling again to pick up the port change")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the NetworkPolicy port was updated")
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, netpol)).To(Succeed())
+			Expect(netpol.Spec.Ingress).To(HaveLen(1))
+			Expect(netpol.Spec.Ingress[0].Ports).To(HaveLen(1))
+			Expect(netpol.Spec.Ingress[0].Ports[0].Port.IntValue()).To(Equal(9090))
+		})
+	})
+})
+
+var _ = Describe("MCPServer Controller - NetworkPolicy Reconciliation Failures", func() {
+	const resourceName = "test-netpol-failure"
+
+	ctx := context.Background()
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	BeforeEach(func() {
+		resource := newTestMCPServer(resourceName)
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("should update status with NetworkPolicyUnavailable when creation fails", func() {
+		By("Creating interceptor that returns error on NetworkPolicy Create")
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*networkingv1.NetworkPolicy); ok {
+					return fmt.Errorf("simulated networkpolicy creation failure")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+
+		netpolFailureReconciler := &MCPServerReconciler{
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		By("Reconciling with NetworkPolicy creation failure")
+		_, err = netpolFailureReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated networkpolicy creation failure"))
+
+		By("Verifying status is updated with NetworkPolicyUnavailable")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(acceptedCondition.Reason).To(Equal("Valid"))
+
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonNetworkPolicyUnavailable))
+		Expect(readyCondition.Message).To(ContainSubstring("Failed to reconcile NetworkPolicy"))
+		Expect(readyCondition.Message).To(ContainSubstring("simulated networkpolicy creation failure"))
+
+		Expect(mcpServer.Status.DeploymentName).To(Equal(resourceName))
+	})
+
+	It("should update status with NetworkPolicyUnavailable when update fails", func() {
+		By("Initial reconcile to create resources")
+		initialReconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+		_, err := initialReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying NetworkPolicy was created")
+		netpol := &networkingv1.NetworkPolicy{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      resourceName,
+			Namespace: "default",
+		}, netpol)).To(Succeed())
+
+		By("Creating interceptor that returns error on NetworkPolicy Update")
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*networkingv1.NetworkPolicy); ok {
+					return fmt.Errorf("simulated networkpolicy update failure")
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		})
+
+		netpolFailureReconciler := &MCPServerReconciler{
+			Client:    interceptedClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		By("Updating MCPServer spec to trigger NetworkPolicy reconciliation")
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+		mcpServer.Spec.Config.Port = 9090
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		By("Reconciling with NetworkPolicy update failure")
+		_, err = netpolFailureReconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: typeNamespacedName,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("simulated networkpolicy update failure"))
+
+		By("Verifying status is updated with NetworkPolicyUnavailable")
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(acceptedCondition.Reason).To(Equal("Valid"))
+
+		readyCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Ready")
+		Expect(readyCondition).NotTo(BeNil())
+		Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(readyCondition.Reason).To(Equal(ReasonNetworkPolicyUnavailable))
+		Expect(readyCondition.Message).To(ContainSubstring("Failed to reconcile NetworkPolicy"))
+		Expect(readyCondition.Message).To(ContainSubstring("simulated networkpolicy update failure"))
+
+		Expect(mcpServer.Status.DeploymentName).To(Equal(resourceName))
+	})
+})
+
+var _ = Describe("MCPServer Controller - NetworkPolicy Reconcile Events", func() {
+	const resourceName = "test-netpol-events"
+
+	ctx := context.Background()
+
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
+
+	BeforeEach(func() {
+		resource := newTestMCPServer(resourceName)
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		resource := &mcpv1alpha1.MCPServer{}
+		err := k8sClient.Get(ctx, typeNamespacedName, resource)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		}
+	})
+
+	It("should emit a Warning NetworkPolicyReconcileFailed event only when error message changes", func() {
+		failMsg := "simulated networkpolicy creation failure"
+		reconciler, fr := newReconcilerForTestWithFakeEvents(k8sClient, k8sClient.Scheme())
+
+		wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*networkingv1.NetworkPolicy); ok {
+					return fmt.Errorf("%s", failMsg)
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+		reconciler.Client = interceptedClient
+
+		By("First NetworkPolicy reconcile failure - Warning event emitted once")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).To(HaveOccurred())
+
+		var netpolFailedEvent string
+		Eventually(func(g Gomega) {
+			for _, ev := range drainEvents(fr.Events) {
+				if strings.Contains(ev, corev1.EventTypeWarning) && strings.Contains(ev, ReasonNetworkPolicyUnavailable) {
+					netpolFailedEvent = ev
+					break
+				}
+			}
+			g.Expect(netpolFailedEvent).NotTo(BeEmpty())
+			g.Expect(netpolFailedEvent).To(ContainSubstring(resourceName))
+			g.Expect(netpolFailedEvent).To(ContainSubstring("Failed to reconcile NetworkPolicy"))
+			g.Expect(netpolFailedEvent).To(ContainSubstring(failMsg))
+		}).Should(Succeed())
+
+		By("Second reconcile with same error - no duplicate event")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).To(HaveOccurred())
+		Consistently(fr.Events, 300*time.Millisecond, 20*time.Millisecond).ShouldNot(Receive())
+
+		By("Change error message - second Warning event emitted")
+		failMsg = "simulated networkpolicy ownership failure"
+		interceptedClient = interceptor.NewClient(wrappedClient, interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*networkingv1.NetworkPolicy); ok {
+					return fmt.Errorf("%s", failMsg)
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		})
+		reconciler.Client = interceptedClient
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+		Expect(err).To(HaveOccurred())
+
+		var secondNetpolFailedEvent string
+		Eventually(func(g Gomega) {
+			for _, ev := range drainEvents(fr.Events) {
+				if strings.Contains(ev, corev1.EventTypeWarning) && strings.Contains(ev, ReasonNetworkPolicyUnavailable) {
+					secondNetpolFailedEvent = ev
+					break
+				}
+			}
+			g.Expect(secondNetpolFailedEvent).NotTo(BeEmpty())
+			g.Expect(secondNetpolFailedEvent).To(ContainSubstring(resourceName))
+			g.Expect(secondNetpolFailedEvent).To(ContainSubstring(failMsg))
+			g.Expect(secondNetpolFailedEvent).NotTo(Equal(netpolFailedEvent))
+		}).Should(Succeed())
+	})
+})
+
+var _ = Describe("MCPServer Controller - NetworkPolicy ExtraLabels/ExtraAnnotations on creation", func() {
+	ctx := context.Background()
+
+	It("should apply ExtraLabels and ExtraAnnotations on initial NetworkPolicy creation", func() {
+		mcpServer := newTestMCPServer("test-netpol-extra-metadata")
+		mcpServer.Spec.ExtraLabels = map[string]string{
+			"team": "platform",
+			"env":  "staging",
+		}
+		mcpServer.Spec.ExtraAnnotations = map[string]string{
+			"example.com/owner": "team-a",
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-netpol-extra-metadata", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		err := reconciler.reconcileNetworkPolicy(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		createdNetpol := &networkingv1.NetworkPolicy{}
+		err = k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-netpol-extra-metadata",
+			Namespace: "default",
+		}, createdNetpol)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying ExtraLabels on NetworkPolicy metadata")
+		Expect(createdNetpol.Labels).To(HaveKeyWithValue("team", "platform"))
+		Expect(createdNetpol.Labels).To(HaveKeyWithValue("env", "staging"))
+
+		By("Verifying ExtraAnnotations on NetworkPolicy metadata")
+		Expect(createdNetpol.Annotations).To(HaveKeyWithValue("example.com/owner", "team-a"))
+
+		By("Verifying tracking annotations are set")
+		Expect(createdNetpol.Annotations).To(HaveKey(managedExtraLabels))
+		Expect(createdNetpol.Annotations).To(HaveKey(managedExtraAnnotations))
+	})
+})
+
+var _ = Describe("MCPServer Controller - NetworkPolicy ExtraLabels/ExtraAnnotations update", func() {
+	ctx := context.Background()
+
+	It("should update ExtraLabels and ExtraAnnotations on existing NetworkPolicy", func() {
+		mcpServer := newTestMCPServer("test-netpol-meta-update")
+		mcpServer.Spec.ExtraLabels = map[string]string{
+			"team": "platform",
+		}
+		mcpServer.Spec.ExtraAnnotations = map[string]string{
+			"example.com/owner": "team-a",
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-netpol-meta-update", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		By("Initial reconcile creates NetworkPolicy with labels/annotations")
+		Expect(reconciler.reconcileNetworkPolicy(ctx, mcpServer)).To(Succeed())
+
+		By("Changing ExtraLabels and ExtraAnnotations")
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "test-netpol-meta-update", Namespace: "default"}, mcpServer)).To(Succeed())
+		mcpServer.Spec.ExtraLabels = map[string]string{
+			"team": "infrastructure",
+			"env":  "production",
+		}
+		mcpServer.Spec.ExtraAnnotations = map[string]string{
+			"example.com/owner":   "team-b",
+			"example.com/contact": "ops@example.com",
+		}
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		By("Reconciling again to update NetworkPolicy metadata")
+		Expect(reconciler.reconcileNetworkPolicy(ctx, mcpServer)).To(Succeed())
+
+		updatedNetpol := &networkingv1.NetworkPolicy{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-netpol-meta-update",
+			Namespace: "default",
+		}, updatedNetpol)).To(Succeed())
+
+		By("Verifying labels updated to new values")
+		Expect(updatedNetpol.Labels).To(HaveKeyWithValue("team", "infrastructure"))
+		Expect(updatedNetpol.Labels).To(HaveKeyWithValue("env", "production"))
+
+		By("Verifying old annotations replaced and new annotations applied")
+		Expect(updatedNetpol.Annotations).To(HaveKeyWithValue("example.com/owner", "team-b"))
+		Expect(updatedNetpol.Annotations).To(HaveKeyWithValue("example.com/contact", "ops@example.com"))
+	})
+
+	It("should remove ExtraLabels and ExtraAnnotations when cleared from spec", func() {
+		mcpServer := newTestMCPServer("test-netpol-meta-clear")
+		mcpServer.Spec.ExtraLabels = map[string]string{
+			"team": "platform",
+		}
+		mcpServer.Spec.ExtraAnnotations = map[string]string{
+			"example.com/owner": "team-a",
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-netpol-meta-clear", Namespace: "default"}, mcpServer)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		By("Initial reconcile creates NetworkPolicy with metadata")
+		Expect(reconciler.reconcileNetworkPolicy(ctx, mcpServer)).To(Succeed())
+
+		By("Clearing ExtraLabels and ExtraAnnotations from spec")
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "test-netpol-meta-clear", Namespace: "default"}, mcpServer)).To(Succeed())
+		mcpServer.Spec.ExtraLabels = map[string]string{}
+		mcpServer.Spec.ExtraAnnotations = map[string]string{}
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		By("Reconciling to clean up metadata")
+		Expect(reconciler.reconcileNetworkPolicy(ctx, mcpServer)).To(Succeed())
+
+		updatedNetpol := &networkingv1.NetworkPolicy{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{
+			Name:      "test-netpol-meta-clear",
+			Namespace: "default",
+		}, updatedNetpol)).To(Succeed())
+
+		By("Verifying custom labels are removed")
+		Expect(updatedNetpol.Labels).NotTo(HaveKey("team"))
+		Expect(updatedNetpol.Labels).To(HaveKeyWithValue("mcp-server", "test-netpol-meta-clear"))
+
+		By("Verifying custom annotations are removed")
+		Expect(updatedNetpol.Annotations).NotTo(HaveKey("example.com/owner"))
+	})
+})

--- a/internal/controller/mcpserver_controller_service_test.go
+++ b/internal/controller/mcpserver_controller_service_test.go
@@ -623,7 +623,7 @@ var _ = Describe("MCPServer Controller - Service Reconcile Events", func() {
 		})
 		reconciler.Client = interceptedClient
 
-		By("First service reconcile failure — Warning event emitted once")
+		By("First service reconcile failure - Warning event emitted once")
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 		Expect(err).To(HaveOccurred())
 
@@ -641,12 +641,12 @@ var _ = Describe("MCPServer Controller - Service Reconcile Events", func() {
 			g.Expect(serviceFailedEvent).To(ContainSubstring(failMsg))
 		}).Should(Succeed())
 
-		By("Second reconcile with same error — no duplicate service failed event")
+		By("Second reconcile with same error - no duplicate service failed event")
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 		Expect(err).To(HaveOccurred())
 		Consistently(fr.Events, 300*time.Millisecond, 20*time.Millisecond).ShouldNot(Receive())
 
-		By("Change error message — second Warning event emitted")
+		By("Change error message - second Warning event emitted")
 		failMsg = "simulated service ownership failure"
 		interceptedClient = interceptor.NewClient(wrappedClient, interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -68,6 +68,17 @@ var (
 		[]string{"name", "namespace", "reason"},
 	)
 
+	// networkPolicyFailuresTotal counts network policy reconciliation failures.
+	// Labels: name, namespace, reason.
+	networkPolicyFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "networkpolicy_failures_total",
+			Help:      "Total number of network policy reconciliation failures.",
+		},
+		[]string{"name", "namespace", "reason"},
+	)
+
 	// reconcileDuration tracks the duration of reconciliation phases.
 	// Labels: phase (ReconcilePhaseValidation / ReconcilePhaseDeployment / ReconcilePhaseService).
 	reconcileDuration = prometheus.NewHistogramVec(
@@ -87,6 +98,7 @@ func init() {
 		validationFailuresTotal,
 		deploymentFailuresTotal,
 		serviceFailuresTotal,
+		networkPolicyFailuresTotal,
 		reconcileDuration,
 	)
 }
@@ -119,4 +131,5 @@ func cleanupMetrics(name, namespace string) {
 	validationFailuresTotal.DeletePartialMatch(labels)
 	deploymentFailuresTotal.DeletePartialMatch(labels)
 	serviceFailuresTotal.DeletePartialMatch(labels)
+	networkPolicyFailuresTotal.DeletePartialMatch(labels)
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -80,7 +80,7 @@ var (
 	)
 
 	// reconcileDuration tracks the duration of reconciliation phases.
-	// Labels: phase (ReconcilePhaseValidation / ReconcilePhaseDeployment / ReconcilePhaseService).
+	// Labels: phase (ReconcilePhaseValidation / ReconcilePhaseDeployment / ReconcilePhaseService / ReconcilePhaseNetworkPolicy).
 	reconcileDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -22,12 +22,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -241,29 +243,60 @@ func TeardownMCPServer(ctx context.Context, t *testing.T, cfg *envconf.Config) c
 	}
 	t.Logf("deleted MCPServer %s/%s", server.Namespace, server.Name)
 
-	dep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace},
-	}
-	if err := wait.For(
-		conditions.New(r).ResourceDeleted(dep),
-		wait.WithTimeout(1*time.Minute),
-		wait.WithInterval(2*time.Second),
-	); err != nil {
-		t.Fatalf("Deployment was not garbage collected: %v", err)
+	var wg sync.WaitGroup
+	gcErrors := make(chan string, 3)
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace},
+		}
+		if err := wait.For(
+			conditions.New(r).ResourceDeleted(dep),
+			wait.WithTimeout(1*time.Minute),
+			wait.WithInterval(2*time.Second),
+			wait.WithContext(ctx),
+		); err != nil {
+			gcErrors <- fmt.Sprintf("Deployment was not garbage collected: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace},
+		}
+		if err := wait.For(
+			conditions.New(r).ResourceDeleted(svc),
+			wait.WithTimeout(1*time.Minute),
+			wait.WithInterval(2*time.Second),
+			wait.WithContext(ctx),
+		); err != nil {
+			gcErrors <- fmt.Sprintf("Service was not garbage collected: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		netpol := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace},
+		}
+		if err := wait.For(
+			conditions.New(r).ResourceDeleted(netpol),
+			wait.WithTimeout(1*time.Minute),
+			wait.WithInterval(2*time.Second),
+			wait.WithContext(ctx),
+		); err != nil {
+			gcErrors <- fmt.Sprintf("NetworkPolicy was not garbage collected: %v", err)
+		}
+	}()
+	wg.Wait()
+	close(gcErrors)
+
+	for msg := range gcErrors {
+		t.Fatal(msg)
 	}
 
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace},
-	}
-	if err := wait.For(
-		conditions.New(r).ResourceDeleted(svc),
-		wait.WithTimeout(1*time.Minute),
-		wait.WithInterval(2*time.Second),
-	); err != nil {
-		t.Fatalf("Service was not garbage collected: %v", err)
-	}
-
-	t.Log("Deployment and Service were garbage collected")
+	t.Log("Deployment, Service, and NetworkPolicy were garbage collected")
 	return ctx
 }
 

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -293,7 +293,10 @@ func TeardownMCPServer(ctx context.Context, t *testing.T, cfg *envconf.Config) c
 	close(gcErrors)
 
 	for msg := range gcErrors {
-		t.Fatal(msg)
+		t.Error(msg)
+	}
+	if t.Failed() {
+		return ctx
 	}
 
 	t.Log("Deployment, Service, and NetworkPolicy were garbage collected")

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -1,0 +1,207 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
+)
+
+func TestNetworkPolicyCreated(t *testing.T) {
+	feature := features.New("MCPServer creates NetworkPolicy").
+		WithLabel("type", "networkpolicy").
+		WithLabel("component", "mcpserver").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.SetupMCPServer(ctx, t, cfg, "netpol-test", true)
+		}).
+		Assess("NetworkPolicy exists with correct spec", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			netpol := &networkingv1.NetworkPolicy{}
+			if err := r.Get(ctx, server.Name, server.Namespace, netpol); err != nil {
+				t.Fatalf("NetworkPolicy not found: %v", err)
+			}
+
+			// Verify podSelector targets MCP server pods
+			if val, ok := netpol.Spec.PodSelector.MatchLabels["mcp-server"]; !ok || val != server.Name {
+				t.Fatalf("expected podSelector {mcp-server: %s}, got %v", server.Name, netpol.Spec.PodSelector.MatchLabels)
+			}
+
+			// Verify only Ingress policyType
+			if len(netpol.Spec.PolicyTypes) != 1 || netpol.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+				t.Fatalf("expected policyTypes [Ingress], got %v", netpol.Spec.PolicyTypes)
+			}
+
+			// Verify ingress allows only the configured port
+			expectedPort := int(server.Spec.Config.Port)
+			if len(netpol.Spec.Ingress) != 1 {
+				t.Fatalf("expected 1 ingress rule, got %d", len(netpol.Spec.Ingress))
+			}
+			rule := netpol.Spec.Ingress[0]
+			if len(rule.Ports) != 1 {
+				t.Fatalf("expected 1 port in ingress rule, got %d", len(rule.Ports))
+			}
+			if rule.Ports[0].Port.IntValue() != expectedPort {
+				t.Fatalf("expected ingress port %d, got %d", expectedPort, rule.Ports[0].Port.IntValue())
+			}
+			if *rule.Ports[0].Protocol != corev1.ProtocolTCP {
+				t.Fatalf("expected protocol TCP, got %s", *rule.Ports[0].Protocol)
+			}
+
+			// Verify ingress From is empty (all sources allowed on MCP port)
+			if len(rule.From) != 0 {
+				t.Fatalf("expected empty From (allow all sources), got %d entries", len(rule.From))
+			}
+
+			// Verify owner reference
+			if len(netpol.OwnerReferences) == 0 {
+				t.Fatal("expected owner reference on NetworkPolicy")
+			}
+			if netpol.OwnerReferences[0].Name != server.Name {
+				t.Fatalf("expected owner %s, got %s", server.Name, netpol.OwnerReferences[0].Name)
+			}
+
+			t.Logf("NetworkPolicy %s exists with correct spec: podSelector={mcp-server: %s}, port=3001/TCP, ingress-only",
+				netpol.Name, server.Name)
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestNetworkPolicyPortUpdate(t *testing.T) {
+	feature := features.New("MCPServer NetworkPolicy port update").
+		WithLabel("type", "networkpolicy").
+		WithLabel("scenario", "port-update").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.SetupMCPServer(ctx, t, cfg, "netpol-port", true)
+		}).
+		Assess("update port from 3001 to 3002", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+				s.Spec.Config.Port = 3002
+			})
+			t.Log("updated MCPServer port to 3002")
+
+			return ctx
+		}).
+		Assess("NetworkPolicy reflects updated port after reconciliation", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			netpol := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace},
+			}
+			err := wait.For(
+				conditions.New(r).ResourceMatch(netpol, func(obj k8s.Object) bool {
+					np := obj.(*networkingv1.NetworkPolicy)
+					if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 {
+						return false
+					}
+					return np.Spec.Ingress[0].Ports[0].Port.IntValue() == 3002
+				}),
+				wait.WithTimeout(1*time.Minute),
+				wait.WithInterval(2*time.Second),
+				wait.WithContext(ctx),
+			)
+			if err != nil {
+				t.Fatalf("NetworkPolicy port did not update to 3002: %v", err)
+			}
+
+			t.Log("NetworkPolicy port updated to 3002")
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestNetworkPolicyGarbageCollected(t *testing.T) {
+	feature := features.New("MCPServer NetworkPolicy garbage collection").
+		WithLabel("type", "networkpolicy").
+		WithLabel("scenario", "gc").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.SetupMCPServer(ctx, t, cfg, "netpol-gc", true)
+		}).
+		Assess("NetworkPolicy exists", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			netpol := &networkingv1.NetworkPolicy{}
+			if err := r.Get(ctx, server.Name, server.Namespace, netpol); err != nil {
+				t.Fatalf("NetworkPolicy not found: %v", err)
+			}
+			t.Logf("NetworkPolicy %s exists", netpol.Name)
+			return ctx
+		}).
+		Assess("NetworkPolicy is deleted when MCPServer is deleted", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			if err := r.Delete(ctx, server); err != nil {
+				t.Fatalf("failed to delete MCPServer: %v", err)
+			}
+			t.Logf("deleted MCPServer %s/%s", server.Namespace, server.Name)
+
+			netpol := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace},
+			}
+			err := wait.For(
+				conditions.New(r).ResourceDeleted(netpol),
+				wait.WithTimeout(1*time.Minute),
+				wait.WithInterval(2*time.Second),
+				wait.WithContext(ctx),
+			)
+			if err != nil {
+				t.Fatalf("NetworkPolicy was not garbage collected: %v", err)
+			}
+			t.Log("NetworkPolicy was garbage collected")
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}


### PR DESCRIPTION
Create a NetworkPolicy per MCPServer that restricts ingress to the configured MCP port (TCP) while leaving egress unrestricted. The policy selects operand pods via the same {mcp-server: <name>} label used by the Deployment and Service, and is owned by the MCPServer for automatic garbage collection.

The reconciler follows the existing Service pattern: create-or-update with ownership validation, orphan adoption, DeepEqual spec comparison, custom metadata propagation, duplicate condition checks, and Prometheus failure metrics.

Also enables the operator's own metrics NetworkPolicy in the default kustomization and adds unit and e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NetworkPolicy reconciliation for MCPServer, including ingress-only configuration and automatic ingress port updates.
  * Enabled inclusion of the network policy manifest in generated configurations.
  * Extended RBAC for NetworkPolicy operations and added NetworkPolicy reconciliation failure metrics.
* **Bug Fixes**
  * Improved MCPServer readiness/status updates and warning events for NetworkPolicy failures, including suppression of duplicate warnings.
  * Ensured managed extra labels/annotations are correctly applied and removed for NetworkPolicies.
* **Tests**
  * Added unit and end-to-end tests covering NetworkPolicy creation, port updates, failure handling, event behavior, and garbage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->