### PR TITLE
feat: propagate tls env to mcp servers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -103,7 +104,8 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
-	if tlsProfile := tlsConfigFromEnv(); tlsProfile != nil {
+	tlsCfg := parseTLSSettings()
+	if tlsProfile := tlsCfg.tlsConfigFunc(); tlsProfile != nil {
 		tlsOpts = append(tlsOpts, tlsProfile)
 	}
 
@@ -183,12 +185,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := (&controller.MCPServerReconciler{
+	reconciler := &controller.MCPServerReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Recorder:  mgr.GetEventRecorder("mcpserver-controller"),
 		APIReader: mgr.GetAPIReader(),
-	}).SetupWithManager(mgr); err != nil {
+	}
+	if strings.EqualFold(os.Getenv("PROPAGATE_TLS_ENV_VARS"), "true") {
+		reconciler.TLSEnvVars = tlsCfg.envVars()
+		setupLog.Info("Propagating TLS environment variables to MCP server containers",
+			"count", len(reconciler.TLSEnvVars))
+	}
+	if err := reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MCPServer")
 		os.Exit(1)
 	}

--- a/cmd/tlsconfig.go
+++ b/cmd/tlsconfig.go
@@ -5,40 +5,89 @@ import (
 	"os"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func tlsConfigFromEnv() func(*tls.Config) {
+const (
+	envTLSMinVersion   = "TLS_MIN_VERSION"
+	envTLSCipherSuites = "TLS_CIPHER_SUITES"
+)
+
+// tlsSettings holds validated TLS configuration parsed from the environment.
+// Both the tls.Config mutator and the env vars propagated to MCP server
+// containers are derived from this single source of truth.
+type tlsSettings struct {
+	minVersionStr   string   // original env value, empty if unset or invalid
+	minVersionCode  uint16   // parsed TLS version constant, 0 if unset or invalid
+	cipherSuitesStr string   // comma-separated list of validated cipher suite names
+	cipherSuiteIDs  []uint16 // parsed cipher suite IDs for validated names
+}
+
+// parseTLSSettings reads TLS_MIN_VERSION and TLS_CIPHER_SUITES from the
+// environment, validates them, and returns a tlsSettings with only the
+// values that passed validation.
+func parseTLSSettings() tlsSettings {
 	log := ctrl.Log.WithName("setup")
 
-	minVersionStr := os.Getenv("TLS_MIN_VERSION")
-	cipherSuitesStr := os.Getenv("TLS_CIPHER_SUITES")
+	var s tlsSettings
 
-	if minVersionStr == "" && cipherSuitesStr == "" {
-		return nil
+	if raw := os.Getenv(envTLSMinVersion); raw != "" {
+		if v := parseTLSVersion(raw); v > 0 {
+			s.minVersionStr = raw
+			s.minVersionCode = v
+		} else {
+			log.Info("Ignoring unknown TLS_MIN_VERSION, falling back to Go defaults", "value", raw)
+		}
 	}
 
-	minVersion := parseTLSVersion(minVersionStr)
-	if minVersionStr != "" && minVersion == 0 {
-		log.Info("Ignoring unknown TLS_MIN_VERSION, falling back to Go defaults", "value", minVersionStr)
+	if raw := os.Getenv(envTLSCipherSuites); raw != "" {
+		ids, names := parseCipherSuites(raw, log)
+		if len(ids) > 0 {
+			s.cipherSuiteIDs = ids
+			s.cipherSuitesStr = strings.Join(names, ",")
+		}
 	}
-	cipherSuites := parseCipherSuites(cipherSuitesStr, log)
 
-	if minVersion >= tls.VersionTLS13 && len(cipherSuites) > 0 {
+	if s.minVersionCode >= tls.VersionTLS13 && len(s.cipherSuiteIDs) > 0 {
 		log.Info("TLS 1.3 manages cipher suites automatically, configured suites will not be applied")
 	}
 
-	log.Info("Applying TLS profile from environment",
-		"minVersion", minVersionStr,
-		"cipherSuiteCount", len(cipherSuites))
+	if s.minVersionStr != "" || s.cipherSuitesStr != "" {
+		log.Info("Applying TLS profile from environment",
+			"minVersion", s.minVersionStr,
+			"cipherSuiteCount", len(s.cipherSuiteIDs))
+	}
 
+	return s
+}
+
+// envVars returns the validated TLS settings as Kubernetes EnvVar entries
+// suitable for injection into MCP server containers.
+func (s tlsSettings) envVars() []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+	if s.minVersionStr != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: envTLSMinVersion, Value: s.minVersionStr})
+	}
+	if s.cipherSuitesStr != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: envTLSCipherSuites, Value: s.cipherSuitesStr})
+	}
+	return envVars
+}
+
+// tlsConfigFunc returns a function that applies the validated TLS settings to
+// a tls.Config, or nil if no valid settings were parsed.
+func (s tlsSettings) tlsConfigFunc() func(*tls.Config) {
+	if s.minVersionCode == 0 && len(s.cipherSuiteIDs) == 0 {
+		return nil
+	}
 	return func(c *tls.Config) {
-		if minVersion > 0 {
-			c.MinVersion = minVersion
+		if s.minVersionCode > 0 {
+			c.MinVersion = s.minVersionCode
 		}
 		// Go manages TLS 1.3 cipher suites automatically
-		if minVersion < tls.VersionTLS13 && len(cipherSuites) > 0 {
-			c.CipherSuites = cipherSuites
+		if s.minVersionCode < tls.VersionTLS13 && len(s.cipherSuiteIDs) > 0 {
+			c.CipherSuites = s.cipherSuiteIDs
 		}
 	}
 }
@@ -58,9 +107,9 @@ func parseTLSVersion(s string) uint16 {
 	}
 }
 
-func parseCipherSuites(s string, log interface{ Info(string, ...any) }) []uint16 {
+func parseCipherSuites(s string, log interface{ Info(string, ...any) }) ([]uint16, []string) {
 	if s == "" {
-		return nil
+		return nil, nil
 	}
 
 	lookup := make(map[string]uint16)
@@ -71,17 +120,19 @@ func parseCipherSuites(s string, log interface{ Info(string, ...any) }) []uint16
 		lookup[cs.Name] = cs.ID
 	}
 
-	names := strings.Split(s, ",")
-	suites := make([]uint16, 0, len(names))
+	raw := strings.Split(s, ",")
+	suites := make([]uint16, 0, len(raw))
+	names := make([]string, 0, len(raw))
 
-	for _, name := range names {
+	for _, name := range raw {
 		name = strings.TrimSpace(name)
 		if id, ok := lookup[name]; ok {
 			suites = append(suites, id)
+			names = append(names, name)
 		} else if name != "" {
 			log.Info("Skipping unknown TLS cipher suite", "cipher", name)
 		}
 	}
 
-	return suites
+	return suites, names
 }

--- a/cmd/tlsconfig_test.go
+++ b/cmd/tlsconfig_test.go
@@ -35,58 +35,75 @@ func TestParseCipherSuites(t *testing.T) {
 	log := noopLogger{}
 
 	t.Run("known IANA names", func(t *testing.T) {
-		suites := parseCipherSuites("TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", log)
-		if len(suites) != 2 {
-			t.Fatalf("expected 2 suites, got %d", len(suites))
+		ids, names := parseCipherSuites("TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", log)
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 suites, got %d", len(ids))
 		}
-		if suites[0] != tls.TLS_AES_128_GCM_SHA256 {
-			t.Errorf("suites[0] = %#x, want %#x", suites[0], tls.TLS_AES_128_GCM_SHA256)
+		if ids[0] != tls.TLS_AES_128_GCM_SHA256 {
+			t.Errorf("ids[0] = %#x, want %#x", ids[0], tls.TLS_AES_128_GCM_SHA256)
 		}
-		if suites[1] != tls.TLS_AES_256_GCM_SHA384 {
-			t.Errorf("suites[1] = %#x, want %#x", suites[1], tls.TLS_AES_256_GCM_SHA384)
+		if ids[1] != tls.TLS_AES_256_GCM_SHA384 {
+			t.Errorf("ids[1] = %#x, want %#x", ids[1], tls.TLS_AES_256_GCM_SHA384)
+		}
+		if len(names) != 2 || names[0] != "TLS_AES_128_GCM_SHA256" || names[1] != "TLS_AES_256_GCM_SHA384" {
+			t.Errorf("names = %v, want [TLS_AES_128_GCM_SHA256 TLS_AES_256_GCM_SHA384]", names)
 		}
 	})
 
 	t.Run("empty input", func(t *testing.T) {
-		suites := parseCipherSuites("", log)
-		if suites != nil {
-			t.Errorf("expected nil, got %v", suites)
+		ids, names := parseCipherSuites("", log)
+		if ids != nil {
+			t.Errorf("expected nil ids, got %v", ids)
+		}
+		if names != nil {
+			t.Errorf("expected nil names, got %v", names)
 		}
 	})
 
 	t.Run("unknown names are skipped", func(t *testing.T) {
-		suites := parseCipherSuites("TLS_AES_128_GCM_SHA256,UNKNOWN_CIPHER", log)
-		if len(suites) != 1 {
-			t.Fatalf("expected 1 suite, got %d", len(suites))
+		ids, names := parseCipherSuites("TLS_AES_256_GCM_SHA384,UNKNOWN_CIPHER", log)
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 suite, got %d", len(ids))
+		}
+		if len(names) != 1 || names[0] != "TLS_AES_256_GCM_SHA384" {
+			t.Errorf("names = %v, want [TLS_AES_256_GCM_SHA384]", names)
 		}
 	})
 
 	t.Run("TLS 1.2 ECDHE cipher", func(t *testing.T) {
-		suites := parseCipherSuites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", log)
-		if len(suites) != 1 {
-			t.Fatalf("expected 1 suite, got %d", len(suites))
+		ids, names := parseCipherSuites("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", log)
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 suite, got %d", len(ids))
 		}
-		if suites[0] != tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
-			t.Errorf("suites[0] = %#x, want %#x", suites[0], tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+		if ids[0] != tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 {
+			t.Errorf("ids[0] = %#x, want %#x", ids[0], tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+		}
+		if names[0] != "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" {
+			t.Errorf("names[0] = %s, want TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", names[0])
 		}
 	})
 }
 
-func TestTlsConfigFromEnv_Unset(t *testing.T) {
-	t.Setenv("TLS_MIN_VERSION", "")
-	t.Setenv("TLS_CIPHER_SUITES", "")
+func TestParseTLSSettings_Unset(t *testing.T) {
+	t.Setenv(envTLSMinVersion, "")
+	t.Setenv(envTLSCipherSuites, "")
 
-	result := tlsConfigFromEnv()
-	if result != nil {
-		t.Error("expected nil when env vars are unset")
+	s := parseTLSSettings()
+	if fn := s.tlsConfigFunc(); fn != nil {
+		t.Error("expected nil tlsConfigFunc when env vars are unset")
+	}
+	if envVars := s.envVars(); envVars != nil {
+		t.Errorf("expected nil envVars when env vars are unset, got %v", envVars)
 	}
 }
 
-func TestTlsConfigFromEnv_AppliesConfig(t *testing.T) {
-	t.Setenv("TLS_MIN_VERSION", "VersionTLS12")
-	t.Setenv("TLS_CIPHER_SUITES", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+func TestParseTLSSettings_AppliesConfig(t *testing.T) {
+	t.Setenv(envTLSMinVersion, "VersionTLS12")
+	t.Setenv(envTLSCipherSuites, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
 
-	fn := tlsConfigFromEnv()
+	s := parseTLSSettings()
+
+	fn := s.tlsConfigFunc()
 	if fn == nil {
 		t.Fatal("expected non-nil TLS config function")
 	}
@@ -102,11 +119,88 @@ func TestTlsConfigFromEnv_AppliesConfig(t *testing.T) {
 	}
 }
 
-func TestTlsConfigFromEnv_TLS13_SkipsCipherSuites(t *testing.T) {
-	t.Setenv("TLS_MIN_VERSION", "VersionTLS13")
-	t.Setenv("TLS_CIPHER_SUITES", "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384")
+func TestTLSSettings_EnvVars(t *testing.T) {
+	t.Setenv(envTLSMinVersion, "")
+	t.Setenv(envTLSCipherSuites, "")
 
-	fn := tlsConfigFromEnv()
+	t.Run("returns both vars when both are valid", func(t *testing.T) {
+		t.Setenv(envTLSMinVersion, "VersionTLS12")
+		t.Setenv(envTLSCipherSuites, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+
+		s := parseTLSSettings()
+		envVars := s.envVars()
+		if len(envVars) != 2 {
+			t.Fatalf("expected 2 env vars, got %d", len(envVars))
+		}
+		if envVars[0].Name != envTLSMinVersion || envVars[0].Value != "VersionTLS12" {
+			t.Errorf("envVars[0] = %s=%s, want TLS_MIN_VERSION=VersionTLS12", envVars[0].Name, envVars[0].Value)
+		}
+		if envVars[1].Name != envTLSCipherSuites || envVars[1].Value != "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" {
+			t.Errorf("envVars[1] = %s=%s, want TLS_CIPHER_SUITES=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", envVars[1].Name, envVars[1].Value)
+		}
+	})
+
+	t.Run("returns only valid vars", func(t *testing.T) {
+		t.Setenv(envTLSMinVersion, "VersionTLS13")
+
+		s := parseTLSSettings()
+		envVars := s.envVars()
+		if len(envVars) != 1 {
+			t.Fatalf("expected 1 env var, got %d", len(envVars))
+		}
+		if envVars[0].Name != envTLSMinVersion || envVars[0].Value != "VersionTLS13" {
+			t.Errorf("envVars[0] = %s=%s, want TLS_MIN_VERSION=VersionTLS13", envVars[0].Name, envVars[0].Value)
+		}
+	})
+
+	t.Run("returns nil when neither var is set", func(t *testing.T) {
+		s := parseTLSSettings()
+		envVars := s.envVars()
+		if envVars != nil {
+			t.Errorf("expected nil, got %v", envVars)
+		}
+	})
+
+	t.Run("excludes invalid min version", func(t *testing.T) {
+		t.Setenv(envTLSMinVersion, "garbage")
+
+		s := parseTLSSettings()
+		envVars := s.envVars()
+		if envVars != nil {
+			t.Errorf("expected nil for invalid min version, got %v", envVars)
+		}
+	})
+
+	t.Run("excludes unknown cipher suites from value", func(t *testing.T) {
+		t.Setenv(envTLSCipherSuites, "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,UNKNOWN_CIPHER")
+
+		s := parseTLSSettings()
+		envVars := s.envVars()
+		if len(envVars) != 1 {
+			t.Fatalf("expected 1 env var, got %d", len(envVars))
+		}
+		if envVars[0].Value != "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" {
+			t.Errorf("expected only valid cipher in value, got %s", envVars[0].Value)
+		}
+	})
+
+	t.Run("excludes all-invalid cipher suites", func(t *testing.T) {
+		t.Setenv(envTLSCipherSuites, "UNKNOWN_CIPHER,ALSO_UNKNOWN")
+
+		s := parseTLSSettings()
+		envVars := s.envVars()
+		if envVars != nil {
+			t.Errorf("expected nil when all cipher suites are invalid, got %v", envVars)
+		}
+	})
+}
+
+func TestParseTLSSettings_TLS13_SkipsCipherSuites(t *testing.T) {
+	t.Setenv(envTLSMinVersion, "VersionTLS13")
+	t.Setenv(envTLSCipherSuites, "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384")
+
+	s := parseTLSSettings()
+	fn := s.tlsConfigFunc()
 	if fn == nil {
 		t.Fatal("expected non-nil TLS config function")
 	}

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -161,6 +161,9 @@ type MCPServerReconciler struct {
 	Recorder  events.EventRecorder
 	MCPDialer func(ctx context.Context, url string) (*mcpv1alpha1.MCPServerInfo, error) // nil = use real MCP handshake
 	APIReader client.Reader
+	// TLSEnvVars holds TLS-related environment variables to propagate to every
+	// MCP server container. Populated at startup when PROPAGATE_TLS_ENV_VARS is set.
+	TLSEnvVars []corev1.EnvVar
 }
 
 // +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers,verbs=get;list;watch

--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -170,6 +170,16 @@ func deploymentNeedsUpdate(mcpServer *mcpv1alpha1.MCPServer, existing, desired *
 		ownershipChanged
 }
 
+// tlsEnvVarOverridden reports whether name matches any operator-propagated TLS env var.
+func tlsEnvVarOverridden(name string, tlsVars []corev1.EnvVar) bool {
+	for _, v := range tlsVars {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func managedWorkloadLabels(mcpServerName string) map[string]string {
 	return map[string]string{
 		LabelKeyApp:       ManagedWorkloadName,
@@ -219,9 +229,17 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 		container.Args = mcpServer.Spec.Config.Arguments
 	}
 
-	// Add env vars if specified
-	if len(mcpServer.Spec.Config.Env) > 0 {
-		container.Env = mcpServer.Spec.Config.Env
+	// Add env vars: user-specified first (filtering out any that collide with
+	// operator-propagated TLS vars), then the operator TLS vars.
+	if len(r.TLSEnvVars) > 0 || len(mcpServer.Spec.Config.Env) > 0 {
+		env := make([]corev1.EnvVar, 0, len(mcpServer.Spec.Config.Env)+len(r.TLSEnvVars))
+		for _, e := range mcpServer.Spec.Config.Env {
+			if !tlsEnvVarOverridden(e.Name, r.TLSEnvVars) {
+				env = append(env, e)
+			}
+		}
+		env = append(env, r.TLSEnvVars...)
+		container.Env = env
 	}
 	if len(mcpServer.Spec.Config.EnvFrom) > 0 {
 		container.EnvFrom = mcpServer.Spec.Config.EnvFrom

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -1387,6 +1387,84 @@ var _ = Describe("MCPServer Controller - Health Probes", func() {
 	})
 })
 
+var _ = Describe("MCPServer Controller - TLS Env Var Propagation", func() {
+	It("should append TLSEnvVars after user-specified env", func() {
+		mcpServer := newTestMCPServer("test-tls-propagate")
+		mcpServer.Spec.Config.Env = []corev1.EnvVar{
+			{Name: "APP_VAR", Value: "app-value"},
+		}
+
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+		reconciler.TLSEnvVars = []corev1.EnvVar{
+			{Name: "TLS_MIN_VERSION", Value: "VersionTLS12"},
+			{Name: "TLS_CIPHER_SUITES", Value: "TLS_AES_128_GCM_SHA256"},
+		}
+
+		deployment, err := reconciler.createDeployment(mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		env := deployment.Spec.Template.Spec.Containers[0].Env
+		Expect(env).To(HaveLen(3))
+		Expect(env[0].Name).To(Equal("APP_VAR"))
+		Expect(env[0].Value).To(Equal("app-value"))
+		Expect(env[1].Name).To(Equal("TLS_MIN_VERSION"))
+		Expect(env[1].Value).To(Equal("VersionTLS12"))
+		Expect(env[2].Name).To(Equal("TLS_CIPHER_SUITES"))
+		Expect(env[2].Value).To(Equal("TLS_AES_128_GCM_SHA256"))
+	})
+
+	It("should filter out user-specified duplicates in favour of operator TLS vars", func() {
+		mcpServer := newTestMCPServer("test-tls-override")
+		mcpServer.Spec.Config.Env = []corev1.EnvVar{
+			{Name: "APP_VAR", Value: "keep-me"},
+			{Name: "TLS_MIN_VERSION", Value: "VersionTLS13"},
+		}
+
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+		reconciler.TLSEnvVars = []corev1.EnvVar{
+			{Name: "TLS_MIN_VERSION", Value: "VersionTLS12"},
+		}
+
+		deployment, err := reconciler.createDeployment(mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		env := deployment.Spec.Template.Spec.Containers[0].Env
+		Expect(env).To(HaveLen(2))
+		Expect(env[0].Name).To(Equal("APP_VAR"))
+		Expect(env[0].Value).To(Equal("keep-me"))
+		Expect(env[1].Name).To(Equal("TLS_MIN_VERSION"))
+		Expect(env[1].Value).To(Equal("VersionTLS12"))
+	})
+
+	It("should not add env vars when TLSEnvVars is empty", func() {
+		mcpServer := newTestMCPServer("test-tls-empty")
+
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+
+		deployment, err := reconciler.createDeployment(mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(BeEmpty())
+	})
+
+	It("should set only TLS vars when user specifies no env", func() {
+		mcpServer := newTestMCPServer("test-tls-only")
+
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+		reconciler.TLSEnvVars = []corev1.EnvVar{
+			{Name: "TLS_MIN_VERSION", Value: "VersionTLS12"},
+		}
+
+		deployment, err := reconciler.createDeployment(mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		env := deployment.Spec.Template.Spec.Containers[0].Env
+		Expect(env).To(HaveLen(1))
+		Expect(env[0].Name).To(Equal("TLS_MIN_VERSION"))
+		Expect(env[0].Value).To(Equal("VersionTLS12"))
+	})
+})
+
 var _ = Describe("MCPServer Controller - Deployment Reconcile Events", func() {
 	const resourceName = "test-deployment-events"
 


### PR DESCRIPTION
In #250 we added support for applying TLS from env vars supplied to the controller deployment.

It can also be useful for those TLS env vars to be propagated to the MCP Server deployments themselves, so that they can be aware of TLS configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional propagation of TLS-related environment variables to managed server workloads when enabled at startup (case-insensitive enablement).
* **Bug Fixes**
  * Improved TLS settings parsing and validation for minimum TLS version and cipher suites, including normalization and skipping unknown/invalid values.
  * Operator-provided TLS env vars now correctly override user-provided values with matching names.
  * TLS 1.3 no longer applies cipher suites (cipher suites remain unset).
* **Tests**
  * Expanded TLS parsing, env-var generation, and deployment env injection precedence coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->