### PR TITLE
fix: stop infinite requeues on permanent ownership conflicts

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -268,8 +268,12 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				conditionToAC(readyCondition),
 			)
 
-		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
-			logger.Error(err, "Failed to update MCPServer status")
+		if statusErr := r.applyStatus(ctx, mcpServer, status); statusErr != nil {
+			logger.Error(statusErr, "Failed to update MCPServer status")
+			return ctrl.Result{}, statusErr
+		}
+		if IsOwnershipConflict(err) {
+			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -312,8 +316,12 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				conditionToAC(readyCondition),
 			)
 
-		if err := r.applyStatus(ctx, mcpServer, status); err != nil {
-			logger.Error(err, "Failed to update MCPServer status")
+		if statusErr := r.applyStatus(ctx, mcpServer, status); statusErr != nil {
+			logger.Error(statusErr, "Failed to update MCPServer status")
+			return ctrl.Result{}, statusErr
+		}
+		if IsOwnershipConflict(err) {
+			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/mcpserver_controller_ownership.go
+++ b/internal/controller/mcpserver_controller_ownership.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,19 @@ import (
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 )
+
+type OwnershipConflictError struct {
+	Message string
+}
+
+func (e *OwnershipConflictError) Error() string {
+	return e.Message
+}
+
+func IsOwnershipConflict(err error) bool {
+	var target *OwnershipConflictError
+	return errors.As(err, &target)
+}
 
 // validateOwnership checks if a resource is owned by a different controller.
 // Returns an error if the resource has a controller owner that is not the given MCPServer,
@@ -38,9 +52,9 @@ func (r *MCPServerReconciler) validateOwnership(
 	if controllerOwner == nil {
 		// No controller owner - reject to prevent silent adoption
 		// User must delete the existing resource or choose a different name for their MCPServer
-		return fmt.Errorf("resource %s/%s exists but has no controller owner; "+
+		return &OwnershipConflictError{Message: fmt.Sprintf("resource %s/%s exists but has no controller owner; "+
 			"delete the resource first or choose a different name for the MCPServer",
-			obj.GetNamespace(), obj.GetName())
+			obj.GetNamespace(), obj.GetName())}
 	}
 
 	// Check if the controller owner is this MCPServer by UID
@@ -63,10 +77,10 @@ func (r *MCPServerReconciler) validateOwnership(
 	}
 
 	// Resource is owned by a different controller
-	return fmt.Errorf("resource %s/%s is owned by %s/%s (UID: %s), cannot be managed by MCPServer %s/%s (UID: %s)",
+	return &OwnershipConflictError{Message: fmt.Sprintf("resource %s/%s is owned by %s/%s (UID: %s), cannot be managed by MCPServer %s/%s (UID: %s)",
 		obj.GetNamespace(), obj.GetName(),
 		controllerOwner.Kind, controllerOwner.Name, controllerOwner.UID,
-		mcpServer.Namespace, mcpServer.Name, mcpServer.UID)
+		mcpServer.Namespace, mcpServer.Name, mcpServer.UID)}
 }
 
 // isSameGroupKind checks if an owner reference matches the expected API group and kind,

--- a/internal/controller/mcpserver_controller_ownership_test.go
+++ b/internal/controller/mcpserver_controller_ownership_test.go
@@ -18,15 +18,18 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -239,9 +242,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("is owned by"))
-			Expect(err.Error()).To(ContainSubstring("cannot be managed by MCPServer"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the deployment spec was NOT overwritten")
 			deployment := &appsv1.Deployment{}
@@ -321,9 +322,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("is owned by"))
-			Expect(err.Error()).To(ContainSubstring("cannot be managed by MCPServer"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the service port was NOT updated")
 			service := &corev1.Service{}
@@ -400,9 +399,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
-			Expect(err.Error()).To(ContainSubstring("delete the resource first or choose a different name"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the deployment was NOT updated")
 			deployment := &appsv1.Deployment{}
@@ -480,8 +477,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the service was NOT updated")
 			service := &corev1.Service{}
@@ -579,8 +575,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the deployment was NOT updated")
 			deployment := &appsv1.Deployment{}
@@ -677,8 +672,7 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("has no controller owner"))
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying the service was NOT updated")
 			service := &corev1.Service{}
@@ -1101,6 +1095,158 @@ var _ = Describe("MCPServer Controller - Foreign Owned Resources", func() {
 
 			By("Cleanup")
 			Expect(k8sClient.Delete(ctx, newMCPServer)).To(Succeed())
+		})
+	})
+
+	Context("When status update fails during an ownership conflict", func() {
+		const resourceName = "test-status-fail-deploy"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			By("Pre-creating a Deployment with no owner")
+			unownedDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: managedWorkloadSelector(resourceName),
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: managedWorkloadLabels(resourceName),
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "manual", Image: "manual-image:latest"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, unownedDeployment)).To(Succeed())
+
+			By("Creating the MCPServer CR")
+			resource := newTestMCPServer(resourceName)
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should propagate the status update error for retry", func() {
+			wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+			Expect(err).NotTo(HaveOccurred())
+
+			interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+				SubResourceApply: func(ctx context.Context, c client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+					if subResourceName == "status" {
+						return fmt.Errorf("simulated status update failure")
+					}
+					return c.SubResource(subResourceName).Apply(ctx, obj, opts...)
+				},
+			})
+
+			controllerReconciler := &MCPServerReconciler{
+				Client:    interceptedClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: wrappedClient,
+			}
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("simulated status update failure"))
+		})
+	})
+
+	Context("When status update fails during a service ownership conflict", func() {
+		const resourceName = "test-status-fail-svc"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			By("Pre-creating a Service with no owner")
+			unownedService := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: managedWorkloadSelector(resourceName),
+					Ports: []corev1.ServicePort{
+						{Name: "http", Port: 8080, TargetPort: intstr.FromInt32(8080)},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, unownedService)).To(Succeed())
+
+			By("Creating the MCPServer CR")
+			resource := newTestMCPServer(resourceName)
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			resource := &mcpv1alpha1.MCPServer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+			service := &corev1.Service{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, service)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, service)).To(Succeed())
+			}
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: resourceName, Namespace: "default"}, deployment)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, deployment)).To(Succeed())
+			}
+		})
+
+		It("should propagate the status update error for retry", func() {
+			wrappedClient, err := client.NewWithWatch(cfg, client.Options{Scheme: k8sClient.Scheme()})
+			Expect(err).NotTo(HaveOccurred())
+
+			interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+				SubResourceApply: func(ctx context.Context, c client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+					if subResourceName == "status" {
+						return fmt.Errorf("simulated status update failure")
+					}
+					return c.SubResource(subResourceName).Apply(ctx, obj, opts...)
+				},
+			})
+
+			controllerReconciler := &MCPServerReconciler{
+				Client:    interceptedClient,
+				Scheme:    k8sClient.Scheme(),
+				APIReader: wrappedClient,
+			}
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("simulated status update failure"))
 		})
 	})
 })


### PR DESCRIPTION
validateOwnership returns permanent errors (resource owned by another controller or no controller owner) that will never self-resolve. Previously these were returned as regular errors, causing controller-runtime to requeue indefinitely with exponential backoff.

Introduce OwnershipConflictError so the reconciler can detect permanent conflicts, set a degraded status condition, and return nil to stop requeuing. The Owns() watch will re-trigger reconciliation if the conflicting resource is deleted or changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation behavior when Deployment/Service ownership conflicts occur.
  * Ownership conflicts are now handled more precisely: they won’t fail the reconcile flow when status updates succeed.
  * If MCPServer status updates fail during reconciliation, the controller now returns the relevant status update error.
  * Existing Deployments and Services with conflicting/no controller ownership remain unchanged.
* **Tests**
  * Added coverage for MCPServer status update failures during ownership-conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->