### PR TITLE
feat: add MCP handshake Prometheus metrics

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/runtimeconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/runtimeconfig.go
@@ -46,7 +46,9 @@ type RuntimeConfigApplyConfiguration struct {
 	Security *SecurityConfigApplyConfiguration `json:"security,omitempty"`
 	// Resources defines the resource requirements for the MCP server container.
 	// This includes CPU and memory requests and limits.
-	// If not specified, the container will run without explicit resource constraints.
+	// If not specified, the following defaults are applied:
+	// - Requests: 50m CPU, 64Mi memory
+	// - Limits: 500m CPU, 256Mi memory
 	// Supports partial specification (e.g., only requests or only limits).
 	// Example:
 	// resources:

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -310,7 +310,9 @@ type RuntimeConfig struct {
 
 	// Resources defines the resource requirements for the MCP server container.
 	// This includes CPU and memory requests and limits.
-	// If not specified, the container will run without explicit resource constraints.
+	// If not specified, the following defaults are applied:
+	//   - Requests: 50m CPU, 64Mi memory
+	//   - Limits: 500m CPU, 256Mi memory
 	// Supports partial specification (e.g., only requests or only limits).
 	// Example:
 	//   resources:

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -958,7 +958,9 @@ spec:
                     description: |-
                       Resources defines the resource requirements for the MCP server container.
                       This includes CPU and memory requests and limits.
-                      If not specified, the container will run without explicit resource constraints.
+                      If not specified, the following defaults are applied:
+                        - Requests: 50m CPU, 64Mi memory
+                        - Limits: 500m CPU, 256Mi memory
                       Supports partial specification (e.g., only requests or only limits).
                       Example:
                         resources:

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -121,6 +121,8 @@ const (
 	eventActionServiceReconcileFailed = "ServiceReconcileFailed"
 	// eventActionNetworkPolicyReconcileFailed is the reporting action when NetworkPolicy reconciliation fails.
 	eventActionNetworkPolicyReconcileFailed = "NetworkPolicyReconcileFailed"
+	// eventActionCapabilityChangeDetected is the reporting action when capability changes are detected.
+	eventActionCapabilityChangeDetected = "CapabilityChangeDetected"
 
 	// requeueDelayMCPHandshake is the initial delay before requeuing when an MCP handshake fails.
 	requeueDelayMCPHandshake = 10 * time.Second
@@ -364,6 +366,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			conditionToAC(acceptedCondition),
 			conditionToAC(readyCondition),
 		)
+
+	r.detectCapabilityChanges(mcpServer, serverInfo)
 
 	if serverInfo != nil {
 		si := acv1alpha1.MCPServerInfo()
@@ -612,6 +616,27 @@ func (r *MCPServerReconciler) emitMCPHandshakeRetriesExhausted(mcpServer *mcpv1a
 	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, ReasonMCPEndpointUnavailable, eventActionMCPHandshakeRetriesExhausted,
 		"MCP handshake retries exhausted for MCPServer %s after %d attempts; fix the MCP endpoint or update spec to retry",
 		mcpServer.Name, retryCount)
+}
+
+func (r *MCPServerReconciler) detectCapabilityChanges(mcpServer *mcpv1alpha1.MCPServer, serverInfo *mcpv1alpha1.MCPServerInfo) {
+	if serverInfo == nil || mcpServer.Status.ServerInfo == nil ||
+		serverInfo.Capabilities == nil || mcpServer.Status.ServerInfo.Capabilities == nil {
+		return
+	}
+	diff := capabilityDiffMessage(mcpServer.Status.ServerInfo.Capabilities, serverInfo.Capabilities)
+	if diff == "" {
+		return
+	}
+	capabilityChangesTotal.WithLabelValues(mcpServer.Name, mcpServer.Namespace).Inc()
+	r.emitCapabilityChangeDetected(mcpServer, diff)
+}
+
+func (r *MCPServerReconciler) emitCapabilityChangeDetected(mcpServer *mcpv1alpha1.MCPServer, diff string) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, "CapabilityChanged", eventActionCapabilityChangeDetected,
+		"MCP server capabilities changed: %s", diff)
 }
 
 func (r *MCPServerReconciler) applyStatus(

--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -252,9 +253,11 @@ func (r *MCPServerReconciler) createDeployment(mcpServer *mcpv1alpha1.MCPServer)
 		container.SecurityContext = defaultContainerSecurityContext()
 	}
 
