### PR TITLE
docs: add NetworkPolicy to documentation and API type comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ kubectl get deployment test-server
 # Verify the Service was created
 kubectl get service test-server
 
+# Verify the NetworkPolicy was created
+kubectl get networkpolicy test-server
+
 # Check the pod is running
 kubectl get pods -l mcp-server=test-server
 ```

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserver.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserver.go
@@ -29,7 +29,7 @@ import (
 //
 // MCPServer runs a Model Context Protocol (MCP) server in Kubernetes.
 //
-// MCPServer creates and manages a Deployment and Service to run an MCP server from a
+// MCPServer creates and manages a Deployment, Service, and NetworkPolicy to run an MCP server from a
 // container image. The MCP server exposes tools, resources, and prompts that AI applications
 // can use via the Model Context Protocol.
 //
@@ -47,7 +47,7 @@ import (
 // config:
 // port: 8080
 //
-// The controller manages Deployment and Service resources with the same name as the MCPServer,
+// The controller manages Deployment, Service, and NetworkPolicy resources with the same name as the MCPServer,
 // using ownerReferences to establish ownership. The controller will reject updates to resources
 // owned by other controllers or resources with no controller owner (to prevent silent overwrites
 // of manually-created resources), but will adopt orphaned resources from a deleted MCPServer

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -507,7 +507,7 @@ type MCPServerStatus struct {
 
 // MCPServer runs a Model Context Protocol (MCP) server in Kubernetes.
 //
-// MCPServer creates and manages a Deployment and Service to run an MCP server from a
+// MCPServer creates and manages a Deployment, Service, and NetworkPolicy to run an MCP server from a
 // container image. The MCP server exposes tools, resources, and prompts that AI applications
 // can use via the Model Context Protocol.
 //
@@ -525,7 +525,7 @@ type MCPServerStatus struct {
 //	  config:
 //	    port: 8080
 //
-// The controller manages Deployment and Service resources with the same name as the MCPServer,
+// The controller manages Deployment, Service, and NetworkPolicy resources with the same name as the MCPServer,
 // using ownerReferences to establish ownership. The controller will reject updates to resources
 // owned by other controllers or resources with no controller owner (to prevent silent overwrites
 // of manually-created resources), but will adopt orphaned resources from a deleted MCPServer

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -37,17 +37,18 @@ spec:
     schema:
       openAPIV3Schema:
         description: "MCPServer runs a Model Context Protocol (MCP) server in Kubernetes.\n\nMCPServer
-          creates and manages a Deployment and Service to run an MCP server from a\ncontainer
-          image. The MCP server exposes tools, resources, and prompts that AI applications\ncan
-          use via the Model Context Protocol.\n\nExample:\n\n\tapiVersion: mcp.x-k8s.io/v1alpha1\n\tkind:
-          MCPServer\n\tmetadata:\n\t  name: example\n\tspec:\n\t  source:\n\t    type:
-          ContainerImage\n\t    containerImage:\n\t      ref: example-mcp-image\n\t
-          \ config:\n\t    port: 8080\n\nThe controller manages Deployment and Service
-          resources with the same name as the MCPServer,\nusing ownerReferences to
-          establish ownership. The controller will reject updates to resources\nowned
-          by other controllers or resources with no controller owner (to prevent silent
-          overwrites\nof manually-created resources), but will adopt orphaned resources
-          from a deleted MCPServer\nwith the same name to enable seamless recreation."
+          creates and manages a Deployment, Service, and NetworkPolicy to run an MCP
+          server from a\ncontainer image. The MCP server exposes tools, resources,
+          and prompts that AI applications\ncan use via the Model Context Protocol.\n\nExample:\n\n\tapiVersion:
+          mcp.x-k8s.io/v1alpha1\n\tkind: MCPServer\n\tmetadata:\n\t  name: example\n\tspec:\n\t
+          \ source:\n\t    type: ContainerImage\n\t    containerImage:\n\t      ref:
+          example-mcp-image\n\t  config:\n\t    port: 8080\n\nThe controller manages
+          Deployment, Service, and NetworkPolicy resources with the same name as the
+          MCPServer,\nusing ownerReferences to establish ownership. The controller
+          will reject updates to resources\nowned by other controllers or resources
+          with no controller owner (to prevent silent overwrites\nof manually-created
+          resources), but will adopt orphaned resources from a deleted MCPServer\nwith
+          the same name to enable seamless recreation."
         properties:
           apiVersion:
             description: |-

--- a/site-src/guides/quickstart.md
+++ b/site-src/guides/quickstart.md
@@ -87,6 +87,9 @@ kubectl get deployment kubernetes-mcp-server
 # Verify the Service was created
 kubectl get service kubernetes-mcp-server
 
+# Verify the NetworkPolicy was created
+kubectl get networkpolicy kubernetes-mcp-server
+
 # Check the pod is running
 kubectl get pods -l mcp-server=kubernetes-mcp-server
 ```

--- a/site-src/index.md
+++ b/site-src/index.md
@@ -7,7 +7,7 @@ A Kubernetes operator that provides a declarative API to deploy, manage, and saf
 
 ## Core Capabilities
 
