### PR TITLE
chore: debug renovate failures

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -59,14 +59,25 @@ module.exports = {
       "matchDepTypes": ["toolchain"],
       "groupName": "go version",
     },
-    // Only bump the minimum supported Go version when adopting a new minor
+    // Bump the `go` directive in place, grouped with the other go updates.
+    // NOTE: `rangeStrategy` cannot be combined with `matchUpdateTypes` in a
+    // single rule (Renovate rejects the rule outright), so the update-type
+    // filtering lives in the follow-up rule below.
     {
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
       "matchDepTypes": ["golang"],
-      "matchUpdateTypes": ["minor"],
       "rangeStrategy": "bump",
       "groupName": "go version",
+    },
+    // Only bump the minimum supported Go version when adopting a new minor,
+    // i.e. ignore patch-level bumps of the `go` directive.
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false,
     },
     // Group GitHub Actions updates together
     {

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -30,4 +30,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: .github/renovate-config.js
         env:
-          LOG_LEVEL: info
+          # TODO: drop back to `info` once the `repository-changed` abort is
+          # diagnosed; the throw sites for it only log at debug level.
+          LOG_LEVEL: debug


### PR DESCRIPTION
Part of #264 

We use renovate to update deps in a way where all our go changes go together. However currently the action is aborting and the logs don't have enough details to debug why, leaving us without dep bumps. This PR bumps the log level to debug and includes a few config fixes I found while researching this that should fix a few warnings we have but are not causing the aborted runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling for Go version directives.
  * Added enhanced diagnostic logging to the automated update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->