-	// Apply resource requirements if specified
+	// Apply resource requirements: use user-specified if provided, otherwise apply defaults
 	if mcpServer.Spec.Runtime.Resources != nil {
 		container.Resources = *mcpServer.Spec.Runtime.Resources
+	} else {
+		container.Resources = defaultContainerResources()
 	}
 
 	// Apply health probes. Zero-valued timing fields are filled with Kubernetes
@@ -381,6 +384,21 @@ func defaultContainerSecurityContext() *corev1.SecurityContext {
 		RunAsNonRoot:             new(true),
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}
+
+// defaultContainerResources returns sensible default resource requests and limits
+// applied to MCP server containers when none are specified.
+func defaultContainerResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
 	}
 }
 

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -705,8 +705,36 @@ var _ = Describe("MCPServer Controller - Resource Requirements", func() {
 			Namespace: "default",
 		}, deployment)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).To(BeEmpty())
-		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).To(BeEmpty())
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("50m")))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("64Mi")))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("500m")))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("256Mi")))
+	})
+
+	It("should apply default resources when none specified", func() {
+		defaultResName := "test-default-resources"
+		defaultResNN := types.NamespacedName{Name: defaultResName, Namespace: "default"}
+		mcpServer := newTestMCPServer(defaultResName)
+		// Resources is nil by default from newTestMCPServer
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: defaultResName, Namespace: "default"},
+			})
+		}()
+
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: defaultResNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := &appsv1.Deployment{}
+		err = k8sClient.Get(ctx, client.ObjectKey{Name: defaultResName, Namespace: "default"}, deployment)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("50m")))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("64Mi")))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("500m")))
+		Expect(deployment.Spec.Template.Spec.Containers[0].Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("256Mi")))
 	})
 
 	It("should handle resources with only requests (no limits)", func() {

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -19,11 +19,13 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -41,6 +43,11 @@ func (r *MCPServerReconciler) reconcileHandshake(
 ) (metav1.Condition, *mcpv1alpha1.MCPServerInfo) {
 	logger := log.FromContext(ctx)
 
+	metricLabels := prometheus.Labels{
+		"name":      mcpServer.Name,
+		"namespace": mcpServer.Namespace,
+	}
+
 	existingReady := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeReady)
 	alreadyVerified := existingReady != nil &&
 		existingReady.Status == metav1.ConditionTrue &&
@@ -52,6 +59,7 @@ func (r *MCPServerReconciler) reconcileHandshake(
 	// Ready=True even if the Deployment has a transient status fluctuation
 	// (e.g. during rollout cleanup).
 	if alreadyVerified {
+		handshakeTotal.With(withResult(metricLabels, "skip")).Inc()
 		return *existingReady, mcpServer.Status.ServerInfo
 	}
 
@@ -65,12 +73,16 @@ func (r *MCPServerReconciler) reconcileHandshake(
 	}
 	dialCtx, dialCancel := context.WithTimeout(ctx, mcpHandshakeTimeout)
 	defer dialCancel()
+	start := time.Now()
 	info, err := dialer(dialCtx, mcpURL)
+	handshakeDuration.With(metricLabels).Observe(time.Since(start).Seconds())
 	if err != nil {
 		if isHTTPAuthError(err) {
+			handshakeTotal.With(withResult(metricLabels, "auth_skip")).Inc()
 			logger.Info("MCP endpoint returned auth error, treating as reachable", "url", mcpURL, "error", err)
 			return readyCondition, &mcpv1alpha1.MCPServerInfo{}
 		}
+		handshakeTotal.With(withResult(metricLabels, "failure")).Inc()
 		logger.Info("MCP endpoint handshake failed", "url", mcpURL, "error", err)
 		cond := newCondition(
 			ConditionTypeReady,
@@ -85,12 +97,20 @@ func (r *MCPServerReconciler) reconcileHandshake(
 		return cond, nil
 	}
 
+	handshakeTotal.With(withResult(metricLabels, "success")).Inc()
 	protocolVersion := ""
 	if info != nil {
 		protocolVersion = info.ProtocolVersion
 	}
 	logger.Info("MCP endpoint verified successfully", "url", mcpURL, "protocolVersion", protocolVersion)
 	return readyCondition, info
+}
+
+func withResult(labels prometheus.Labels, result string) prometheus.Labels {
+	m := make(prometheus.Labels, len(labels)+1)
+	maps.Copy(m, labels)
+	m["result"] = result
+	return m
 }
 
 // verifyMCPEndpoint performs an MCP protocol handshake (initialize or

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -193,6 +193,37 @@ func mcpHandshakeBackoff(retryCount int) time.Duration {
 	return delay
 }
 
+// capabilityDiffMessage compares two MCPServerCapabilities and returns a
+// human-readable message describing the differences. Nil is treated as
+// all-false. Returns an empty string when nothing changed.
+func capabilityDiffMessage(old, new *mcpv1alpha1.MCPServerCapabilities) string {
+	var oldCaps, newCaps mcpv1alpha1.MCPServerCapabilities
+	if old != nil {
+		oldCaps = *old
+	}
+	if new != nil {
+		newCaps = *new
+	}
+
+	var diffs []string
+	if oldCaps.Tools != newCaps.Tools {
+		diffs = append(diffs, fmt.Sprintf("tools: %v->%v", oldCaps.Tools, newCaps.Tools))
+	}
+	if oldCaps.Resources != newCaps.Resources {
+		diffs = append(diffs, fmt.Sprintf("resources: %v->%v", oldCaps.Resources, newCaps.Resources))
+	}
+	if oldCaps.Prompts != newCaps.Prompts {
+		diffs = append(diffs, fmt.Sprintf("prompts: %v->%v", oldCaps.Prompts, newCaps.Prompts))
+	}
+	if oldCaps.Logging != newCaps.Logging { //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
+		diffs = append(diffs, fmt.Sprintf("logging: %v->%v", oldCaps.Logging, newCaps.Logging)) //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
+	}
+	if oldCaps.Completions != newCaps.Completions {
+		diffs = append(diffs, fmt.Sprintf("completions: %v->%v", oldCaps.Completions, newCaps.Completions))
+	}
+	return strings.Join(diffs, ", ")
+}
+
 // isHTTPAuthError checks whether the error from the MCP SDK indicates an HTTP
 // 401 Unauthorized or 403 Forbidden response. The SDK does not wrap these with
 // a sentinel error type; it returns a plain error whose message ends with the

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -1018,6 +1018,44 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 	})
 })
 
