### PR TITLE
feat: add structured audit logging for security-relevant operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 toolchain go1.26.5
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/onsi/ginkgo/v2 v2.31.0
 	github.com/onsi/gomega v1.42.0
@@ -32,7 +33,6 @@ require (
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.24.0 // indirect

--- a/internal/controller/audit.go
+++ b/internal/controller/audit.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+func auditLog(ctx context.Context) logr.Logger {
+	return log.FromContext(ctx).WithName("audit")
+}
+
+func auditFields(mcpServer *mcpv1alpha1.MCPServer) []any {
+	return []any{
+		"mcpserver", mcpServer.Name,
+		"namespace", mcpServer.Namespace,
+		"generation", mcpServer.Generation,
+		"resourceVersion", mcpServer.ResourceVersion,
+	}
+}
+
+func auditHandshakeAttempt(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, url string) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "HandshakeAttempt",
+			"url", url,
+		)...,
+	)
+}
+
+func auditHandshakeSuccess(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, url string, info *mcpv1alpha1.MCPServerInfo, duration time.Duration) {
+	fields := append(auditFields(mcpServer),
+		"operation", "HandshakeSuccess",
+		"url", url,
+		"durationMs", duration.Milliseconds(),
+	)
+	if info != nil {
+		fields = append(fields,
+			"protocolVersion", info.ProtocolVersion,
+			"serverName", info.Name,
+			"serverVersion", info.Version,
+		)
+	}
+	auditLog(ctx).Info("audit", fields...)
+}
+
+func auditHandshakeFailed(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, url string, err error, duration time.Duration) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "HandshakeFailed",
+			"url", url,
+			"error", err.Error(),
+			"durationMs", duration.Milliseconds(),
+		)...,
+	)
+}
+
+func auditHandshakeAuthSkip(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, url string, err error) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "HandshakeAuthSkip",
+			"url", url,
+			"error", err.Error(),
+		)...,
+	)
+}
+
+func auditHandshakeRetriesExhausted(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, retries int, max int) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "HandshakeRetriesExhausted",
+			"retries", retries,
+			"max", max,
+		)...,
+	)
+}
+
+func auditCapabilityChange(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, diff string) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "CapabilityChange",
+			"diff", diff,
+		)...,
+	)
+}
+
+func auditNetworkPolicyCreated(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, netpolName string, hasIngressRestriction bool) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "NetworkPolicyCreated",
+			"networkPolicy", netpolName,
+			"hasIngressRestriction", hasIngressRestriction,
+		)...,
+	)
+}
+
+func auditNetworkPolicyUpdated(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, netpolName string) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "NetworkPolicyUpdated",
+			"networkPolicy", netpolName,
+		)...,
+	)
+}
+
+func auditConfigurationRejected(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, reason string, message string) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "ConfigurationRejected",
+			"reason", reason,
+			"message", message,
+		)...,
+	)
+}
+
+func auditOwnershipViolation(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, resource string, resourceKind string, existingOwner string) {
+	auditLog(ctx).Info("audit",
+		append(auditFields(mcpServer),
+			"operation", "OwnershipViolation",
+			"resource", resource,
+			"resourceKind", resourceKind,
+			"existingOwner", existingOwner,
+		)...,
+	)
+}

