### PR TITLE
ci: add workflow to build mcp-everything server image

### DIFF
--- a/.github/workflows/build-mcp-everything.yml
+++ b/.github/workflows/build-mcp-everything.yml
@@ -1,0 +1,57 @@
+# Copyright 2026 The Kubernetes Authors.
+
+name: Build MCP Everything Server Image
+
+on:
+  schedule:
+    # Daily at 06:00 UTC.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and push
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Resolve latest upstream release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh api repos/modelcontextprotocol/servers/releases/latest --jq '.tag_name')
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved latest release: ${TAG}"
+
+      - name: Clone the upstream repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: modelcontextprotocol/servers
+          ref: ${{ steps.release.outputs.tag }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: src/everything/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/mcp-everything:latest

--- a/.github/workflows/build-mcp-everything.yml
+++ b/.github/workflows/build-mcp-everything.yml
@@ -8,6 +8,10 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write
@@ -32,6 +36,7 @@ jobs:
         with:
           repository: modelcontextprotocol/servers
           ref: ${{ steps.release.outputs.tag }}
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/build-mcp-everything.yml
+++ b/.github/workflows/build-mcp-everything.yml
@@ -60,3 +60,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/mcp-everything:latest
+            ghcr.io/${{ github.repository }}/mcp-everything:${{ steps.release.outputs.tag }}


### PR DESCRIPTION
## Summary
- Adds a daily GitHub Actions workflow that builds the [MCP everything server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) image from the latest upstream release and pushes it to `ghcr.io/kubernetes-sigs/mcp-lifecycle-operator/mcp-everything`, tagged with both `latest` and the upstream release version (e.g. `2026.7.10`)
- Supports multi-arch builds (linux/amd64, linux/arm64)
- Can be triggered manually via `workflow_dispatch`

As a follow-up we need to update the references in the code