+var _ = Describe("capabilityDiffMessage", func() {
+	It("should return empty string when both are nil", func() {
+		Expect(capabilityDiffMessage(nil, nil)).To(BeEmpty())
+	})
+
+	It("should return empty string when capabilities are the same", func() {
+		caps := &mcpv1alpha1.MCPServerCapabilities{
+			Tools:     true,
+			Resources: false,
+			Prompts:   true,
+		}
+		Expect(capabilityDiffMessage(caps, caps.DeepCopy())).To(BeEmpty())
+	})
+
+	It("should detect tools added", func() {
+		old := &mcpv1alpha1.MCPServerCapabilities{Tools: false}
+		new := &mcpv1alpha1.MCPServerCapabilities{Tools: true}
+		diff := capabilityDiffMessage(old, new)
+		Expect(diff).To(ContainSubstring("tools: false->true"))
+	})
+
+	It("should detect multiple changes", func() {
+		old := &mcpv1alpha1.MCPServerCapabilities{Tools: true, Prompts: true}
+		new := &mcpv1alpha1.MCPServerCapabilities{Tools: false, Resources: true}
+		diff := capabilityDiffMessage(old, new)
+		Expect(diff).To(ContainSubstring("tools: true->false"))
+		Expect(diff).To(ContainSubstring("resources: false->true"))
+		Expect(diff).To(ContainSubstring("prompts: true->false"))
+	})
+
+	It("should treat old nil as all-false", func() {
+		new := &mcpv1alpha1.MCPServerCapabilities{Tools: true, Resources: true}
+		diff := capabilityDiffMessage(nil, new)
+		Expect(diff).To(ContainSubstring("tools: false->true"))
+		Expect(diff).To(ContainSubstring("resources: false->true"))
+	})
+})
+
 var _ = Describe("extractServerInfo", func() {
 	It("should return nil for nil input", func() {
 		Expect(extractServerInfo(nil)).To(BeNil())

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -95,7 +95,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Name:      "handshake_total",
-			Help:      "Total number of MCP handshake attempts.",
+			Help:      "Total number of MCP handshake outcomes.",
 		},
 		[]string{"name", "namespace", "result"},
 	)

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -109,6 +109,15 @@ var (
 		},
 		[]string{"name", "namespace"},
 	)
+
+	capabilityChangesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "capability_changes_total",
+			Help:      "Total number of MCP server capability changes detected.",
+		},
+		[]string{"name", "namespace"},
+	)
 )
 
 func init() {
@@ -121,6 +130,7 @@ func init() {
 		reconcileDuration,
 		handshakeTotal,
 		handshakeDuration,
+		capabilityChangesTotal,
 	)
 }
 
