### PR TITLE
fix: add semantic validation for NetworkPolicy ingress peers

### DIFF
--- a/internal/controller/mcpserver_controller_networkpolicy_test.go
+++ b/internal/controller/mcpserver_controller_networkpolicy_test.go
@@ -753,6 +753,128 @@ var _ = Describe("MCPServer Controller - NetworkPolicy Ingress Source Restrictio
 		Expect(acceptedCondition.Message).To(ContainSubstring("invalid ipBlock.except[0]"))
 	})
 
+	It("should reject ingressFrom with ipBlock combined with podSelector", func() {
+		mcpServer := newTestMCPServer("test-netpol-ipblock-podselector")
+		mcpServer.Spec.Network = &mcpv1alpha1.NetworkConfig{
+			IngressFrom: []networkingv1.NetworkPolicyPeer{
+				{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR: "10.0.0.0/8",
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "test"},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, mcpServer)
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-netpol-ipblock-podselector",
+				Namespace: "default",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Accepted condition is False with Invalid reason")
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mcpServer), mcpServer)).To(Succeed())
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(acceptedCondition.Reason).To(Equal("Invalid"))
+		Expect(acceptedCondition.Message).To(ContainSubstring("ipBlock cannot be combined with podSelector or namespaceSelector"))
+	})
+
+	It("should reject ingressFrom with ipBlock except outside cidr", func() {
+		mcpServer := newTestMCPServer("test-netpol-except-outside")
+		mcpServer.Spec.Network = &mcpv1alpha1.NetworkConfig{
+			IngressFrom: []networkingv1.NetworkPolicyPeer{
+				{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.0.0.0/24",
+						Except: []string{"192.168.1.0/24"},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, mcpServer)
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-netpol-except-outside",
+				Namespace: "default",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Accepted condition is False with Invalid reason")
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mcpServer), mcpServer)).To(Succeed())
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(acceptedCondition.Reason).To(Equal("Invalid"))
+		Expect(acceptedCondition.Message).To(ContainSubstring("is not within cidr"))
+	})
+
+	It("should reject ingressFrom with except CIDR wider than parent", func() {
+		mcpServer := newTestMCPServer("test-netpol-except-wider")
+		mcpServer.Spec.Network = &mcpv1alpha1.NetworkConfig{
+			IngressFrom: []networkingv1.NetworkPolicyPeer{
+				{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.0.0.0/24",
+						Except: []string{"10.0.0.0/8"},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, mcpServer)
+		}()
+
+		reconciler := &MCPServerReconciler{
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			APIReader: k8sClient,
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-netpol-except-wider",
+				Namespace: "default",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Accepted condition is False with Invalid reason")
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(mcpServer), mcpServer)).To(Succeed())
+		acceptedCondition := meta.FindStatusCondition(mcpServer.Status.Conditions, "Accepted")
+		Expect(acceptedCondition).NotTo(BeNil())
+		Expect(acceptedCondition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(acceptedCondition.Reason).To(Equal("Invalid"))
+		Expect(acceptedCondition.Message).To(ContainSubstring("is not within cidr"))
+	})
+
 	It("should accept valid ingressFrom with ipBlock CIDR", func() {
 		mcpServer := newTestMCPServer("test-netpol-valid-cidr")
 		mcpServer.Spec.Network = &mcpv1alpha1.NetworkConfig{

--- a/internal/controller/mcpserver_controller_validation.go
+++ b/internal/controller/mcpserver_controller_validation.go
@@ -255,23 +255,39 @@ func classifyAPIError(resourceDesc string, namespace string, err error) error {
 // validateIngressFromPeer validates a single NetworkPolicyPeer entry.
 func validateIngressFromPeer(peer networkingv1.NetworkPolicyPeer, index int) *ValidationError {
 	if peer.IPBlock != nil {
+		if peer.PodSelector != nil || peer.NamespaceSelector != nil {
+			return &ValidationError{
+				Reason:  ReasonInvalid,
+				Message: fmt.Sprintf("network.ingressFrom[%d]: ipBlock cannot be combined with podSelector or namespaceSelector", index),
+			}
+		}
 		if peer.IPBlock.CIDR == "" {
 			return &ValidationError{
 				Reason:  ReasonInvalid,
 				Message: fmt.Sprintf("network.ingressFrom[%d]: ipBlock.cidr must not be empty", index),
 			}
 		}
-		if _, _, err := net.ParseCIDR(peer.IPBlock.CIDR); err != nil {
+		_, cidrNet, err := net.ParseCIDR(peer.IPBlock.CIDR)
+		if err != nil {
 			return &ValidationError{
 				Reason:  ReasonInvalid,
 				Message: fmt.Sprintf("network.ingressFrom[%d]: invalid ipBlock.cidr %q: %v", index, peer.IPBlock.CIDR, err),
 			}
 		}
+		parentOnes, parentBits := cidrNet.Mask.Size()
 		for j, except := range peer.IPBlock.Except {
-			if _, _, err := net.ParseCIDR(except); err != nil {
+			_, exceptNet, err := net.ParseCIDR(except)
+			if err != nil {
 				return &ValidationError{
 					Reason:  ReasonInvalid,
 					Message: fmt.Sprintf("network.ingressFrom[%d]: invalid ipBlock.except[%d] %q: %v", index, j, except, err),
+				}
+			}
+			exceptOnes, exceptBits := exceptNet.Mask.Size()
+			if parentBits != exceptBits || parentOnes > exceptOnes || !cidrNet.Contains(exceptNet.IP) {
+				return &ValidationError{
+					Reason:  ReasonInvalid,
+					Message: fmt.Sprintf("network.ingressFrom[%d]: ipBlock.except[%d] %q is not within cidr %q", index, j, except, peer.IPBlock.CIDR),
 				}
 			}
 		}


### PR DESCRIPTION
Extend validateIngressFromPeer to catch two misconfigurations that the Kubernetes API would reject at NetworkPolicy creation time, but that the operator should surface as permanent validation errors on the MCPServer status:

- Reject ipBlock combined with podSelector or namespaceSelector in the same NetworkPolicyPeer (mutually exclusive per K8s API spec)
- Reject ipBlock.except CIDRs that fall outside the parent ipBlock.cidr

This gives users immediate feedback via the Accepted condition rather than a transient NetworkPolicyUnavailable error after resource creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network policy validation for ingress rules.
  * Invalid configurations that combine IP blocks with pod or namespace selectors are now rejected.
  * Exception CIDRs must be valid and fall within their parent IP block.
  * Invalid configurations now clearly report an `Invalid` status and validation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->