### PR TITLE
fix(e2e): remove hardcoded UID/fsGroup from TestPodSecurityContext

### DIFF
--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -672,8 +672,6 @@ func TestPodSecurityContext(t *testing.T) {
 			return f.SetupMCPServer(ctx, t, cfg, "sec-pod", true,
 				f.WithPodSecurityContext(&corev1.PodSecurityContext{
 					RunAsNonRoot: ptr.To(true),
-					RunAsUser:    ptr.To(int64(1000)),
-					FSGroup:      ptr.To(int64(2000)),
 				}),
 			)
 		}).
@@ -693,12 +691,6 @@ func TestPodSecurityContext(t *testing.T) {
 
 			if psc.RunAsNonRoot == nil || !*psc.RunAsNonRoot {
 				t.Fatal("expected RunAsNonRoot=true")
-			}
-			if psc.RunAsUser == nil || *psc.RunAsUser != 1000 {
-				t.Fatal("expected RunAsUser=1000")
-			}
-			if psc.FSGroup == nil || *psc.FSGroup != 2000 {
-				t.Fatal("expected FSGroup=2000")
 			}
 
 			t.Log("pod security context is correctly applied")


### PR DESCRIPTION
## Summary
- Remove hardcoded `runAsUser: 1000` and `fsGroup: 2000` from `TestPodSecurityContext`
- The test now only sets `RunAsNonRoot: true`, which is portable across all environments
- Hardcoded UIDs conflict with platforms that enforce pod security admission and require UIDs from a namespace-allocated range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified the pod security context end-to-end test to validate only `RunAsNonRoot`, removing checks for specific user and group IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->