### PR TITLE
fix: reconcile Service selector drift

### DIFF
--- a/internal/controller/mcpserver_controller_service.go
+++ b/internal/controller/mcpserver_controller_service.go
@@ -88,8 +88,9 @@ func (r *MCPServerReconciler) reconcileService(
 		ownershipChanged = oldOwnerUID != string(newOwner.UID)
 	}
 
-	// Update if ports changed OR if we adopted an orphaned resource
+	// Update if the desired Service fields changed OR if we adopted an orphaned resource.
 	needsUpdate := !equality.Semantic.DeepEqual(service.Spec.Ports, existingService.Spec.Ports) ||
+		!equality.Semantic.DeepEqual(service.Spec.Selector, existingService.Spec.Selector) ||
 		existingService.Spec.SessionAffinity != service.Spec.SessionAffinity ||
 		serviceLabelsChanged(mcpServer, existingService) ||
 		serviceAnnotationsChanged(mcpServer, existingService) ||
@@ -100,6 +101,7 @@ func (r *MCPServerReconciler) reconcileService(
 			return fmt.Errorf("applying custom service metadata; %w", err)
 		}
 		existingService.Spec.Ports = service.Spec.Ports
+		existingService.Spec.Selector = service.Spec.Selector
 		existingService.Spec.SessionAffinity = service.Spec.SessionAffinity
 		if err := r.Update(ctx, existingService); err != nil {
 			logger.Error(err, "Failed to update Service")

--- a/internal/controller/mcpserver_controller_service_test.go
+++ b/internal/controller/mcpserver_controller_service_test.go
@@ -273,6 +273,42 @@ var _ = Describe("MCPServer Controller - reconcileService", func() {
 		Expect(reconciler.reconcileService(ctx, mcpServer)).To(Succeed())
 		Expect(reconciler.reconcileService(ctx, mcpServer)).To(Succeed())
 	})
+
+	It("should restore a drifted selector without changing the ClusterIP", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		By("Creating the managed Service")
+		Expect(reconciler.reconcileService(ctx, mcpServer)).To(Succeed())
+
+		svc := &corev1.Service{}
+		serviceKey := client.ObjectKey{Name: resourceName, Namespace: "default"}
+		Expect(k8sClient.Get(ctx, serviceKey, svc)).To(Succeed())
+		originalClusterIP := svc.Spec.ClusterIP
+		originalClusterIPs := append([]string(nil), svc.Spec.ClusterIPs...)
+
+		By("Changing the selector to no longer match the managed workload")
+		svc.Spec.Selector = map[string]string{
+			LabelKeyMCPServer: "wrong",
+			"unexpected":      "value",
+		}
+		Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+
+		By("Reconciling the Service selector drift")
+		Expect(reconciler.reconcileService(ctx, mcpServer)).To(Succeed())
+
+		By("Verifying the selector is restored and allocated addresses are preserved")
+		Expect(k8sClient.Get(ctx, serviceKey, svc)).To(Succeed())
+		Expect(svc.Spec.Selector).To(Equal(managedWorkloadSelector(resourceName)))
+		Expect(svc.Spec.ClusterIP).To(Equal(originalClusterIP))
+		Expect(svc.Spec.ClusterIPs).To(Equal(originalClusterIPs))
+	})
 })
 
 var _ = Describe("MCPServer Controller - Stateless Service", func() {

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -348,6 +348,57 @@ func TestServicePortDrift(t *testing.T) {
 	testenv.Test(t, feature)
 }
 
+func TestServiceSelectorDrift(t *testing.T) {
+	feature := features.New("MCPServer Service selector drift correction").
+		WithLabel("type", "reconciliation").
+		WithLabel("scenario", "drift-service-selector").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.SetupMCPServer(ctx, t, cfg, "drift-selector", true)
+		}).
+		Assess("manually change Service selector and verify reconciliation", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: server.Name, Namespace: server.Namespace}}
+			if err := r.Get(ctx, server.Name, server.Namespace, svc); err != nil {
+				t.Fatalf("Service not found: %v", err)
+			}
+			originalClusterIP := svc.Spec.ClusterIP
+
+			f.UpdateWithRetry(ctx, t, r, svc, func(s *corev1.Service) {
+				s.Spec.Selector = map[string]string{
+					"mcp-server": "wrong",
+					"unexpected": "value",
+				}
+			})
+			t.Log("manually changed Service selector")
+
+			err := wait.For(
+				conditions.New(r).ResourceMatch(svc, func(obj k8s.Object) bool {
+					s := obj.(*corev1.Service)
+					return len(s.Spec.Selector) == 1 &&
+						s.Spec.Selector["mcp-server"] == server.Name &&
+						s.Spec.ClusterIP == originalClusterIP
+				}),
+				wait.WithTimeout(2*time.Minute),
+				wait.WithInterval(2*time.Second),
+			)
+			if err != nil {
+				t.Fatalf("controller did not reconcile Service selector back to mcp-server=%s: %v", server.Name, err)
+			}
+
+			f.WaitForEndpointsReady(ctx, t, cfg, server.Namespace, server.Name)
+			t.Logf("controller restored Service selector and endpoints for %s", server.Name)
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
 func TestDeploymentDeletion(t *testing.T) {
 	feature := features.New("MCPServer Deployment recreation after deletion").
 		WithLabel("type", "reconciliation").


### PR DESCRIPTION
## Summary

- detect drift in the managed Service selector during reconciliation
- restore the desired selector without overwriting API-server-managed Service fields such as ClusterIP
- add unit and end-to-end coverage for selector drift correction and endpoint recovery

## Testing

- go test ./...
- go test -c -tags=e2e -o /tmp/mcp-lifecycle-operator-e2e.test ./test/e2e

Fixes #274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Services now automatically restore their intended label selectors when those selectors are changed or drift from the expected configuration.
  * Existing network identity, including cluster IP assignments, is preserved during reconciliation.
  * Endpoint readiness is restored after selector correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->