### PR TITLE
Bump go-sdk to v1.7.0

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpservercapabilities.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpservercapabilities.go
@@ -30,7 +30,8 @@ type MCPServerCapabilitiesApplyConfiguration struct {
 	Resources *bool `json:"resources,omitempty"`
 	// Prompts indicates the server supports prompt templates.
 	Prompts *bool `json:"prompts,omitempty"`
-	// Logging indicates the server supports sending log messages.
+	// Deprecated: Logging is deprecated per MCP protocol SEP-2577 and will be
+	// removed after the deprecation window (mid-2027).
 	Logging *bool `json:"logging,omitempty"`
 	// Completions indicates the server supports argument autocompletion.
 	Completions *bool `json:"completions,omitempty"`

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -398,7 +398,8 @@ type MCPServerCapabilities struct {
 	// Prompts indicates the server supports prompt templates.
 	// +optional
 	Prompts bool `json:"prompts,omitempty"`
-	// Logging indicates the server supports sending log messages.
+	// Deprecated: Logging is deprecated per MCP protocol SEP-2577 and will be
+	// removed after the deprecation window (mid-2027).
 	// +optional
 	Logging bool `json:"logging,omitempty"`
 	// Completions indicates the server supports argument autocompletion.

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -1694,8 +1694,9 @@ spec:
                           autocompletion.
                         type: boolean
                       logging:
-                        description: Logging indicates the server supports sending
-                          log messages.
+                        description: |-
+                          Deprecated: Logging is deprecated per MCP protocol SEP-2577 and will be
+                          removed after the deprecation window (mid-2027).
                         type: boolean
                       prompts:
                         description: Prompts indicates the server supports prompt

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.4
 
 require (
-	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/onsi/ginkgo/v2 v2.31.0
 	github.com/onsi/gomega v1.42.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 toolchain go1.26.4
 
 require (
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.1
 	github.com/onsi/ginkgo/v2 v2.31.0
 	github.com/onsi/gomega v1.42.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3v
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0-pre.1 h1:GlMIJyMHFX76bBSQuBCLXZ7pB9cGh4VBS6O5wGd0tgI=
+github.com/modelcontextprotocol/go-sdk v1.7.0-pre.1/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3v
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
-github.com/modelcontextprotocol/go-sdk v1.7.0-pre.1 h1:GlMIJyMHFX76bBSQuBCLXZ7pB9cGh4VBS6O5wGd0tgI=
-github.com/modelcontextprotocol/go-sdk v1.7.0-pre.1/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -388,7 +388,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				WithTools(serverInfo.Capabilities.Tools).
 				WithResources(serverInfo.Capabilities.Resources).
 				WithPrompts(serverInfo.Capabilities.Prompts).
-				WithLogging(serverInfo.Capabilities.Logging).
+				WithLogging(serverInfo.Capabilities.Logging). //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
 				WithCompletions(serverInfo.Capabilities.Completions))
 		}
 		status = status.WithServerInfo(si)

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -148,7 +148,7 @@ func extractServerInfo(res *mcp.InitializeResult) *mcpv1alpha1.MCPServerInfo {
 			Tools:       res.Capabilities.Tools != nil,
 			Resources:   res.Capabilities.Resources != nil,
 			Prompts:     res.Capabilities.Prompts != nil,
-			Logging:     res.Capabilities.Logging != nil,
+			Logging:     res.Capabilities.Logging != nil, //nolint:staticcheck // deprecated per SEP-2577, still functional
 			Completions: res.Capabilities.Completions != nil,
 		}
 	}

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -148,7 +148,7 @@ func extractServerInfo(res *mcp.InitializeResult) *mcpv1alpha1.MCPServerInfo {
 			Tools:       res.Capabilities.Tools != nil,
 			Resources:   res.Capabilities.Resources != nil,
 			Prompts:     res.Capabilities.Prompts != nil,
-			Logging:     res.Capabilities.Logging != nil, //nolint:staticcheck // deprecated per SEP-2577, still functional
+			Logging:     res.Capabilities.Logging != nil, //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
 			Completions: res.Capabilities.Completions != nil,
 		}
 	}

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -1068,7 +1068,7 @@ var _ = Describe("extractServerInfo", func() {
 				Tools:       &mcp.ToolCapabilities{},
 				Resources:   &mcp.ResourceCapabilities{},
 				Prompts:     &mcp.PromptCapabilities{},
-				Logging:     &mcp.LoggingCapabilities{}, //nolint:staticcheck // deprecated per SEP-2577, still functional
+				Logging:     &mcp.LoggingCapabilities{}, //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
 				Completions: &mcp.CompletionCapabilities{},
 			},
 		}

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -1068,7 +1068,7 @@ var _ = Describe("extractServerInfo", func() {
 				Tools:       &mcp.ToolCapabilities{},
 				Resources:   &mcp.ResourceCapabilities{},
 				Prompts:     &mcp.PromptCapabilities{},
-				Logging:     &mcp.LoggingCapabilities{},
+				Logging:     &mcp.LoggingCapabilities{}, //nolint:staticcheck // deprecated per SEP-2577, still functional
 				Completions: &mcp.CompletionCapabilities{},
 			},
 		}

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -912,7 +912,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 		Expect(mcpServer.Status.ServerInfo.Capabilities.Tools).To(BeTrue())
 		Expect(mcpServer.Status.ServerInfo.Capabilities.Resources).To(BeTrue())
 		Expect(mcpServer.Status.ServerInfo.Capabilities.Prompts).To(BeFalse())
-		Expect(mcpServer.Status.ServerInfo.Capabilities.Logging).To(BeTrue())
+		Expect(mcpServer.Status.ServerInfo.Capabilities.Logging).To(BeTrue()) //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
 		Expect(mcpServer.Status.ServerInfo.Capabilities.Completions).To(BeFalse())
 	})
 
@@ -1078,7 +1078,7 @@ var _ = Describe("extractServerInfo", func() {
 		Expect(info.Capabilities.Tools).To(BeTrue())
 		Expect(info.Capabilities.Resources).To(BeTrue())
 		Expect(info.Capabilities.Prompts).To(BeTrue())
-		Expect(info.Capabilities.Logging).To(BeTrue())
+		Expect(info.Capabilities.Logging).To(BeTrue()) //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
 		Expect(info.Capabilities.Completions).To(BeTrue())
 	})
 
@@ -1095,7 +1095,7 @@ var _ = Describe("extractServerInfo", func() {
 		Expect(info.Capabilities.Tools).To(BeTrue())
 		Expect(info.Capabilities.Resources).To(BeFalse())
 		Expect(info.Capabilities.Prompts).To(BeFalse())
-		Expect(info.Capabilities.Logging).To(BeFalse())
+		Expect(info.Capabilities.Logging).To(BeFalse()) //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
 		Expect(info.Capabilities.Completions).To(BeFalse())
 	})
 


### PR DESCRIPTION
Upgrades github.com/modelcontextprotocol/go-sdk from v1.6.1 to v1.7.0. Adds support for MCP protocol version 2026-07-28 (stateless MCP, server/discover). The SDK handles protocol negotiation transparently - no functional code changes required.

The only code change is adding nolint:staticcheck directives on the LoggingCapabilities field, which the SDK now marks as deprecated per SEP-2577. The field remains functional during the 12-month deprecation window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server capability detection for logging-related information, making handling of server responses more reliable when servers report logging support.
* **Chores**
  * Updated the core MCP SDK to a newer version to stay aligned with upstream improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->