### PR TITLE
fix: kustomize-set-image overlay not matching when IMAGE_TAG_BASE is overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ dir=$$(mktemp -d); \
 trap 'rm -rf "$$dir"' EXIT; \
 ln -s $(CURDIR)/$(1) $$dir/base && \
 printf 'resources:\n- base\n' > $$dir/kustomization.yaml && \
-cd $$dir && "$(KUSTOMIZE)" edit set image $(IMAGE_TAG_BASE)=$(2) && \
+cd $$dir && "$(KUSTOMIZE)" edit set image controller=$(2) && \
 "$(KUSTOMIZE)" build $$dir | "$(KUBECTL)" apply -f -
 endef
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,3 @@ resources:
 - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-images:
-- name: controller
-  newName: mcp-lifecycle-operator
-  newTag: latest


### PR DESCRIPTION
## Summary
- The `kustomize-set-image` function used `$(IMAGE_TAG_BASE)` as the old image name in the overlay. Since `config/manager/kustomization.yaml` already renamed `controller` to `mcp-lifecycle-operator`, overriding `IMAGE_TAG_BASE` (e.g. `IMAGE_TAG_BASE=localhost:5001/mcp-lifecycle-operator make deploy`) caused the overlay to silently have no effect - the deployed pod always used the default image.
- Removed the `images` transformer from `config/manager/kustomization.yaml` and changed the overlay to match against `controller` (the literal image name in `manager.yaml`), keeping a single source of truth for image replacement at deploy time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image configuration handling so the controller image is identified and updated consistently.
  * Removed the outdated controller image override, preventing unintended image naming and tagging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->