### PR TITLE
fix(networkpolicy): allow kubelet health probes on port 8081

### DIFF
--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -17,6 +17,10 @@ spec:
   policyTypes:
     - Ingress
   ingress:
+    # Allow kubelet health probes (liveness/readiness) on port 8081
+    - ports:
+        - port: 8081
+          protocol: TCP
     # This allows ingress traffic from any namespace with the label metrics: enabled
     - from:
       - namespaceSelector:


### PR DESCRIPTION
The allow-metrics-traffic NetworkPolicy only permits ingress on port 8443 for metrics scraping. Since it selects the controller-manager pod with policyTypes: [Ingress], all other ingress is implicitly denied, including kubelet liveness/readiness probes on port 8081. This can cause CrashLoopBackOff when the CNI enforces NetworkPolicy on node-to-pod traffic.

Add an ingress rule allowing traffic on port 8081 from any source so kubelet probes are not blocked.