@@ -155,4 +165,5 @@ func cleanupMetrics(name, namespace string) {
 	networkPolicyFailuresTotal.DeletePartialMatch(labels)
 	handshakeTotal.DeletePartialMatch(labels)
 	handshakeDuration.DeletePartialMatch(labels)
+	capabilityChangesTotal.DeletePartialMatch(labels)
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -90,6 +90,25 @@ var (
 		},
 		[]string{"phase"},
 	)
+
+	handshakeTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "handshake_total",
+			Help:      "Total number of MCP handshake attempts.",
+		},
+		[]string{"name", "namespace", "result"},
+	)
+
+	handshakeDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "handshake_duration_seconds",
+			Help:      "Duration of MCP handshake operations in seconds.",
+			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"name", "namespace"},
+	)
 )
 
 func init() {
@@ -100,6 +119,8 @@ func init() {
 		serviceFailuresTotal,
 		networkPolicyFailuresTotal,
 		reconcileDuration,
+		handshakeTotal,
+		handshakeDuration,
 	)
 }
 
@@ -132,4 +153,6 @@ func cleanupMetrics(name, namespace string) {
 	deploymentFailuresTotal.DeletePartialMatch(labels)
 	serviceFailuresTotal.DeletePartialMatch(labels)
 	networkPolicyFailuresTotal.DeletePartialMatch(labels)
+	handshakeTotal.DeletePartialMatch(labels)
+	handshakeDuration.DeletePartialMatch(labels)
 }

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -405,6 +405,98 @@ var _ = Describe("MCPServer Metrics", func() {
 		))).To(Equal(1.0))
 		Expect(testutil.CollectAndCount(handshakeDuration)).To(BeNumerically(">", 0))
 	})
