### PR TITLE
fix: build entire cmd package instead of single file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,11 +165,11 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -o bin/manager ./cmd/
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run ./cmd/
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
The Makefile build and run targets used `cmd/main.go` (single file compilation) instead of `./cmd/` (whole package). This excluded tlsconfig.go from the build, causing an "undefined: tlsConfigFromEnv" error introduced in #250.

The Dockerfile already used `./cmd` correctly, so container builds were unaffected. Only local `make build` and `make run` were broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project build and run commands to use the application directory, aligning local workflows with the current project structure.
  * No user-facing feature changes; behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->