-**Declarative Deployment** - Define MCP servers using Kubernetes Custom Resources with automatic deployment, service creation, and lifecycle management.
+**Declarative Deployment** - Define MCP servers using Kubernetes Custom Resources with automatic deployment, service creation, network policy enforcement, and lifecycle management.
 
 **Production Ready** - Built-in health checks, security configurations, and robust status reporting for production environments.
 

--- a/site-src/introduction.md
+++ b/site-src/introduction.md
@@ -24,7 +24,7 @@ spec:
 
 #### Custom Labels and Annotations
 
-Add custom labels and annotations to the managed Deployment, PodTemplate, and Service:
+Add custom labels and annotations to the managed Deployment, PodTemplate, Service, and NetworkPolicy:
 
 ```yaml
 spec:
@@ -153,8 +153,10 @@ graph TB
     MCPServer -->|Reconciles| Operator[MCP Lifecycle Operator]
     Operator -->|Creates/Updates| Deployment[Deployment]
     Operator -->|Creates/Updates| Service[Service]
+    Operator -->|Creates/Updates| NetworkPolicy[NetworkPolicy]
     Deployment -->|Manages| Pods[MCP Server Pods]
     Service -->|Routes to| Pods
+    NetworkPolicy -->|Secures| Pods
     Operator -->|Updates| Status[Status with Address]
 ```
 
@@ -162,9 +164,10 @@ The operator watches for `MCPServer` resources and automatically:
 
 1. Creates a Deployment to run the MCP server containers
 2. Creates a Service for network access
-3. Manages updates and rollouts
-4. Reports status and connection information
-5. Cleans up resources on deletion
+3. Creates a NetworkPolicy to restrict ingress to the configured server port
+4. Manages updates and rollouts
+5. Reports status and connection information
+6. Cleans up resources on deletion
 
 ## Next Steps
 

--- a/site-src/operating/metrics.md
+++ b/site-src/operating/metrics.md
@@ -39,7 +39,8 @@ Custom metrics use the Prometheus namespace **`mcpserver`** (exported names star
 | `mcpserver_validation_failures_total` | counter | Total permanent configuration validation failures (`ValidationError`). |
 | `mcpserver_deployment_failures_total` | counter | Total failures when reconciling the workload Deployment (`reason` is currently `ReconcileError`). |
 | `mcpserver_service_failures_total` | counter | Total failures when reconciling the Service (`reason` is currently `ReconcileError`). |
-| `mcpserver_reconcile_phase_duration_seconds` | histogram | Duration of reconciliation phases **validation**, **deployment**, and **service** (seconds; default Prometheus histogram buckets). |
+| `mcpserver_networkpolicy_failures_total` | counter | Total failures when reconciling the NetworkPolicy (`reason` is currently `ReconcileError`). |
+| `mcpserver_reconcile_phase_duration_seconds` | histogram | Duration of reconciliation phases **validation**, **deployment**, **service**, and **networkpolicy** (seconds; default Prometheus histogram buckets). |
 
 ### Labels for `mcpserver_condition_info`
 
@@ -58,7 +59,7 @@ Only one active series exists per `(name, namespace, type)`. On delete, both gau
 | `type` | Typical `reason` values | `status` notes |
 | --- | --- | --- |
 | `Accepted` | `Valid`, `Invalid` | Usually `True` or `False` |
-| `Ready` | `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable` | May be `Unknown` (for example `Initializing` while the Deployment has not reported conditions yet) |
+| `Ready` | `Available`, `ConfigurationInvalid`, `DeploymentUnavailable`, `ServiceUnavailable`, `NetworkPolicyUnavailable`, `ScaledToZero`, `Initializing`, `MCPEndpointUnavailable` | May be `Unknown` (for example `Initializing` while the Deployment has not reported conditions yet) |
 
 ### Gauge versus API status
 
@@ -90,7 +91,7 @@ histogram_quantile(
 
 ### Labels for failure counters (`mcpserver_*_failures_total`)
 
-`mcpserver_validation_failures_total`, `mcpserver_deployment_failures_total`, and `mcpserver_service_failures_total` share the **same label set**:
+`mcpserver_validation_failures_total`, `mcpserver_deployment_failures_total`, `mcpserver_service_failures_total`, and `mcpserver_networkpolicy_failures_total` share the **same label set**:
 
 | Label | Description |
 | --- | --- |
@@ -101,13 +102,13 @@ histogram_quantile(
 **`reason` values**
 
 - **`mcpserver_validation_failures_total`** — permanent validation errors currently use `Invalid`.
-- **`mcpserver_deployment_failures_total`** and **`mcpserver_service_failures_total`** — currently `ReconcileError` when the corresponding reconcile step returns an error.
+- **`mcpserver_deployment_failures_total`**, **`mcpserver_service_failures_total`**, and **`mcpserver_networkpolicy_failures_total`** — currently `ReconcileError` when the corresponding reconcile step returns an error.
 
 ### Labels for `mcpserver_reconcile_phase_duration_seconds`
 
 | Label | Description |
 | --- | --- |
-| `phase` | Reconciliation phase: `validation`, `deployment`, or `service` |
+| `phase` | Reconciliation phase: `validation`, `deployment`, `service`, or `networkpolicy` |
 
 Histogram time series use the usual `_bucket`, `_sum`, and `_count` suffixes for quantiles and averages.
 


### PR DESCRIPTION
Based on https://github.com/kubernetes-sigs/mcp-lifecycle-operator/pull/249 feature - adding some more docs 