+
+	It("should record auth_skip metrics when handshake returns HTTP auth error", func() {
+		hsAuthName := "metrics-hs-auth"
+		hsAuthNN := types.NamespacedName{Name: hsAuthName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hsAuthName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
+				return nil, fmt.Errorf("POST http://localhost:8080/mcp: Unauthorized")
+			},
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsAuthNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		simulateDeploymentAvailable(ctx, hsAuthNN)
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsAuthNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(testutil.ToFloat64(handshakeTotal.WithLabelValues(
+			hsAuthName, namespace, "auth_skip",
+		))).To(Equal(1.0))
+		Expect(testutil.CollectAndCount(handshakeDuration)).To(BeNumerically(">", 0))
+	})
+
+	It("should record skip metrics when handshake was already verified", func() {
+		hsSkipName := "metrics-hs-skip"
+		hsSkipNN := types.NamespacedName{Name: hsSkipName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hsSkipName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
+				return &mcpv1alpha1.MCPServerInfo{Name: "test-server", Version: "1.0"}, nil
+			},
+		}
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsSkipNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		simulateDeploymentAvailable(ctx, hsSkipNN)
+
+		// Second reconcile: handshake succeeds
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsSkipNN})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(testutil.ToFloat64(handshakeTotal.WithLabelValues(
+			hsSkipName, namespace, "success",
+		))).To(Equal(1.0))
+
+		// Third reconcile: already verified, hits the skip path
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsSkipNN})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(testutil.ToFloat64(handshakeTotal.WithLabelValues(
+			hsSkipName, namespace, "skip",
+		))).To(Equal(1.0))
+	})
 })
 
 func simulateDeploymentAvailable(ctx context.Context, nn types.NamespacedName) {

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -57,6 +57,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		reconcileDuration.Reset()
 		handshakeTotal.Reset()
 		handshakeDuration.Reset()
+		capabilityChangesTotal.Reset()
 	})
 
 	It("should record Accepted and Ready condition metrics on successful reconcile", func() {
@@ -447,6 +448,72 @@ var _ = Describe("MCPServer Metrics", func() {
 			hsAuthName, namespace, "auth_skip",
 		))).To(Equal(1.0))
 		Expect(testutil.CollectAndCount(handshakeDuration)).To(BeNumerically(">", 0))
+	})
+
+	It("should increment capabilityChangesTotal when capabilities change between reconciles", func() {
+		capChangeName := "metrics-cap-change"
+		capChangeNN := types.NamespacedName{Name: capChangeName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      capChangeName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+		firstCaps := &mcpv1alpha1.MCPServerCapabilities{Tools: true, Resources: false}
+		secondCaps := &mcpv1alpha1.MCPServerCapabilities{Tools: true, Resources: true}
+
+		currentCaps := firstCaps
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
+				return &mcpv1alpha1.MCPServerInfo{
+					Name:         "cap-server",
+					Version:      "1.0",
+					Capabilities: currentCaps.DeepCopy(),
+				}, nil
+			},
+		}
+
+		// First reconcile creates the Deployment
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: capChangeNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		simulateDeploymentAvailable(ctx, capChangeNN)
+
+		// Second reconcile triggers handshake and sets initial capabilities
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: capChangeNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Change capabilities for next handshake
+		currentCaps = secondCaps
+
+		// Bump generation by changing a spec field so the handshake re-runs
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, capChangeNN, mcpServer)).To(Succeed())
+		mcpServer.Spec.Config.Path = "/mcp-v2"
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		// Third reconcile detects the capability change
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: capChangeNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(testutil.ToFloat64(capabilityChangesTotal.WithLabelValues(
+			capChangeName, namespace,
+		))).To(Equal(1.0))
 	})
 
 	It("should record skip metrics when handshake was already verified", func() {

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -55,6 +55,8 @@ var _ = Describe("MCPServer Metrics", func() {
 		deploymentFailuresTotal.Reset()
 		serviceFailuresTotal.Reset()
 		reconcileDuration.Reset()
+		handshakeTotal.Reset()
+		handshakeDuration.Reset()
 	})
 
 	It("should record Accepted and Ready condition metrics on successful reconcile", func() {
@@ -313,4 +315,112 @@ var _ = Describe("MCPServer Metrics", func() {
 			svcFailName, namespace, "Ready", "False", "ServiceUnavailable",
 		))).To(Equal(1.0))
 	})
+
+	It("should record handshake success metrics when handshake succeeds", func() {
+		hsSuccessName := "metrics-hs-ok"
+		hsSuccessNN := types.NamespacedName{Name: hsSuccessName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hsSuccessName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
+				return &mcpv1alpha1.MCPServerInfo{Name: "test-server", Version: "1.0"}, nil
+			},
+		}
+		// First reconcile creates the Deployment
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsSuccessNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		simulateDeploymentAvailable(ctx, hsSuccessNN)
+
+		// Second reconcile triggers handshake
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsSuccessNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(testutil.ToFloat64(handshakeTotal.WithLabelValues(
+			hsSuccessName, namespace, "success",
+		))).To(Equal(1.0))
+		Expect(testutil.CollectAndCount(handshakeDuration)).To(BeNumerically(">", 0))
+	})
+
+	It("should record handshake failure metrics when handshake fails", func() {
+		hsFailName := "metrics-hs-fail"
+		hsFailNN := types.NamespacedName{Name: hsFailName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hsFailName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
+				return nil, fmt.Errorf("connection refused")
+			},
+		}
+		// First reconcile creates the Deployment
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsFailNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		simulateDeploymentAvailable(ctx, hsFailNN)
+
+		// Second reconcile triggers handshake
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: hsFailNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(testutil.ToFloat64(handshakeTotal.WithLabelValues(
+			hsFailName, namespace, "failure",
+		))).To(Equal(1.0))
+		Expect(testutil.CollectAndCount(handshakeDuration)).To(BeNumerically(">", 0))
+	})
 })
