### PR TITLE
chore: exclude e2e test framework from codecov patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -35,3 +35,4 @@ comment:
 ignore:
   - "**/zz_generated.*.go"
   - "**/applyconfiguration/**"
+  - "test/e2e/**"


### PR DESCRIPTION
The test/e2e/ directory contains e2e test infrastructure, not production code. Codecov patch coverage checks on test framework files are not meaningful....