### PR TITLE
fix: use metadata-only watches for ConfigMap and Secret

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -684,12 +684,12 @@ func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&networkingv1.NetworkPolicy{}).
-		Watches(
+		WatchesMetadata(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.findMCPServersForConfigMap),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
-		Watches(
+		WatchesMetadata(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findMCPServersForSecret),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),

--- a/internal/controller/mcpserver_controller_confighash.go
+++ b/internal/controller/mcpserver_controller_confighash.go
@@ -71,10 +71,12 @@ func (r *MCPServerReconciler) computeConfigHash(
 	h := sha256.New()
 	dataWritten := false
 
+	// APIReader bypasses the cache to avoid starting a full structured informer
+	// for ConfigMaps/Secrets, which would negate the metadata-only watches.
 	sort.Strings(configMapNames)
 	for _, name := range configMapNames {
 		cm := &corev1.ConfigMap{}
-		if err := r.Get(ctx, client.ObjectKey{
+		if err := r.APIReader.Get(ctx, client.ObjectKey{
 			Name:      name,
 			Namespace: mcpServer.Namespace,
 		}, cm); err != nil {
@@ -106,7 +108,7 @@ func (r *MCPServerReconciler) computeConfigHash(
 	sort.Strings(secretNames)
 	for _, name := range secretNames {
 		secret := &corev1.Secret{}
-		if err := r.Get(ctx, client.ObjectKey{
+		if err := r.APIReader.Get(ctx, client.ObjectKey{
 			Name:      name,
 			Namespace: mcpServer.Namespace,
 		}, secret); err != nil {

--- a/internal/controller/mcpserver_controller_deployment_test.go
+++ b/internal/controller/mcpserver_controller_deployment_test.go
@@ -458,7 +458,7 @@ var _ = Describe("MCPServer Controller - Transient Validation Errors", func() {
 		transientReconciler := &MCPServerReconciler{
 			Client:    interceptedClient,
 			Scheme:    k8sClient.Scheme(),
-			APIReader: k8sClient,
+			APIReader: interceptedClient,
 		}
 
 		By("Reconciling with transient ConfigMap validation failure")
@@ -532,7 +532,7 @@ var _ = Describe("MCPServer Controller - Transient Validation Errors", func() {
 		transientReconciler := &MCPServerReconciler{
 			Client:    interceptedClient,
 			Scheme:    k8sClient.Scheme(),
-			APIReader: k8sClient,
+			APIReader: interceptedClient,
 		}
 
 		By("Reconciling with transient failure")

--- a/internal/controller/mcpserver_controller_storage_test.go
+++ b/internal/controller/mcpserver_controller_storage_test.go
@@ -1340,7 +1340,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			reconciler := &MCPServerReconciler{
 				Client:    fakeClient,
 				Scheme:    scheme,
-				APIReader: k8sClient,
+				APIReader: fakeClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1402,7 +1402,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			reconciler := &MCPServerReconciler{
 				Client:    fakeClient,
 				Scheme:    scheme,
-				APIReader: k8sClient,
+				APIReader: fakeClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1461,7 +1461,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			reconciler := &MCPServerReconciler{
 				Client:    fakeClient,
 				Scheme:    scheme,
-				APIReader: k8sClient,
+				APIReader: fakeClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1518,7 +1518,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			reconciler := &MCPServerReconciler{
 				Client:    fakeClient,
 				Scheme:    scheme,
-				APIReader: k8sClient,
+				APIReader: fakeClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1579,7 +1579,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			reconciler := &MCPServerReconciler{
 				Client:    fakeClient,
 				Scheme:    scheme,
-				APIReader: k8sClient,
+				APIReader: fakeClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1640,7 +1640,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			reconciler := &MCPServerReconciler{
 				Client:    fakeClient,
 				Scheme:    scheme,
-				APIReader: k8sClient,
+				APIReader: fakeClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{
@@ -1701,7 +1701,7 @@ var _ = Describe("MCPServer Controller - Storage Mounts", func() {
 			reconciler := &MCPServerReconciler{
 				Client:    fakeClient,
 				Scheme:    scheme,
-				APIReader: k8sClient,
+				APIReader: fakeClient,
 			}
 
 			mcpServer := &mcpv1alpha1.MCPServer{

--- a/internal/controller/mcpserver_controller_validation.go
+++ b/internal/controller/mcpserver_controller_validation.go
@@ -76,7 +76,7 @@ func (r *MCPServerReconciler) validateReferencedConfigMap(
 	namespace, name, resourceDesc string,
 ) error {
 	cm := &corev1.ConfigMap{}
-	if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, cm); err != nil {
+	if err := r.APIReader.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, cm); err != nil {
 		return classifyAPIError(resourceDesc, namespace, err)
 	}
 	return nil
@@ -89,7 +89,7 @@ func (r *MCPServerReconciler) validateReferencedSecret(
 	namespace, name, resourceDesc string,
 ) error {
 	secret := &corev1.Secret{}
-	if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+	if err := r.APIReader.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
 		return classifyAPIError(resourceDesc, namespace, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Switch `Watches` to `WatchesMetadata` for ConfigMap and Secret informers to prevent unbounded memory growth on large clusters. The metadata-only informer caches only object metadata (~200 bytes per object) instead of full objects including `.data` fields (potentially kilobytes each).
- Use `APIReader` for ConfigMap/Secret fetches in `computeConfigHash` to bypass the cache and avoid starting a full structured informer that would negate the metadata-only watches.
- The mapper functions (`findMCPServersForConfigMap`/`findMCPServersForSecret`) only need `GetName()` and `GetNamespace()`, both available on `PartialObjectMetadata`, so no changes are needed there.

Fixes #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of configuration changes from ConfigMaps and Secrets.
  * Ensured configuration updates are processed reliably, including when resources are not available in the local cache.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->