+
+func simulateDeploymentAvailable(ctx context.Context, nn types.NamespacedName) {
+	dep := &appsv1.Deployment{}
+	EventuallyWithOffset(1, func() error {
+		return k8sClient.Get(ctx, nn, dep)
+	}).Should(Succeed())
+
+	dep.Status.Replicas = 1
+	dep.Status.ReadyReplicas = 1
+	dep.Status.AvailableReplicas = 1
+	dep.Status.Conditions = []appsv1.DeploymentCondition{
+		{
+			Type:   appsv1.DeploymentAvailable,
+			Status: corev1.ConditionTrue,
+		},
+	}
+	ExpectWithOffset(1, k8sClient.Status().Update(ctx, dep)).To(Succeed())
+}

--- a/site-src/operating/metrics.md
+++ b/site-src/operating/metrics.md
@@ -41,6 +41,8 @@ Custom metrics use the Prometheus namespace **`mcpserver`** (exported names star
 | `mcpserver_service_failures_total` | counter | Total failures when reconciling the Service (`reason` is currently `ReconcileError`). |
 | `mcpserver_networkpolicy_failures_total` | counter | Total failures when reconciling the NetworkPolicy (`reason` is currently `ReconcileError`). |
 | `mcpserver_reconcile_phase_duration_seconds` | histogram | Duration of reconciliation phases **validation**, **deployment**, **service**, and **networkpolicy** (seconds; default Prometheus histogram buckets). |
+| `mcpserver_handshake_total` | counter | Total MCP handshake attempts per `MCPServer`, broken down by `result`. |
+| `mcpserver_handshake_duration_seconds` | histogram | Duration of MCP handshake operations in seconds (buckets: 0.1, 0.25, 0.5, 1, 2.5, 5, 10). |
 
 ### Labels for `mcpserver_condition_info`
 
@@ -88,6 +90,43 @@ histogram_quantile(
   sum(rate(mcpserver_reconcile_phase_duration_seconds_bucket[5m])) by (le, phase)
 )
 ```
+
+```promql
+sum(rate(mcpserver_handshake_total{result="failure"}[5m])) by (namespace, name)
+```
+
+```promql
+histogram_quantile(
+  0.99,
+  sum(rate(mcpserver_handshake_duration_seconds_bucket[5m])) by (le)
+)
+```
+
+### Labels for `mcpserver_handshake_total`
+
+| Label | Description |
+| --- | --- |
+| `name` | `MCPServer` name |
+| `namespace` | `MCPServer` namespace |
+| `result` | Handshake outcome (see below) |
+
+**`result` values**
+
+| Value | Meaning |
+| --- | --- |
+| `success` | Handshake completed and the server returned valid MCP capabilities. |
+| `failure` | Handshake failed (server unreachable, protocol error, timeout, etc.). |
+| `auth_skip` | Server returned an HTTP auth error (401/403); treated as reachable without completing the handshake. |
+| `skip` | Handshake was skipped because the endpoint was already verified for the current generation. |
+
+### Labels for `mcpserver_handshake_duration_seconds`
+
+| Label | Description |
+| --- | --- |
+| `name` | `MCPServer` name |
+| `namespace` | `MCPServer` namespace |
+
+Duration is recorded for every handshake attempt (success, failure, or auth_skip) but not for skipped handshakes.
 
 ### Labels for failure counters (`mcpserver_*_failures_total`)
 

--- a/site-src/operating/metrics.md
+++ b/site-src/operating/metrics.md
@@ -43,6 +43,7 @@ Custom metrics use the Prometheus namespace **`mcpserver`** (exported names star
 | `mcpserver_reconcile_phase_duration_seconds` | histogram | Duration of reconciliation phases **validation**, **deployment**, **service**, and **networkpolicy** (seconds; default Prometheus histogram buckets). |
 | `mcpserver_handshake_total` | counter | Total MCP handshake attempts per `MCPServer`, broken down by `result`. |
 | `mcpserver_handshake_duration_seconds` | histogram | Duration of MCP handshake operations in seconds (buckets: 0.1, 0.25, 0.5, 1, 2.5, 5, 10). |
+| `mcpserver_capability_changes_total` | counter | Total MCP server capability changes detected between reconcile generations. |
 
 ### Labels for `mcpserver_condition_info`
 
@@ -127,6 +128,13 @@ histogram_quantile(
 | `namespace` | `MCPServer` namespace |
 
 Duration is recorded for every handshake attempt (success, failure, or auth_skip) but not for skipped handshakes.
+
+### Labels for `mcpserver_capability_changes_total`
+
+| Label | Description |
+| --- | --- |
+| `name` | `MCPServer` name |
+| `namespace` | `MCPServer` namespace |
 
 ### Labels for failure counters (`mcpserver_*_failures_total`)
 

--- a/site-src/operating/metrics.md
+++ b/site-src/operating/metrics.md
@@ -41,7 +41,7 @@ Custom metrics use the Prometheus namespace **`mcpserver`** (exported names star
 | `mcpserver_service_failures_total` | counter | Total failures when reconciling the Service (`reason` is currently `ReconcileError`). |
 | `mcpserver_networkpolicy_failures_total` | counter | Total failures when reconciling the NetworkPolicy (`reason` is currently `ReconcileError`). |
 | `mcpserver_reconcile_phase_duration_seconds` | histogram | Duration of reconciliation phases **validation**, **deployment**, **service**, and **networkpolicy** (seconds; default Prometheus histogram buckets). |
-| `mcpserver_handshake_total` | counter | Total MCP handshake attempts per `MCPServer`, broken down by `result`. |
+| `mcpserver_handshake_total` | counter | Total MCP handshake outcomes per `MCPServer`, broken down by `result`. |
 | `mcpserver_handshake_duration_seconds` | histogram | Duration of MCP handshake operations in seconds (buckets: 0.1, 0.25, 0.5, 1, 2.5, 5, 10). |
 | `mcpserver_capability_changes_total` | counter | Total MCP server capability changes detected between reconcile generations. |
 


### PR DESCRIPTION
Add handshake_total counter (labels: name, namespace, result) and handshake_duration_seconds histogram to track MCP endpoint verification.

Results tracked: success, failure, auth_skip, skip (already verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring**
  * Added Prometheus metrics for MCP handshake attempts, outcomes, and duration.
  * Handshake metrics distinguish successful, failed, authentication-skipped, and already-verified results.
  * Added labels, duration histograms, and example queries to support troubleshooting and performance analysis.
  * Improved visibility into deployment availability and handshake performance.

* **Documentation**
  * Documented the new handshake metrics, outcome values, and recommended recording rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->