### PR TITLE
Apply TLS security profile from environment variables

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,6 +103,10 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
+	if tlsProfile := tlsConfigFromEnv(); tlsProfile != nil {
+		tlsOpts = append(tlsOpts, tlsProfile)
+	}
+
 	// Initial webhook TLS options
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{

--- a/cmd/tlsconfig.go
+++ b/cmd/tlsconfig.go
@@ -19,7 +19,14 @@ func tlsConfigFromEnv() func(*tls.Config) {
 	}
 
 	minVersion := parseTLSVersion(minVersionStr)
+	if minVersionStr != "" && minVersion == 0 {
+		log.Info("Ignoring unknown TLS_MIN_VERSION, falling back to Go defaults", "value", minVersionStr)
+	}
 	cipherSuites := parseCipherSuites(cipherSuitesStr, log)
+
+	if minVersion >= tls.VersionTLS13 && len(cipherSuites) > 0 {
+		log.Info("TLS 1.3 manages cipher suites automatically, configured suites will not be applied")
+	}
 
 	log.Info("Applying TLS profile from environment",
 		"minVersion", minVersionStr,
@@ -51,7 +58,7 @@ func parseTLSVersion(s string) uint16 {
 	}
 }
 
-func parseCipherSuites(s string, log interface{ Info(string, ...interface{}) }) []uint16 {
+func parseCipherSuites(s string, log interface{ Info(string, ...any) }) []uint16 {
 	if s == "" {
 		return nil
 	}

--- a/cmd/tlsconfig.go
+++ b/cmd/tlsconfig.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"crypto/tls"
+	"os"
+	"strings"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func tlsConfigFromEnv() func(*tls.Config) {
+	log := ctrl.Log.WithName("setup")
+
+	minVersionStr := os.Getenv("TLS_MIN_VERSION")
+	cipherSuitesStr := os.Getenv("TLS_CIPHER_SUITES")
+
+	if minVersionStr == "" && cipherSuitesStr == "" {
+		return nil
+	}
+
+	minVersion := parseTLSVersion(minVersionStr)
+	cipherSuites := parseCipherSuites(cipherSuitesStr, log)
+
+	log.Info("Applying TLS profile from environment",
+		"minVersion", minVersionStr,
+		"cipherSuiteCount", len(cipherSuites))
+
+	return func(c *tls.Config) {
+		if minVersion > 0 {
+			c.MinVersion = minVersion
+		}
+		// Go manages TLS 1.3 cipher suites automatically
+		if minVersion < tls.VersionTLS13 && len(cipherSuites) > 0 {
+			c.CipherSuites = cipherSuites
+		}
+	}
+}
+
+func parseTLSVersion(s string) uint16 {
+	switch s {
+	case "VersionTLS10":
+		return tls.VersionTLS10
+	case "VersionTLS11":
+		return tls.VersionTLS11
+	case "VersionTLS12":
+		return tls.VersionTLS12
+	case "VersionTLS13":
+		return tls.VersionTLS13
+	default:
+		return 0
+	}
+}
+
+func parseCipherSuites(s string, log interface{ Info(string, ...interface{}) }) []uint16 {
+	if s == "" {
+		return nil
+	}
+
+	lookup := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		lookup[cs.Name] = cs.ID
+	}
+	for _, cs := range tls.InsecureCipherSuites() {
+		lookup[cs.Name] = cs.ID
+	}
+
+	names := strings.Split(s, ",")
+	suites := make([]uint16, 0, len(names))
+
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if id, ok := lookup[name]; ok {
+			suites = append(suites, id)
+		} else if name != "" {
+			log.Info("Skipping unknown TLS cipher suite", "cipher", name)
+		}
+	}
+
+	return suites
+}

--- a/cmd/tlsconfig_test.go
+++ b/cmd/tlsconfig_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+type noopLogger struct{}
+
+func (noopLogger) Info(_ string, _ ...interface{}) {}
+
+func TestParseTLSVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  uint16
+	}{
+		{"VersionTLS10", tls.VersionTLS10},
+		{"VersionTLS11", tls.VersionTLS11},
+		{"VersionTLS12", tls.VersionTLS12},
+		{"VersionTLS13", tls.VersionTLS13},
+		{"", 0},
+		{"unknown", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseTLSVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("parseTLSVersion(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	log := noopLogger{}
+
+	t.Run("known IANA names", func(t *testing.T) {
+		suites := parseCipherSuites("TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", log)
+		if len(suites) != 2 {
+			t.Fatalf("expected 2 suites, got %d", len(suites))
+		}
+		if suites[0] != tls.TLS_AES_128_GCM_SHA256 {
+			t.Errorf("suites[0] = %#x, want %#x", suites[0], tls.TLS_AES_128_GCM_SHA256)
+		}
+		if suites[1] != tls.TLS_AES_256_GCM_SHA384 {
+			t.Errorf("suites[1] = %#x, want %#x", suites[1], tls.TLS_AES_256_GCM_SHA384)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		suites := parseCipherSuites("", log)
+		if suites != nil {
+			t.Errorf("expected nil, got %v", suites)
+		}
+	})
+
+	t.Run("unknown names are skipped", func(t *testing.T) {
+		suites := parseCipherSuites("TLS_AES_128_GCM_SHA256,UNKNOWN_CIPHER", log)
+		if len(suites) != 1 {
+			t.Fatalf("expected 1 suite, got %d", len(suites))
+		}
+	})
+
+	t.Run("TLS 1.2 ECDHE cipher", func(t *testing.T) {
+		suites := parseCipherSuites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", log)
+		if len(suites) != 1 {
+			t.Fatalf("expected 1 suite, got %d", len(suites))
+		}
+		if suites[0] != tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("suites[0] = %#x, want %#x", suites[0], tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+		}
+	})
+}
+
+func TestTlsConfigFromEnv_Unset(t *testing.T) {
+	t.Setenv("TLS_MIN_VERSION", "")
+	t.Setenv("TLS_CIPHER_SUITES", "")
+
+	result := tlsConfigFromEnv()
+	if result != nil {
+		t.Error("expected nil when env vars are unset")
+	}
+}
+
+func TestTlsConfigFromEnv_AppliesConfig(t *testing.T) {
+	t.Setenv("TLS_MIN_VERSION", "VersionTLS12")
+	t.Setenv("TLS_CIPHER_SUITES", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+
+	fn := tlsConfigFromEnv()
+	if fn == nil {
+		t.Fatal("expected non-nil TLS config function")
+	}
+
+	cfg := &tls.Config{}
+	fn(cfg)
+
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS12)
+	}
+	if len(cfg.CipherSuites) != 2 {
+		t.Fatalf("expected 2 cipher suites, got %d", len(cfg.CipherSuites))
+	}
+}
+
+func TestTlsConfigFromEnv_TLS13_SkipsCipherSuites(t *testing.T) {
+	t.Setenv("TLS_MIN_VERSION", "VersionTLS13")
+	t.Setenv("TLS_CIPHER_SUITES", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384")
+
+	fn := tlsConfigFromEnv()
+	if fn == nil {
+		t.Fatal("expected non-nil TLS config function")
+	}
+
+	cfg := &tls.Config{}
+	fn(cfg)
+
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS13)
+	}
+	if cfg.CipherSuites != nil {
+		t.Errorf("CipherSuites should be nil for TLS 1.3, got %v", cfg.CipherSuites)
+	}
+}

--- a/cmd/tlsconfig_test.go
+++ b/cmd/tlsconfig_test.go
@@ -7,7 +7,7 @@ import (
 
 type noopLogger struct{}
 
-func (noopLogger) Info(_ string, _ ...interface{}) {}
+func (noopLogger) Info(_ string, _ ...any) {}
 
 func TestParseTLSVersion(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
The operator exposes metrics and webhook endpoints over TLS, but currently uses Go's default TLS settings with no way to configure the minimum TLS version or allowed cipher suites. In environments with strict security policies, cluster administrators need to enforce a consistent TLS profile across all components.

This PR adds support for configuring TLS via two environment variables:
- `TLS_MIN_VERSION` — Go-style version string (e.g. `VersionTLS12`, `VersionTLS13`)
- `TLS_CIPHER_SUITES` — comma-separated IANA cipher suite names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-based TLS configuration to control the minimum TLS version and allowed cipher suites.
  * Applied the TLS settings consistently to both the webhook server and the metrics server.
* **Bug Fixes**
  * Improved resilience by safely ignoring unknown/unsupported TLS version and cipher suite values.
  * When TLS 1.3 is selected, cipher suites are not applied (even if provided).
* **Tests**
  * Added unit tests covering TLS version parsing, cipher suite parsing, and environment-driven TLS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->