--- a/internal/controller/audit_test.go
+++ b/internal/controller/audit_test.go
@@ -20,14 +20,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/go-logr/logr/funcr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func newTestMCPServerForAudit(name string) *mcpv1alpha1.MCPServer {
@@ -70,124 +71,97 @@ func findAuditEntry(entries []logEntry, operation string) (logEntry, bool) {
 	return logEntry{}, false
 }
 
-func TestAuditHandshakeSuccess(t *testing.T) {
-	mcpServer := newTestMCPServerForAudit("test-server")
-	info := &mcpv1alpha1.MCPServerInfo{
-		Name:            "echo-server",
-		Version:         "1.2.0",
-		ProtocolVersion: "2026-07-28",
-	}
-	entries := captureAuditLogs(func(ctx context.Context) {
-		auditHandshakeSuccess(ctx, mcpServer, "http://test.svc:8080/mcp", info, 142*time.Millisecond)
-	})
-
-	entry, found := findAuditEntry(entries, "HandshakeSuccess")
-	if !found {
-		t.Fatalf("expected HandshakeSuccess audit entry, got %v", entries)
-	}
-	for _, expected := range []string{"audit", "mcpserver", "test-server", "test-ns", "2026-07-28", "echo-server"} {
-		if !strings.Contains(entry.output, expected) {
-			t.Errorf("expected audit entry to contain %q, got: %s", expected, entry.output)
+var _ = Describe("Audit Logging", func() {
+	It("should log HandshakeSuccess with server info fields", func() {
+		mcpServer := newTestMCPServerForAudit("test-server")
+		info := &mcpv1alpha1.MCPServerInfo{
+			Name:            "echo-server",
+			Version:         "1.2.0",
+			ProtocolVersion: "2026-07-28",
 		}
-	}
-}
+		entries := captureAuditLogs(func(ctx context.Context) {
+			auditHandshakeSuccess(ctx, mcpServer, "http://test.svc:8080/mcp", info, 142*time.Millisecond)
+		})
 
-func TestAuditHandshakeFailed(t *testing.T) {
-	mcpServer := newTestMCPServerForAudit("fail-server")
-	entries := captureAuditLogs(func(ctx context.Context) {
-		auditHandshakeFailed(ctx, mcpServer, "http://fail.svc:8080/mcp", fmt.Errorf("connection refused"), 50*time.Millisecond)
-	})
-
-	entry, found := findAuditEntry(entries, "HandshakeFailed")
-	if !found {
-		t.Fatalf("expected HandshakeFailed audit entry, got %v", entries)
-	}
-	if !strings.Contains(entry.output, "connection refused") {
-		t.Errorf("expected error in audit entry, got: %s", entry.output)
-	}
-}
-
-func TestAuditNetworkPolicyCreated(t *testing.T) {
-	mcpServer := newTestMCPServerForAudit("np-server")
-	entries := captureAuditLogs(func(ctx context.Context) {
-		auditNetworkPolicyCreated(ctx, mcpServer, "np-server", true)
-	})
-
-	entry, found := findAuditEntry(entries, "NetworkPolicyCreated")
-	if !found {
-		t.Fatalf("expected NetworkPolicyCreated audit entry, got %v", entries)
-	}
-	if !strings.Contains(entry.output, "hasIngressRestriction") {
-		t.Errorf("expected hasIngressRestriction field, got: %s", entry.output)
-	}
-}
-
-func TestAuditConfigurationRejected(t *testing.T) {
-	mcpServer := newTestMCPServerForAudit("invalid-server")
-	entries := captureAuditLogs(func(ctx context.Context) {
-		auditConfigurationRejected(ctx, mcpServer, "Invalid", "port must be > 0")
-	})
-
-	entry, found := findAuditEntry(entries, "ConfigurationRejected")
-	if !found {
-		t.Fatalf("expected ConfigurationRejected audit entry, got %v", entries)
-	}
-	for _, expected := range []string{"Invalid", "port must be > 0"} {
-		if !strings.Contains(entry.output, expected) {
-			t.Errorf("expected %q in audit entry, got: %s", expected, entry.output)
+		entry, found := findAuditEntry(entries, "HandshakeSuccess")
+		Expect(found).To(BeTrue(), "expected HandshakeSuccess audit entry, got %v", entries)
+		for _, expected := range []string{"audit", "mcpserver", "test-server", "test-ns", "2026-07-28", "echo-server"} {
+			Expect(entry.output).To(ContainSubstring(expected))
 		}
-	}
-}
-
-func TestAuditOwnershipViolation(t *testing.T) {
-	mcpServer := newTestMCPServerForAudit("owned-server")
-	entries := captureAuditLogs(func(ctx context.Context) {
-		auditOwnershipViolation(ctx, mcpServer, "my-deployment", "Deployment", "other-controller")
 	})
 
-	entry, found := findAuditEntry(entries, "OwnershipViolation")
-	if !found {
-		t.Fatalf("expected OwnershipViolation audit entry, got %v", entries)
-	}
-	for _, expected := range []string{"my-deployment", "Deployment", "other-controller"} {
-		if !strings.Contains(entry.output, expected) {
-			t.Errorf("expected %q in audit entry, got: %s", expected, entry.output)
+	It("should log HandshakeFailed with error details", func() {
+		mcpServer := newTestMCPServerForAudit("fail-server")
+		entries := captureAuditLogs(func(ctx context.Context) {
+			auditHandshakeFailed(ctx, mcpServer, "http://fail.svc:8080/mcp", fmt.Errorf("connection refused"), 50*time.Millisecond)
+		})
+
+		entry, found := findAuditEntry(entries, "HandshakeFailed")
+		Expect(found).To(BeTrue(), "expected HandshakeFailed audit entry, got %v", entries)
+		Expect(entry.output).To(ContainSubstring("connection refused"))
+	})
+
+	It("should log NetworkPolicyCreated with ingress restriction status", func() {
+		mcpServer := newTestMCPServerForAudit("np-server")
+		entries := captureAuditLogs(func(ctx context.Context) {
+			auditNetworkPolicyCreated(ctx, mcpServer, "np-server", true)
+		})
+
+		entry, found := findAuditEntry(entries, "NetworkPolicyCreated")
+		Expect(found).To(BeTrue(), "expected NetworkPolicyCreated audit entry, got %v", entries)
+		Expect(entry.output).To(ContainSubstring("hasIngressRestriction"))
+	})
+
+	It("should log ConfigurationRejected with reason and message", func() {
+		mcpServer := newTestMCPServerForAudit("invalid-server")
+		entries := captureAuditLogs(func(ctx context.Context) {
+			auditConfigurationRejected(ctx, mcpServer, "Invalid", "port must be > 0")
+		})
+
+		entry, found := findAuditEntry(entries, "ConfigurationRejected")
+		Expect(found).To(BeTrue(), "expected ConfigurationRejected audit entry, got %v", entries)
+		Expect(entry.output).To(ContainSubstring("Invalid"))
+		Expect(entry.output).To(ContainSubstring("port must be > 0"))
+	})
+
+	It("should log OwnershipViolation with resource details", func() {
+		mcpServer := newTestMCPServerForAudit("owned-server")
+		entries := captureAuditLogs(func(ctx context.Context) {
+			auditOwnershipViolation(ctx, mcpServer, "my-deployment", "Deployment", "other-controller")
+		})
+
+		entry, found := findAuditEntry(entries, "OwnershipViolation")
+		Expect(found).To(BeTrue(), "expected OwnershipViolation audit entry, got %v", entries)
+		for _, expected := range []string{"my-deployment", "Deployment", "other-controller"} {
+			Expect(entry.output).To(ContainSubstring(expected))
 		}
-	}
-}
-
-func TestAuditCommonFields(t *testing.T) {
-	mcpServer := newTestMCPServerForAudit("common-fields-server")
-	entries := captureAuditLogs(func(ctx context.Context) {
-		auditHandshakeAttempt(ctx, mcpServer, "http://test.svc:8080/mcp")
 	})
 
-	entry, found := findAuditEntry(entries, "HandshakeAttempt")
-	if !found {
-		t.Fatalf("expected HandshakeAttempt audit entry, got %v", entries)
-	}
-	for _, expected := range []string{
-		"common-fields-server",
-		"test-ns",
-		`"generation"=3`,
-		`"resourceVersion"="12345"`,
-	} {
-		if !strings.Contains(entry.output, expected) {
-			t.Errorf("expected common field %q in audit entry, got: %s", expected, entry.output)
+	It("should include common fields in all audit entries", func() {
+		mcpServer := newTestMCPServerForAudit("common-fields-server")
+		entries := captureAuditLogs(func(ctx context.Context) {
+			auditHandshakeAttempt(ctx, mcpServer, "http://test.svc:8080/mcp")
+		})
+
+		entry, found := findAuditEntry(entries, "HandshakeAttempt")
+		Expect(found).To(BeTrue(), "expected HandshakeAttempt audit entry, got %v", entries)
+		for _, expected := range []string{
+			"common-fields-server",
+			"test-ns",
+			`"generation"=3`,
+			`"resourceVersion"="12345"`,
+		} {
+			Expect(entry.output).To(ContainSubstring(expected))
 		}
-	}
-}
-
-func TestAuditLoggerName(t *testing.T) {
-	mcpServer := newTestMCPServerForAudit("logger-name-server")
-	entries := captureAuditLogs(func(ctx context.Context) {
-		auditCapabilityChange(ctx, mcpServer, "tools: true->false")
 	})
 
-	if len(entries) == 0 {
-		t.Fatal("expected at least one audit entry")
-	}
-	if !strings.Contains(entries[0].output, "audit") {
-		t.Errorf("expected logger name containing 'audit', got: %s", entries[0].output)
-	}
-}
+	It("should use an audit-prefixed logger name", func() {
+		mcpServer := newTestMCPServerForAudit("logger-name-server")
+		entries := captureAuditLogs(func(ctx context.Context) {
+			auditCapabilityChange(ctx, mcpServer, "tools: true->false")
+		})
+
+		Expect(entries).NotTo(BeEmpty())
+		Expect(entries[0].output).To(ContainSubstring("audit"))
+	})
+})

--- a/internal/controller/audit_test.go
+++ b/internal/controller/audit_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/funcr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestMCPServerForAudit(name string) *mcpv1alpha1.MCPServer {
+	return &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       "test-ns",
+			Generation:      3,
+			ResourceVersion: "12345",
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Config: mcpv1alpha1.ServerConfig{
+				Port: 8080,
+			},
+		},
+	}
+}
+
+type logEntry struct {
+	output string
+}
+
+func captureAuditLogs(fn func(ctx context.Context)) []logEntry {
+	var entries []logEntry
+	logger := funcr.New(func(prefix, args string) {
+		entries = append(entries, logEntry{output: prefix + " " + args})
+	}, funcr.Options{})
+
+	ctx := log.IntoContext(context.Background(), logger)
+	fn(ctx)
+	return entries
+}
+
+func findAuditEntry(entries []logEntry, operation string) (logEntry, bool) {
+	for _, e := range entries {
+		if strings.Contains(e.output, "audit") && strings.Contains(e.output, fmt.Sprintf(`"operation"=%q`, operation)) {
+			return e, true
+		}
+	}
+	return logEntry{}, false
+}
+
+func TestAuditHandshakeSuccess(t *testing.T) {
+	mcpServer := newTestMCPServerForAudit("test-server")
+	info := &mcpv1alpha1.MCPServerInfo{
+		Name:            "echo-server",
+		Version:         "1.2.0",
+		ProtocolVersion: "2026-07-28",
+	}
+	entries := captureAuditLogs(func(ctx context.Context) {
+		auditHandshakeSuccess(ctx, mcpServer, "http://test.svc:8080/mcp", info, 142*time.Millisecond)
+	})
+
+	entry, found := findAuditEntry(entries, "HandshakeSuccess")
+	if !found {
+		t.Fatalf("expected HandshakeSuccess audit entry, got %v", entries)
+	}
+	for _, expected := range []string{"audit", "mcpserver", "test-server", "test-ns", "2026-07-28", "echo-server"} {
+		if !strings.Contains(entry.output, expected) {
+			t.Errorf("expected audit entry to contain %q, got: %s", expected, entry.output)
+		}
+	}
+}
+
+func TestAuditHandshakeFailed(t *testing.T) {
+	mcpServer := newTestMCPServerForAudit("fail-server")
+	entries := captureAuditLogs(func(ctx context.Context) {
+		auditHandshakeFailed(ctx, mcpServer, "http://fail.svc:8080/mcp", fmt.Errorf("connection refused"), 50*time.Millisecond)
+	})
+
+	entry, found := findAuditEntry(entries, "HandshakeFailed")
+	if !found {
+		t.Fatalf("expected HandshakeFailed audit entry, got %v", entries)
+	}
+	if !strings.Contains(entry.output, "connection refused") {
+		t.Errorf("expected error in audit entry, got: %s", entry.output)
+	}
+}
+
+func TestAuditNetworkPolicyCreated(t *testing.T) {
+	mcpServer := newTestMCPServerForAudit("np-server")
+	entries := captureAuditLogs(func(ctx context.Context) {
+		auditNetworkPolicyCreated(ctx, mcpServer, "np-server", true)
+	})
+
+	entry, found := findAuditEntry(entries, "NetworkPolicyCreated")
+	if !found {
+		t.Fatalf("expected NetworkPolicyCreated audit entry, got %v", entries)
+	}
+	if !strings.Contains(entry.output, "hasIngressRestriction") {
+		t.Errorf("expected hasIngressRestriction field, got: %s", entry.output)
+	}
+}
+
+func TestAuditConfigurationRejected(t *testing.T) {
+	mcpServer := newTestMCPServerForAudit("invalid-server")
+	entries := captureAuditLogs(func(ctx context.Context) {
+		auditConfigurationRejected(ctx, mcpServer, "Invalid", "port must be > 0")
+	})
+
+	entry, found := findAuditEntry(entries, "ConfigurationRejected")
+	if !found {
+		t.Fatalf("expected ConfigurationRejected audit entry, got %v", entries)
+	}
+	for _, expected := range []string{"Invalid", "port must be > 0"} {
+		if !strings.Contains(entry.output, expected) {
+			t.Errorf("expected %q in audit entry, got: %s", expected, entry.output)
+		}
+	}
+}
+
+func TestAuditOwnershipViolation(t *testing.T) {
+	mcpServer := newTestMCPServerForAudit("owned-server")
+	entries := captureAuditLogs(func(ctx context.Context) {
+		auditOwnershipViolation(ctx, mcpServer, "my-deployment", "Deployment", "other-controller")
+	})
+
+	entry, found := findAuditEntry(entries, "OwnershipViolation")
+	if !found {
+		t.Fatalf("expected OwnershipViolation audit entry, got %v", entries)
+	}
+	for _, expected := range []string{"my-deployment", "Deployment", "other-controller"} {
+		if !strings.Contains(entry.output, expected) {
+			t.Errorf("expected %q in audit entry, got: %s", expected, entry.output)
+		}
+	}
+}
+
+func TestAuditCommonFields(t *testing.T) {
+	mcpServer := newTestMCPServerForAudit("common-fields-server")
+	entries := captureAuditLogs(func(ctx context.Context) {
+		auditHandshakeAttempt(ctx, mcpServer, "http://test.svc:8080/mcp")
+	})
+
+	entry, found := findAuditEntry(entries, "HandshakeAttempt")
+	if !found {
+		t.Fatalf("expected HandshakeAttempt audit entry, got %v", entries)
+	}
+	for _, expected := range []string{
+		"common-fields-server",
+		"test-ns",
+		`"generation"=3`,
+		`"resourceVersion"="12345"`,
+	} {
+		if !strings.Contains(entry.output, expected) {
+			t.Errorf("expected common field %q in audit entry, got: %s", expected, entry.output)
+		}
+	}
+}
+
+func TestAuditLoggerName(t *testing.T) {
+	mcpServer := newTestMCPServerForAudit("logger-name-server")
+	entries := captureAuditLogs(func(ctx context.Context) {
+		auditCapabilityChange(ctx, mcpServer, "tools: true->false")
+	})
+
+	if len(entries) == 0 {
+		t.Fatal("expected at least one audit entry")
+	}
+	if !strings.Contains(entries[0].output, "audit") {
+		t.Errorf("expected logger name containing 'audit', got: %s", entries[0].output)
+	}
+}

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -407,6 +407,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if capDiff != "" {
 		capabilityChangesTotal.WithLabelValues(mcpServer.Name, mcpServer.Namespace).Inc()
 		r.emitCapabilityChangeDetected(mcpServer, capDiff)
+		auditCapabilityChange(ctx, mcpServer, capDiff)
 	}
 
 	logger.Info("Successfully reconciled MCPServer",
@@ -426,6 +427,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if retryCount >= maxMCPHandshakeRetries {
 			logger.Info("MCP handshake retries exhausted, not requeuing",
 				"retries", retryCount, "max", maxMCPHandshakeRetries)
+			auditHandshakeRetriesExhausted(ctx, mcpServer, retryCount, maxMCPHandshakeRetries)
 			return ctrl.Result{}, nil
 		}
 		// retryCount is 1-based (already incremented); backoff expects 0-based
@@ -497,6 +499,7 @@ func (r *MCPServerReconciler) reconcilePermanentValidationError(
 	}
 
 	logger.Info("MCPServer configuration is invalid", "reason", validationErr.Reason)
+	auditConfigurationRejected(ctx, mcpServer, validationErr.Reason, validationErr.Message)
 	recordCondition(mcpServer.Name, mcpServer.Namespace,
 		readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
 	return nil

--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -79,7 +79,7 @@ func (r *MCPServerReconciler) reconcileDeployment(
 	}
 
 	// Validate ownership before updating
-	if err := r.validateOwnership(existingDeployment, mcpServer); err != nil {
+	if err := r.validateOwnership(ctx, existingDeployment, mcpServer); err != nil {
 		logger.Error(err, "Deployment ownership validation failed")
 		return nil, err
 	}

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -73,17 +73,21 @@ func (r *MCPServerReconciler) reconcileHandshake(
 	}
 	dialCtx, dialCancel := context.WithTimeout(ctx, mcpHandshakeTimeout)
 	defer dialCancel()
+	auditHandshakeAttempt(ctx, mcpServer, mcpURL)
 	start := time.Now()
 	info, err := dialer(dialCtx, mcpURL)
-	handshakeDuration.With(metricLabels).Observe(time.Since(start).Seconds())
+	elapsed := time.Since(start)
+	handshakeDuration.With(metricLabels).Observe(elapsed.Seconds())
 	if err != nil {
 		if isHTTPAuthError(err) {
 			handshakeTotal.With(withResult(metricLabels, "auth_skip")).Inc()
 			logger.Info("MCP endpoint returned auth error, treating as reachable", "url", mcpURL, "error", err)
+			auditHandshakeAuthSkip(ctx, mcpServer, mcpURL, err)
 			return readyCondition, &mcpv1alpha1.MCPServerInfo{}
 		}
 		handshakeTotal.With(withResult(metricLabels, "failure")).Inc()
 		logger.Info("MCP endpoint handshake failed", "url", mcpURL, "error", err)
+		auditHandshakeFailed(ctx, mcpServer, mcpURL, err, elapsed)
 		cond := newCondition(
 			ConditionTypeReady,
 			metav1.ConditionFalse,
@@ -103,6 +107,7 @@ func (r *MCPServerReconciler) reconcileHandshake(
 		protocolVersion = info.ProtocolVersion
 	}
 	logger.Info("MCP endpoint verified successfully", "url", mcpURL, "protocolVersion", protocolVersion)
+	auditHandshakeSuccess(ctx, mcpServer, mcpURL, info, elapsed)
 	return readyCondition, info
 }
 

--- a/internal/controller/mcpserver_controller_networkpolicy.go
+++ b/internal/controller/mcpserver_controller_networkpolicy.go
@@ -156,8 +156,10 @@ func (r *MCPServerReconciler) createNetworkPolicy(mcpServer *mcpv1alpha1.MCPServ
 
 func hasIngressSourceRestriction(netpol *networkingv1.NetworkPolicy) bool {
 	for _, rule := range netpol.Spec.Ingress {
-		if len(rule.From) > 0 {
-			return true
+		for _, peer := range rule.From {
+			if peer.PodSelector != nil || peer.NamespaceSelector != nil || peer.IPBlock != nil {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/controller/mcpserver_controller_networkpolicy.go
+++ b/internal/controller/mcpserver_controller_networkpolicy.go
@@ -60,13 +60,14 @@ func (r *MCPServerReconciler) reconcileNetworkPolicy(
 		if mcpServer.Spec.Network == nil || len(mcpServer.Spec.Network.IngressFrom) == 0 {
 			logger.Info("NetworkPolicy created without ingress source restrictions", "name", netpol.Name)
 		}
+		auditNetworkPolicyCreated(ctx, mcpServer, netpol.Name, hasIngressSourceRestriction(netpol))
 		return nil
 	} else if err != nil {
 		logger.Error(err, "Failed to get NetworkPolicy")
 		return err
 	}
 
-	if err := r.validateOwnership(existingNetpol, mcpServer); err != nil {
+	if err := r.validateOwnership(ctx, existingNetpol, mcpServer); err != nil {
 		logger.Error(err, "NetworkPolicy ownership validation failed")
 		return err
 	}
@@ -104,6 +105,7 @@ func (r *MCPServerReconciler) reconcileNetworkPolicy(
 			logger.Error(err, "Failed to update NetworkPolicy")
 			return err
 		}
+		auditNetworkPolicyUpdated(ctx, mcpServer, existingNetpol.Name)
 	} else {
 		logger.Info("NetworkPolicy already exists and is up to date", "name", netpol.Name)
 	}
@@ -150,4 +152,13 @@ func (r *MCPServerReconciler) createNetworkPolicy(mcpServer *mcpv1alpha1.MCPServ
 			},
 		},
 	}
+}
+
+func hasIngressSourceRestriction(netpol *networkingv1.NetworkPolicy) bool {
+	for _, rule := range netpol.Spec.Ingress {
+		if len(rule.From) > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controller/mcpserver_controller_ownership.go
+++ b/internal/controller/mcpserver_controller_ownership.go
@@ -17,10 +17,12 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -44,14 +46,14 @@ func IsOwnershipConflict(err error) bool {
 // Returns an error if the resource has a controller owner that is not the given MCPServer,
 // or if the resource has no controller owner (preventing silent adoption of unowned resources).
 func (r *MCPServerReconciler) validateOwnership(
+	ctx context.Context,
 	obj client.Object,
 	mcpServer *mcpv1alpha1.MCPServer,
 ) error {
 	// Get the controller owner reference from the existing resource
 	controllerOwner := metav1.GetControllerOf(obj)
 	if controllerOwner == nil {
-		// No controller owner - reject to prevent silent adoption
-		// User must delete the existing resource or choose a different name for their MCPServer
+		auditOwnershipViolation(ctx, mcpServer, obj.GetName(), gvkKind(obj, r.Scheme), "<none>")
 		return &OwnershipConflictError{Message: fmt.Sprintf("resource %s/%s exists but has no controller owner; "+
 			"delete the resource first or choose a different name for the MCPServer",
 			obj.GetNamespace(), obj.GetName())}
@@ -77,6 +79,7 @@ func (r *MCPServerReconciler) validateOwnership(
 	}
 
 	// Resource is owned by a different controller
+	auditOwnershipViolation(ctx, mcpServer, obj.GetName(), controllerOwner.Kind, controllerOwner.Name)
 	return &OwnershipConflictError{Message: fmt.Sprintf("resource %s/%s is owned by %s/%s (UID: %s), cannot be managed by MCPServer %s/%s (UID: %s)",
 		obj.GetNamespace(), obj.GetName(),
 		controllerOwner.Kind, controllerOwner.Name, controllerOwner.UID,
@@ -96,4 +99,12 @@ func isSameGroupKind(ownerRef *metav1.OwnerReference, expectedGroup, expectedKin
 	}
 
 	return ownerGV.Group == expectedGroup
+}
+
+func gvkKind(obj client.Object, scheme *runtime.Scheme) string {
+	gvks, _, err := scheme.ObjectKinds(obj)
+	if err != nil || len(gvks) == 0 {
+		return "<unknown>"
+	}
+	return gvks[0].Kind
 }

--- a/internal/controller/mcpserver_controller_service.go
+++ b/internal/controller/mcpserver_controller_service.go
@@ -63,7 +63,7 @@ func (r *MCPServerReconciler) reconcileService(
 	}
 
 	// Validate ownership before updating
-	if err := r.validateOwnership(existingService, mcpServer); err != nil {
+	if err := r.validateOwnership(ctx, existingService, mcpServer); err != nil {
 		logger.Error(err, "Service ownership validation failed")
 		return err
 	}


### PR DESCRIPTION
Add a dedicated audit sub-logger ("mcpserver.audit") that emits structured log entries for handshake lifecycle, NetworkPolicy mutations, capability changes, configuration rejections, and ownership violations. Each entry carries common fields (mcpserver, namespace, generation, resourceVersion) plus operation-specific context.

Includes unit tests using funcr-based log capture, a gvkKind helper to resolve Kind from typed objects via the Scheme, and dynamic computation of ingress source restriction status on NetworkPolicy creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured audit logging for server identity, handshake activity, capability changes, network policy changes, configuration rejections, and ownership violations.
  * Audit records include outcomes, relevant metadata, errors, authentication status, and handshake duration.
* **Bug Fixes**
  * Improved ownership validation reporting for unmanaged or conflicting resources.
  * Expanded audit coverage for failed, retried, and authentication-skipped handshakes and rejected configurations.
* **Tests**
  * Added coverage for handshake outcomes, network policy events, configuration rejection, ownership violations, and shared audit metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->