### PR TITLE
Update references to mcp-everything server

### DIFF
--- a/examples/everything-mcp-server/mcpserver.yaml
+++ b/examples/everything-mcp-server/mcpserver.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     type: ContainerImage
     containerImage:
-      ref: quay.io/matzew/mcp-everything:latest
+      ref: ghcr.io/kubernetes-sigs/mcp-lifecycle-operator/mcp-everything:latest
   config:
     port: 3001
     path: /mcp

--- a/test/e2e/failure_scenarios_test.go
+++ b/test/e2e/failure_scenarios_test.go
@@ -436,9 +436,9 @@ func TestRecoveryFromImagePullFailure(t *testing.T) {
 			r := cfg.Client().Resources()
 
 			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
-				s.Spec.Source.ContainerImage.Ref = "quay.io/matzew/mcp-everything:latest"
+				s.Spec.Source.ContainerImage.Ref = "ghcr.io/kubernetes-sigs/mcp-lifecycle-operator/mcp-everything:latest"
 			})
-			t.Log("updated image to quay.io/matzew/mcp-everything:latest")
+			t.Log("updated image to ghcr.io/kubernetes-sigs/mcp-lifecycle-operator/mcp-everything:latest")
 
 			f.WaitForMCPServerReconciledAndReady(ctx, t, r, server, 5*time.Minute)
 			t.Log("Ready=True — recovery from image pull failure complete")

--- a/test/e2e/framework/builders.go
+++ b/test/e2e/framework/builders.go
@@ -106,7 +106,7 @@ func WithReplicas(n int32) MCPServerOption {
 }
 
 // NewMCPServer creates an MCPServer with sensible defaults for e2e tests.
-// Defaults: image=quay.io/matzew/mcp-everything:latest, port=3001.
+// Defaults: image=ghcr.io/kubernetes-sigs/mcp-lifecycle-operator/mcp-everything:latest, port=3001.
 func NewMCPServer(name, namespace string, opts ...MCPServerOption) *mcpv1alpha1.MCPServer {
 	server := &mcpv1alpha1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
@@ -117,7 +117,7 @@ func NewMCPServer(name, namespace string, opts ...MCPServerOption) *mcpv1alpha1.
 			Source: mcpv1alpha1.Source{
 				Type: mcpv1alpha1.SourceTypeContainerImage,
 				ContainerImage: &mcpv1alpha1.ContainerImageSource{
-					Ref: "quay.io/matzew/mcp-everything:latest",
+					Ref: "ghcr.io/kubernetes-sigs/mcp-lifecycle-operator/mcp-everything:latest",
 				},
 			},
 			Config: mcpv1alpha1.ServerConfig{

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -47,7 +47,7 @@ const configHashAnnotation = "mcp.x-k8s.io/config-hash"
 // --- Spec Update Tests ---
 
 func TestImageUpdate(t *testing.T) {
-	digestRef := "quay.io/matzew/mcp-everything@sha256:537cdedad807bb56140caca9c332d3577b16e533584164bbc3f27abac7b5ba15"
+	digestRef := "ghcr.io/kubernetes-sigs/mcp-lifecycle-operator/mcp-everything@sha256:7b7a1358ba0f020916e2259ee6d5e5d92b4a0637d700cb9dc4ae64ba59f0b69e"
 
 	feature := features.New("MCPServer image update").
 		WithLabel(category.Label, category.Lifecycle).


### PR DESCRIPTION
Follow up on #277 to update the references in the code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server container image references to use GitHub Container Registry.
  * Updated example configurations and end-to-end test scenarios to use the new image location.
  * Preserved existing image ports, options, and test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->