### PR TITLE
build: extract KUSTOMIZE_DEFAULT_DIR to avoid hardcoded kustomize path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# KUSTOMIZE_DEFAULT_DIR is the kustomize directory used by build-installer,
+# deploy and undeploy. Override to use a different overlay.
+KUSTOMIZE_DEFAULT_DIR ?= config/default
+
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
@@ -204,7 +208,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
-	"$(KUSTOMIZE)" build config/default > dist/install.yaml
+	"$(KUSTOMIZE)" build $(KUSTOMIZE_DEFAULT_DIR) > dist/install.yaml
 
 ##@ Documentation
 
@@ -246,7 +250,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
-	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
+	"$(KUSTOMIZE)" build $(KUSTOMIZE_DEFAULT_DIR) | "$(KUBECTL)" apply -f -
 
 .PHONY: deploy-debug
 deploy-debug: manifests kustomize ## Deploy controller with Delve for remote debugging.
@@ -255,7 +259,7 @@ deploy-debug: manifests kustomize ## Deploy controller with Delve for remote deb
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
+	"$(KUSTOMIZE)" build $(KUSTOMIZE_DEFAULT_DIR) | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Dependencies
 


### PR DESCRIPTION
as per title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration flexibility for selecting the default Kustomize source directory.
  * Build, deploy, and undeploy commands now use the configured directory while retaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->