### PR TITLE
fix: defer capability-change side effects until status write succeeds

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -368,7 +368,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			conditionToAC(readyCondition),
 		)
 
-	r.detectCapabilityChanges(mcpServer, serverInfo)
+	capDiff := capabilityChangeMessage(mcpServer, serverInfo)
 
 	if serverInfo != nil {
 		si := acv1alpha1.MCPServerInfo()
@@ -398,6 +398,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.applyStatus(ctx, mcpServer, status); err != nil {
 		logger.Error(err, "Failed to apply MCPServer status")
 		return ctrl.Result{}, err
+	}
+
+	if capDiff != "" {
+		capabilityChangesTotal.WithLabelValues(mcpServer.Name, mcpServer.Namespace).Inc()
+		r.emitCapabilityChangeDetected(mcpServer, capDiff)
 	}
 
 	logger.Info("Successfully reconciled MCPServer",
@@ -619,19 +624,14 @@ func (r *MCPServerReconciler) emitMCPHandshakeRetriesExhausted(mcpServer *mcpv1a
 		mcpServer.Name, retryCount)
 }
 
-func (r *MCPServerReconciler) detectCapabilityChanges(mcpServer *mcpv1alpha1.MCPServer, serverInfo *mcpv1alpha1.MCPServerInfo) {
+func capabilityChangeMessage(mcpServer *mcpv1alpha1.MCPServer, serverInfo *mcpv1alpha1.MCPServerInfo) string {
 	if serverInfo == nil || mcpServer.Status.ServerInfo == nil {
-		return
+		return ""
 	}
 	if serverInfo.Capabilities == nil && mcpServer.Status.ServerInfo.Capabilities == nil {
-		return
+		return ""
 	}
-	diff := capabilityDiffMessage(mcpServer.Status.ServerInfo.Capabilities, serverInfo.Capabilities)
-	if diff == "" {
-		return
-	}
-	capabilityChangesTotal.WithLabelValues(mcpServer.Name, mcpServer.Namespace).Inc()
-	r.emitCapabilityChangeDetected(mcpServer, diff)
+	return capabilityDiffMessage(mcpServer.Status.ServerInfo.Capabilities, serverInfo.Capabilities)
 }
 
 func (r *MCPServerReconciler) emitCapabilityChangeDetected(mcpServer *mcpv1alpha1.MCPServer, diff string) {

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -89,7 +89,7 @@ const (
 
 // Event-only reasons (not used as condition reasons).
 const (
-	ReasonCapabilityChanged = "CapabilityChanged"
+	EventReasonCapabilityChanged = "CapabilityChanged"
 )
 
 // Container waiting reasons from Kubernetes pod status.
@@ -642,7 +642,7 @@ func (r *MCPServerReconciler) emitCapabilityChangeDetected(mcpServer *mcpv1alpha
 	if r.Recorder == nil {
 		return
 	}
-	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, ReasonCapabilityChanged, eventActionCapabilityChangeDetected,
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, EventReasonCapabilityChanged, eventActionCapabilityChangeDetected,
 		"MCP server capabilities changed: %s", diff)
 }
 

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -85,7 +85,11 @@ const (
 	ReasonScaledToZero             = "ScaledToZero"
 	ReasonInitializing             = "Initializing"
 	ReasonMCPEndpointUnavailable   = "MCPEndpointUnavailable"
-	ReasonCapabilityChanged        = "CapabilityChanged"
+)
+
+// Event-only reasons (not used as condition reasons).
+const (
+	ReasonCapabilityChanged = "CapabilityChanged"
 )
 
 // Container waiting reasons from Kubernetes pod status.

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -85,6 +85,7 @@ const (
 	ReasonScaledToZero             = "ScaledToZero"
 	ReasonInitializing             = "Initializing"
 	ReasonMCPEndpointUnavailable   = "MCPEndpointUnavailable"
+	ReasonCapabilityChanged        = "CapabilityChanged"
 )
 
 // Container waiting reasons from Kubernetes pod status.
@@ -619,8 +620,10 @@ func (r *MCPServerReconciler) emitMCPHandshakeRetriesExhausted(mcpServer *mcpv1a
 }
 
 func (r *MCPServerReconciler) detectCapabilityChanges(mcpServer *mcpv1alpha1.MCPServer, serverInfo *mcpv1alpha1.MCPServerInfo) {
-	if serverInfo == nil || mcpServer.Status.ServerInfo == nil ||
-		serverInfo.Capabilities == nil || mcpServer.Status.ServerInfo.Capabilities == nil {
+	if serverInfo == nil || mcpServer.Status.ServerInfo == nil {
+		return
+	}
+	if serverInfo.Capabilities == nil && mcpServer.Status.ServerInfo.Capabilities == nil {
 		return
 	}
 	diff := capabilityDiffMessage(mcpServer.Status.ServerInfo.Capabilities, serverInfo.Capabilities)
@@ -635,7 +638,7 @@ func (r *MCPServerReconciler) emitCapabilityChangeDetected(mcpServer *mcpv1alpha
 	if r.Recorder == nil {
 		return
 	}
-	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, "CapabilityChanged", eventActionCapabilityChangeDetected,
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeWarning, ReasonCapabilityChanged, eventActionCapabilityChangeDetected,
 		"MCP server capabilities changed: %s", diff)
 }
 

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -193,6 +193,9 @@ func mcpHandshakeBackoff(retryCount int) time.Duration {
 	return delay
 }
 
+// capabilityDiffMessage compares two MCPServerCapabilities and returns a
+// human-readable message describing the differences. Nil is treated as
+// all-false. Returns an empty string when nothing changed.
 func capabilityDiffMessage(old, new *mcpv1alpha1.MCPServerCapabilities) string {
 	var oldCaps, newCaps mcpv1alpha1.MCPServerCapabilities
 	if old != nil {

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -193,9 +193,6 @@ func mcpHandshakeBackoff(retryCount int) time.Duration {
 	return delay
 }
 
-// capabilityDiffMessage compares two MCPServerCapabilities and returns a
-// human-readable message describing the differences. Nil is treated as
-// all-false. Returns an empty string when nothing changed.
 func capabilityDiffMessage(old, new *mcpv1alpha1.MCPServerCapabilities) string {
 	var oldCaps, newCaps mcpv1alpha1.MCPServerCapabilities
 	if old != nil {

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -1100,6 +1100,19 @@ var _ = Describe("capabilityChangeMessage", func() {
 		Expect(diff).To(ContainSubstring("resources: false->true"))
 	})
 
+	It("should return diff when old capabilities are non-nil and new are nil", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{
+			Status: mcpv1alpha1.MCPServerStatus{
+				ServerInfo: &mcpv1alpha1.MCPServerInfo{
+					Capabilities: &mcpv1alpha1.MCPServerCapabilities{Tools: true},
+				},
+			},
+		}
+		serverInfo := &mcpv1alpha1.MCPServerInfo{}
+		Expect(capabilityChangeMessage(mcpServer, serverInfo)).
+			To(ContainSubstring("tools: true->false"))
+	})
+
 	It("should return diff when capabilities changed", func() {
 		mcpServer := &mcpv1alpha1.MCPServer{
 			Status: mcpv1alpha1.MCPServerStatus{

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -1056,6 +1056,61 @@ var _ = Describe("capabilityDiffMessage", func() {
 	})
 })
 
+var _ = Describe("capabilityChangeMessage", func() {
+	It("should return empty when serverInfo is nil", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{
+			Status: mcpv1alpha1.MCPServerStatus{
+				ServerInfo: &mcpv1alpha1.MCPServerInfo{
+					Capabilities: &mcpv1alpha1.MCPServerCapabilities{Tools: true},
+				},
+			},
+		}
+		Expect(capabilityChangeMessage(mcpServer, nil)).To(BeEmpty())
+	})
+
+	It("should return empty when status serverInfo is nil", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		serverInfo := &mcpv1alpha1.MCPServerInfo{
+			Capabilities: &mcpv1alpha1.MCPServerCapabilities{Tools: true},
+		}
+		Expect(capabilityChangeMessage(mcpServer, serverInfo)).To(BeEmpty())
+	})
+
+	It("should return empty when both capabilities are nil", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{
+			Status: mcpv1alpha1.MCPServerStatus{
+				ServerInfo: &mcpv1alpha1.MCPServerInfo{},
+			},
+		}
+		serverInfo := &mcpv1alpha1.MCPServerInfo{}
+		Expect(capabilityChangeMessage(mcpServer, serverInfo)).To(BeEmpty())
+	})
+
+	It("should return diff when capabilities changed", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{
+			Status: mcpv1alpha1.MCPServerStatus{
+				ServerInfo: &mcpv1alpha1.MCPServerInfo{
+					Capabilities: &mcpv1alpha1.MCPServerCapabilities{Tools: false},
+				},
+			},
+		}
+		serverInfo := &mcpv1alpha1.MCPServerInfo{
+			Capabilities: &mcpv1alpha1.MCPServerCapabilities{Tools: true},
+		}
+		Expect(capabilityChangeMessage(mcpServer, serverInfo)).To(ContainSubstring("tools: false->true"))
+	})
+})
+
+var _ = Describe("emitCapabilityChangeDetected", func() {
+	It("should not panic when Recorder is nil", func() {
+		r := &MCPServerReconciler{}
+		mcpServer := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		}
+		Expect(func() { r.emitCapabilityChangeDetected(mcpServer, "tools: false->true") }).NotTo(Panic())
+	})
+})
+
 var _ = Describe("extractServerInfo", func() {
 	It("should return nil for nil input", func() {
 		Expect(extractServerInfo(nil)).To(BeNil())

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -1086,6 +1086,20 @@ var _ = Describe("capabilityChangeMessage", func() {
 		Expect(capabilityChangeMessage(mcpServer, serverInfo)).To(BeEmpty())
 	})
 
+	It("should return diff when old capabilities are nil and new are non-nil", func() {
+		mcpServer := &mcpv1alpha1.MCPServer{
+			Status: mcpv1alpha1.MCPServerStatus{
+				ServerInfo: &mcpv1alpha1.MCPServerInfo{},
+			},
+		}
+		serverInfo := &mcpv1alpha1.MCPServerInfo{
+			Capabilities: &mcpv1alpha1.MCPServerCapabilities{Tools: true, Resources: true},
+		}
+		diff := capabilityChangeMessage(mcpServer, serverInfo)
+		Expect(diff).To(ContainSubstring("tools: false->true"))
+		Expect(diff).To(ContainSubstring("resources: false->true"))
+	})
+
 	It("should return diff when capabilities changed", func() {
 		mcpServer := &mcpv1alpha1.MCPServer{
 			Status: mcpv1alpha1.MCPServerStatus{

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -110,6 +110,8 @@ var (
 		[]string{"name", "namespace"},
 	)
 
+	// capabilityChangesTotal counts MCP server capability changes detected between generations.
+	// Labels: name, namespace.
 	capabilityChangesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -479,6 +480,7 @@ var _ = Describe("MCPServer Metrics", func() {
 			Client:    k8sClient,
 			Scheme:    k8sClient.Scheme(),
 			APIReader: k8sClient,
+			Recorder:  events.NewFakeRecorder(testRecorderBuffer),
 			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
 				return &mcpv1alpha1.MCPServerInfo{
 					Name:         "cap-server",

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -516,6 +517,17 @@ var _ = Describe("MCPServer Metrics", func() {
 		Expect(testutil.ToFloat64(capabilityChangesTotal.WithLabelValues(
 			capChangeName, namespace,
 		))).To(Equal(1.0))
+
+		collected := drainEvents(reconciler.Recorder.(*events.FakeRecorder).Events)
+		var capEvent string
+		for _, ev := range collected {
+			if strings.Contains(ev, ReasonCapabilityChanged) {
+				capEvent = ev
+			}
+		}
+		Expect(capEvent).NotTo(BeEmpty(), "expected a CapabilityChanged event")
+		Expect(capEvent).To(ContainSubstring(corev1.EventTypeWarning))
+		Expect(capEvent).To(ContainSubstring("resources: false->true"))
 	})
 
 	It("should record skip metrics when handshake was already verified", func() {
@@ -590,10 +602,12 @@ var _ = Describe("MCPServer Metrics", func() {
 
 		firstCaps := &mcpv1alpha1.MCPServerCapabilities{Tools: true, Resources: true}
 		returnCaps := firstCaps
+		fr := events.NewFakeRecorder(testRecorderBuffer)
 		reconciler := &MCPServerReconciler{
 			Client:    k8sClient,
 			Scheme:    k8sClient.Scheme(),
 			APIReader: k8sClient,
+			Recorder:  fr,
 			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
 				info := &mcpv1alpha1.MCPServerInfo{
 					Name:    "cap-nil-server",

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -521,7 +521,7 @@ var _ = Describe("MCPServer Metrics", func() {
 		collected := drainEvents(reconciler.Recorder.(*events.FakeRecorder).Events)
 		var capEvent string
 		for _, ev := range collected {
-			if strings.Contains(ev, ReasonCapabilityChanged) {
+			if strings.Contains(ev, EventReasonCapabilityChanged) {
 				capEvent = ev
 			}
 		}

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -564,6 +564,73 @@ var _ = Describe("MCPServer Metrics", func() {
 			hsSkipName, namespace, "skip",
 		))).To(Equal(1.0))
 	})
+
+	It("should detect capability change when capabilities go from non-nil to nil", func() {
+		capNilName := "metrics-cap-nil"
+		capNilNN := types.NamespacedName{Name: capNilName, Namespace: namespace}
+		resource := &mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      capNilName,
+				Namespace: namespace,
+			},
+			Spec: mcpv1alpha1.MCPServerSpec{
+				Source: mcpv1alpha1.Source{
+					Type: mcpv1alpha1.SourceTypeContainerImage,
+					ContainerImage: &mcpv1alpha1.ContainerImageSource{
+						Ref: "docker.io/library/test-image:latest",
+					},
+				},
+				Config: mcpv1alpha1.ServerConfig{Port: 8080},
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+		firstCaps := &mcpv1alpha1.MCPServerCapabilities{Tools: true, Resources: true}
+		returnCaps := firstCaps
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+			MCPDialer: func(_ context.Context, _ string) (*mcpv1alpha1.MCPServerInfo, error) {
+				info := &mcpv1alpha1.MCPServerInfo{
+					Name:    "cap-nil-server",
+					Version: "1.0",
+				}
+				if returnCaps != nil {
+					info.Capabilities = returnCaps.DeepCopy()
+				}
+				return info, nil
+			},
+		}
+
+		// First reconcile creates the Deployment
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: capNilNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		simulateDeploymentAvailable(ctx, capNilNN)
+
+		// Second reconcile triggers handshake and sets initial capabilities
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: capNilNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Server now returns nil capabilities
+		returnCaps = nil
+
+		// Bump generation so the handshake re-runs
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx, capNilNN, mcpServer)).To(Succeed())
+		mcpServer.Spec.Config.Path = "/mcp-v2"
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		// Third reconcile detects the capability change (non-nil to nil)
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: capNilNN})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(testutil.ToFloat64(capabilityChangesTotal.WithLabelValues(
+			capNilName, namespace,
+		))).To(Equal(1.0))
+	})
 })
 
 func simulateDeploymentAvailable(ctx context.Context, nn types.NamespacedName) {

--- a/site-src/operating/metrics.md
+++ b/site-src/operating/metrics.md
@@ -136,6 +136,12 @@ Duration is recorded for every handshake attempt (success, failure, or auth_skip
 | `name` | `MCPServer` name |
 | `namespace` | `MCPServer` namespace |
 
+**Example query**
+
+```promql
+sum(rate(mcpserver_capability_changes_total[5m])) by (name, namespace)
+```
+
 ### Labels for failure counters (`mcpserver_*_failures_total`)
 
 `mcpserver_validation_failures_total`, `mcpserver_deployment_failures_total`, `mcpserver_service_failures_total`, and `mcpserver_networkpolicy_failures_total` share the **same label set**:


### PR DESCRIPTION
- Move capability change side effects (metric increment, warning event) to after `applyStatus()` succeeds, preventing duplicate emissions on retry
- Refactor `detectCapabilityChanges` into a pure `capabilityChangeMessage` function
- Separate `ReasonCapabilityChanged` into an event-only constants block
- Restore godoc on `capabilityDiffMessage` documenting nil-as-all-false semantics
- Add unit tests for all `capabilityChangeMessage` branches (nil serverInfo, nil status, both-nil capabilities, nil-to-non-nil, actual change)
- Add test coverage for `emitCapabilityChangeDetected` with and without Recorder
- Verify event content and reason in the capability change integration test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of MCP server capability changes, including capability additions, removals, and value updates.
  * Capability-change events and metrics are now emitted only after successful status updates and when an actual change is detected.
  * Added safer handling when event recording is unavailable.

* **Documentation**
  * Added a PromQL example for monitoring capability-change rates by MCP server name and namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->