### PR TITLE
Add protocol version observability and update CRD godoc 

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpservercapabilities.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpservercapabilities.go
@@ -22,7 +22,7 @@ package v1alpha1
 // with apply.
 //
 // MCPServerCapabilities describes which MCP protocol capabilities the server advertises
-// during the initialize handshake.
+// during the protocol handshake (initialize or server/discover).
 type MCPServerCapabilitiesApplyConfiguration struct {
 	// Tools indicates the server supports tool listing and invocation.
 	Tools *bool `json:"tools,omitempty"`
@@ -30,8 +30,11 @@ type MCPServerCapabilitiesApplyConfiguration struct {
 	Resources *bool `json:"resources,omitempty"`
 	// Prompts indicates the server supports prompt templates.
 	Prompts *bool `json:"prompts,omitempty"`
-	// Deprecated: Logging is deprecated per MCP protocol SEP-2577 and will be
-	// removed after the deprecation window (mid-2027).
+	// Logging indicates the server supports sending log messages.
+	//
+	// Deprecated: logging capability is deprecated as of MCP protocol version
+	// 2026-07-28 (SEP-2577) and will be removed after the 12-month deprecation
+	// window. The field remains functional during the transition period.
 	Logging *bool `json:"logging,omitempty"`
 	// Completions indicates the server supports argument autocompletion.
 	Completions *bool `json:"completions,omitempty"`

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverinfo.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverinfo.go
@@ -22,13 +22,15 @@ package v1alpha1
 // with apply.
 //
 // MCPServerInfo contains identity and capability information reported by the
-// MCP server during the protocol initialize handshake.
+// MCP server during the protocol handshake (initialize or server/discover).
 type MCPServerInfoApplyConfiguration struct {
 	// Name is the server's self-reported name.
 	Name *string `json:"name,omitempty"`
 	// Version is the server's self-reported version.
 	Version *string `json:"version,omitempty"`
-	// ProtocolVersion is the MCP protocol version negotiated during the handshake.
+	// ProtocolVersion is the MCP protocol version negotiated during the protocol
+	// handshake. The value reflects whichever version was agreed upon by both
+	// client and server.
 	ProtocolVersion *string `json:"protocolVersion,omitempty"`
 	// Instructions describes how to use the server and its features.
 	// This can be used by clients to improve the LLM's understanding of

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
@@ -38,7 +38,7 @@ type MCPServerStatusApplyConfiguration struct {
 	// Address contains the address of the MCP server service.
 	Address *MCPServerAddressApplyConfiguration `json:"address,omitempty"`
 	// ServerInfo contains identity and capability information reported by the
-	// MCP server during the protocol initialize handshake.
+	// MCP server during the protocol handshake (initialize or server/discover).
 	// This field is populated only after a successful handshake.
 	ServerInfo *MCPServerInfoApplyConfiguration `json:"serverInfo,omitempty"`
 	// HandshakeRetryCount tracks the number of consecutive MCP handshake

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -387,7 +387,7 @@ type MCPServerAddress struct {
 }
 
 // MCPServerCapabilities describes which MCP protocol capabilities the server advertises
-// during the initialize handshake.
+// during the protocol handshake (initialize or server/discover).
 type MCPServerCapabilities struct {
 	// Tools indicates the server supports tool listing and invocation.
 	// +optional
@@ -398,8 +398,11 @@ type MCPServerCapabilities struct {
 	// Prompts indicates the server supports prompt templates.
 	// +optional
 	Prompts bool `json:"prompts,omitempty"`
-	// Deprecated: Logging is deprecated per MCP protocol SEP-2577 and will be
-	// removed after the deprecation window (mid-2027).
+	// Logging indicates the server supports sending log messages.
+	//
+	// Deprecated: logging capability is deprecated as of MCP protocol version
+	// 2026-07-28 (SEP-2577) and will be removed after the 12-month deprecation
+	// window. The field remains functional during the transition period.
 	// +optional
 	Logging bool `json:"logging,omitempty"`
 	// Completions indicates the server supports argument autocompletion.
@@ -408,7 +411,7 @@ type MCPServerCapabilities struct {
 }
 
 // MCPServerInfo contains identity and capability information reported by the
-// MCP server during the protocol initialize handshake.
+// MCP server during the protocol handshake (initialize or server/discover).
 type MCPServerInfo struct {
 	// Name is the server's self-reported name.
 	// +optional
@@ -416,7 +419,9 @@ type MCPServerInfo struct {
 	// Version is the server's self-reported version.
 	// +optional
 	Version string `json:"version,omitempty"`
-	// ProtocolVersion is the MCP protocol version negotiated during the handshake.
+	// ProtocolVersion is the MCP protocol version negotiated during the protocol
+	// handshake. The value reflects whichever version was agreed upon by both
+	// client and server.
 	// +optional
 	ProtocolVersion string `json:"protocolVersion,omitempty"`
 	// Instructions describes how to use the server and its features.
@@ -450,7 +455,7 @@ type MCPServerStatus struct {
 	Address *MCPServerAddress `json:"address,omitempty"`
 
 	// ServerInfo contains identity and capability information reported by the
-	// MCP server during the protocol initialize handshake.
+	// MCP server during the protocol handshake (initialize or server/discover).
 	// This field is populated only after a successful handshake.
 	// +optional
 	ServerInfo *MCPServerInfo `json:"serverInfo,omitempty"`

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -1683,7 +1683,7 @@ spec:
               serverInfo:
                 description: |-
                   ServerInfo contains identity and capability information reported by the
-                  MCP server during the protocol initialize handshake.
+                  MCP server during the protocol handshake (initialize or server/discover).
                   This field is populated only after a successful handshake.
                 properties:
                   capabilities:
@@ -1696,8 +1696,11 @@ spec:
                         type: boolean
                       logging:
                         description: |-
-                          Deprecated: Logging is deprecated per MCP protocol SEP-2577 and will be
-                          removed after the deprecation window (mid-2027).
+                          Logging indicates the server supports sending log messages.
+
+                          Deprecated: logging capability is deprecated as of MCP protocol version
+                          2026-07-28 (SEP-2577) and will be removed after the 12-month deprecation
+                          window. The field remains functional during the transition period.
                         type: boolean
                       prompts:
                         description: Prompts indicates the server supports prompt
@@ -1722,8 +1725,10 @@ spec:
                     description: Name is the server's self-reported name.
                     type: string
                   protocolVersion:
-                    description: ProtocolVersion is the MCP protocol version negotiated
-                      during the handshake.
+                    description: |-
+                      ProtocolVersion is the MCP protocol version negotiated during the protocol
+                      handshake. The value reflects whichever version was agreed upon by both
+                      client and server.
                     type: string
                   version:
                     description: Version is the server's self-reported version.

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -85,12 +85,17 @@ func (r *MCPServerReconciler) reconcileHandshake(
 		return cond, nil
 	}
 
-	logger.Info("MCP endpoint verified successfully", "url", mcpURL)
+	protocolVersion := ""
+	if info != nil {
+		protocolVersion = info.ProtocolVersion
+	}
+	logger.Info("MCP endpoint verified successfully", "url", mcpURL, "protocolVersion", protocolVersion)
 	return readyCondition, info
 }
 
-// verifyMCPEndpoint performs an MCP initialize handshake against the given URL
-// to verify the endpoint actually speaks the MCP protocol.
+// verifyMCPEndpoint performs an MCP protocol handshake (initialize or
+// server/discover) against the given URL to verify the endpoint actually
+// speaks the MCP protocol.
 // On success it returns the server's self-reported identity and capabilities
 // extracted from the InitializeResult.
 // It uses a dedicated context for the connection so that cancelling it tears


### PR DESCRIPTION
Log the negotiated MCP protocol version on successful handshake in reconcileHandshake. Update CRD godoc to reflect that the handshake may use either initialize or server/discover, and add deprecation
notice on the Logging capability per SEP-2577.

https://modelcontextprotocol.io/seps/2577-deprecate-roots-sampling-and-logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP handshake support for both `initialize` and `server/discover`.
  * Clarified that the protocol version is agreed upon by the client and server.
  * Documented the deprecation timeline for the logging capability.
* **Enhancements**
  * Handshake logs now include the negotiated protocol version when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->