### PR TITLE
fix(rbac): add update/patch verbs for mcpservers to manager role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -55,7 +55,15 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
+- apiGroups:
+  - mcp.x-k8s.io
+  resources:
+  - mcpservers/finalizers
+  verbs:
+  - update
 - apiGroups:
   - mcp.x-k8s.io
   resources:
@@ -63,6 +71,7 @@ rules:
   verbs:
   - get
   - patch
+  - update
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -163,8 +163,9 @@ type MCPServerReconciler struct {
 	APIReader client.Reader
 }
 
-// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers/status,verbs=get;patch
+// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=mcp.x-k8s.io,resources=mcpservers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch


### PR DESCRIPTION
The controller creates Deployments with OwnerReferences (`blockOwnerDeletion: true`) pointing to MCPServer resources. Kubernetes requires the controller to have `update`/`patch` permission on the owner resource to set `blockOwnerDeletion`, and update permission on the `finalizers` subresource.

Without these permissions, reconciling any MCPServer fails with:
```
  "deployments.apps is forbidden: cannot set blockOwnerDeletion
   if an ownerReference refers to a resource you can't set
   finalizers on"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded access permissions for MCP server resources to support additional management actions.
  * Added support for updating and watching MCP servers, including their status and finalizers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->