### PR TITLE
 docs: clarify partial resource spec behavior

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/runtimeconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/runtimeconfig.go
@@ -50,6 +50,8 @@ type RuntimeConfigApplyConfiguration struct {
 	// - Requests: 50m CPU, 64Mi memory
 	// - Limits: 500m CPU, 256Mi memory
 	// Supports partial specification (e.g., only requests or only limits).
+	// When partially specified, only the provided fields are used; defaults
+	// are not merged into the unspecified fields.
 	// Example:
 	// resources:
 	// requests:

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -314,6 +314,8 @@ type RuntimeConfig struct {
 	//   - Requests: 50m CPU, 64Mi memory
 	//   - Limits: 500m CPU, 256Mi memory
 	// Supports partial specification (e.g., only requests or only limits).
+	// When partially specified, only the provided fields are used; defaults
+	// are not merged into the unspecified fields.
 	// Example:
 	//   resources:
 	//     requests:

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -962,6 +962,8 @@ spec:
                         - Requests: 50m CPU, 64Mi memory
                         - Limits: 500m CPU, 256Mi memory
                       Supports partial specification (e.g., only requests or only limits).
+                      When partially specified, only the provided fields are used; defaults
+                      are not merged into the unspecified fields.
                       Example:
                         resources:
                           requests:


### PR DESCRIPTION
- Document that when `Resources` is partially specified (e.g., only requests or only limits), only the provided fields are used and defaults are not merged into the
unspecified fields
- Updates godoc on `RuntimeConfig.Resources`, apply-configuration, and regenerated CRD YAML