### PR TITLE
bump Go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
Fixes [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (crypto/tls ECH privacy leak).

`toolchain go1.26.4` → `toolchain go1.26.5` in go.mod.

Assisted-by: 🤖 claude-opus-4-6@default