### PR TITLE
feat: add egress NetworkPolicy for MCP server pods

### DIFF
--- a/internal/controller/mcpserver_controller_networkpolicy.go
+++ b/internal/controller/mcpserver_controller_networkpolicy.go
@@ -125,6 +125,7 @@ func (r *MCPServerReconciler) createNetworkPolicy(mcpServer *mcpv1alpha1.MCPServ
 			},
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
 			},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{
 				{
@@ -135,6 +136,9 @@ func (r *MCPServerReconciler) createNetworkPolicy(mcpServer *mcpv1alpha1.MCPServ
 						},
 					},
 				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{},
 			},
 		},
 	}

--- a/internal/controller/mcpserver_controller_networkpolicy_test.go
+++ b/internal/controller/mcpserver_controller_networkpolicy_test.go
@@ -87,9 +87,10 @@ var _ = Describe("MCPServer Controller - reconcileNetworkPolicy", func() {
 		By("Verifying podSelector targets MCP server pods")
 		Expect(netpol.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("mcp-server", resourceName))
 
-		By("Verifying only Ingress policyType is set")
-		Expect(netpol.Spec.PolicyTypes).To(HaveLen(1))
-		Expect(netpol.Spec.PolicyTypes[0]).To(Equal(networkingv1.PolicyTypeIngress))
+		By("Verifying Ingress and Egress policyTypes are set")
+		Expect(netpol.Spec.PolicyTypes).To(HaveLen(2))
+		Expect(netpol.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeIngress))
+		Expect(netpol.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeEgress))
 
 		By("Verifying ingress allows only the configured port")
 		Expect(netpol.Spec.Ingress).To(HaveLen(1))
@@ -99,6 +100,11 @@ var _ = Describe("MCPServer Controller - reconcileNetworkPolicy", func() {
 
 		By("Verifying ingress From is empty (all sources allowed on MCP port)")
 		Expect(netpol.Spec.Ingress[0].From).To(BeEmpty())
+
+		By("Verifying egress allows all traffic")
+		Expect(netpol.Spec.Egress).To(HaveLen(1))
+		Expect(netpol.Spec.Egress[0].Ports).To(BeEmpty())
+		Expect(netpol.Spec.Egress[0].To).To(BeEmpty())
 
 		By("Verifying owner reference is set")
 		Expect(netpol.OwnerReferences).To(HaveLen(1))

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -60,9 +60,21 @@ func TestNetworkPolicyCreated(t *testing.T) {
 				t.Fatalf("expected podSelector {mcp-server: %s}, got %v", server.Name, netpol.Spec.PodSelector.MatchLabels)
 			}
 
-			// Verify only Ingress policyType
-			if len(netpol.Spec.PolicyTypes) != 1 || netpol.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
-				t.Fatalf("expected policyTypes [Ingress], got %v", netpol.Spec.PolicyTypes)
+			// Verify Ingress and Egress policyTypes
+			if len(netpol.Spec.PolicyTypes) != 2 {
+				t.Fatalf("expected 2 policyTypes, got %d: %v", len(netpol.Spec.PolicyTypes), netpol.Spec.PolicyTypes)
+			}
+			hasIngress, hasEgress := false, false
+			for _, pt := range netpol.Spec.PolicyTypes {
+				switch pt {
+				case networkingv1.PolicyTypeIngress:
+					hasIngress = true
+				case networkingv1.PolicyTypeEgress:
+					hasEgress = true
+				}
+			}
+			if !hasIngress || !hasEgress {
+				t.Fatalf("expected policyTypes [Ingress, Egress], got %v", netpol.Spec.PolicyTypes)
 			}
 
 			// Verify ingress allows only the configured port
@@ -86,6 +98,18 @@ func TestNetworkPolicyCreated(t *testing.T) {
 				t.Fatalf("expected empty From (allow all sources), got %d entries", len(rule.From))
 			}
 
+			// Verify egress allows all traffic
+			if len(netpol.Spec.Egress) != 1 {
+				t.Fatalf("expected 1 egress rule, got %d", len(netpol.Spec.Egress))
+			}
+			egressRule := netpol.Spec.Egress[0]
+			if len(egressRule.Ports) != 0 {
+				t.Fatalf("expected empty egress ports (allow all), got %d", len(egressRule.Ports))
+			}
+			if len(egressRule.To) != 0 {
+				t.Fatalf("expected empty egress To (allow all destinations), got %d", len(egressRule.To))
+			}
+
 			// Verify owner reference
 			if len(netpol.OwnerReferences) == 0 {
 				t.Fatal("expected owner reference on NetworkPolicy")
@@ -94,7 +118,7 @@ func TestNetworkPolicyCreated(t *testing.T) {
 				t.Fatalf("expected owner %s, got %s", server.Name, netpol.OwnerReferences[0].Name)
 			}
 
-			t.Logf("NetworkPolicy %s exists with correct spec: podSelector={mcp-server: %s}, port=3001/TCP, ingress-only",
+			t.Logf("NetworkPolicy %s exists with correct spec: podSelector={mcp-server: %s}, port=3001/TCP, ingress+egress",
 				netpol.Name, server.Name)
 			return ctx
 		}).


### PR DESCRIPTION
Add explicit egress policy type and an allow-all egress rule to the per-MCPServer NetworkPolicy. Declaring both ingress and egress policy types ensures MCP server pods are protected when platform defaults change to deny-all, and aligns with security best practices for network boundary controls.

The egress rule is intentionally permissive (empty rule = allow all) with a tight pod selector, which is a reasonable baseline for MCP server workloads that need outbound access to arbitrary backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network policies now support egress enforcement for selected workloads.
  * Egress traffic is permitted by default without port or destination restrictions.

* **Tests**
  * Added validation for ingress and egress policy types.
  * Expanded end-to-end coverage for unrestricted egress rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->