### PR TITLE
fix: skip reconciliation during namespace termination

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,17 +8,12 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
   - secrets
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
 - apiGroups:
   - ""
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -180,6 +180,7 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
@@ -203,6 +204,14 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		logger.Error(err, "Failed to get MCPServer")
 		return ctrl.Result{}, err
+	}
+
+	// Skip reconciliation when the MCPServer or its namespace is being deleted
+	// to avoid error-level log spam from failed resource creation (see #300).
+	if skip, err := r.shouldSkipReconciliation(ctx, mcpServer, req.Namespace); err != nil {
+		return ctrl.Result{}, err
+	} else if skip {
+		return ctrl.Result{}, nil
 	}
 
 	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
@@ -436,6 +445,32 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// shouldSkipReconciliation returns true when the MCPServer is being deleted or
+// its namespace is terminating / already gone. This lets Reconcile return early
+// and avoid noisy errors from resource creation in a dying namespace (see #300).
+func (r *MCPServerReconciler) shouldSkipReconciliation(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer, namespace string) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	if mcpServer.DeletionTimestamp != nil {
+		logger.Info("MCPServer is being deleted, skipping reconciliation")
+		return true, nil
+	}
+
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Namespace not found, skipping reconciliation", "namespace", namespace)
+			return true, nil
+		}
+		return false, err
+	}
+	if ns.DeletionTimestamp != nil {
+		logger.Info("Namespace is terminating, skipping reconciliation", "namespace", namespace)
+		return true, nil
+	}
+	return false, nil
 }
 
 func (r *MCPServerReconciler) reconcilePermanentValidationError(

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -180,7 +180,7 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
@@ -384,28 +384,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	capDiff := capabilityChangeMessage(mcpServer, serverInfo)
 
 	if serverInfo != nil {
-		si := acv1alpha1.MCPServerInfo()
-		if serverInfo.Name != "" {
-			si = si.WithName(serverInfo.Name)
-		}
-		if serverInfo.Version != "" {
-			si = si.WithVersion(serverInfo.Version)
-		}
-		if serverInfo.ProtocolVersion != "" {
-			si = si.WithProtocolVersion(serverInfo.ProtocolVersion)
-		}
-		if serverInfo.Instructions != "" {
-			si = si.WithInstructions(serverInfo.Instructions)
-		}
-		if serverInfo.Capabilities != nil {
-			si = si.WithCapabilities(acv1alpha1.MCPServerCapabilities().
-				WithTools(serverInfo.Capabilities.Tools).
-				WithResources(serverInfo.Capabilities.Resources).
-				WithPrompts(serverInfo.Capabilities.Prompts).
-				WithLogging(serverInfo.Capabilities.Logging). //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
-				WithCompletions(serverInfo.Capabilities.Completions))
-		}
-		status = status.WithServerInfo(si)
+		status = status.WithServerInfo(serverInfoToAC(serverInfo))
 	}
 
 	if err := r.applyStatus(ctx, mcpServer, status); err != nil {
@@ -445,6 +424,31 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func serverInfoToAC(info *mcpv1alpha1.MCPServerInfo) *acv1alpha1.MCPServerInfoApplyConfiguration {
+	si := acv1alpha1.MCPServerInfo()
+	if info.Name != "" {
+		si = si.WithName(info.Name)
+	}
+	if info.Version != "" {
+		si = si.WithVersion(info.Version)
+	}
+	if info.ProtocolVersion != "" {
+		si = si.WithProtocolVersion(info.ProtocolVersion)
+	}
+	if info.Instructions != "" {
+		si = si.WithInstructions(info.Instructions)
+	}
+	if info.Capabilities != nil {
+		si = si.WithCapabilities(acv1alpha1.MCPServerCapabilities().
+			WithTools(info.Capabilities.Tools).
+			WithResources(info.Capabilities.Resources).
+			WithPrompts(info.Capabilities.Prompts).
+			WithLogging(info.Capabilities.Logging). //nolint:staticcheck // TODO: remove after SEP-2577 deprecation window (mid-2027)
+			WithCompletions(info.Capabilities.Completions))
+	}
+	return si
 }
 
 // shouldSkipReconciliation returns true when the MCPServer is being deleted or

--- a/internal/controller/mcpserver_controller_termination_test.go
+++ b/internal/controller/mcpserver_controller_termination_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,7 +26,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -55,6 +59,7 @@ var _ = Describe("MCPServer Controller - Namespace Termination", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
+
 			Expect(result.RequeueAfter).To(BeZero())
 
 			By("Verifying no Deployment was created")
@@ -102,6 +107,7 @@ var _ = Describe("MCPServer Controller - Namespace Termination", func() {
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
+
 			Expect(result.RequeueAfter).To(BeZero())
 
 			By("Verifying no Deployment was created")
@@ -113,6 +119,62 @@ var _ = Describe("MCPServer Controller - Namespace Termination", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespaceName}, ns)).To(Succeed())
 			ns.Finalizers = nil
 			Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+		})
+	})
+
+	Context("When the namespace lookup fails or is missing", func() {
+		var wrappedClient client.WithWatch
+
+		BeforeEach(func() {
+			var err error
+			wrappedClient, err = client.NewWithWatch(cfg, client.Options{Scheme: runtime.NewScheme()})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip reconciliation when namespace is not found", func() {
+			interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.Namespace); ok {
+						return errors.NewNotFound(corev1.Resource("namespaces"), key.Name)
+					}
+					return k8sClient.Get(ctx, key, obj, opts...)
+				},
+			})
+
+			By("Creating an MCPServer in the default namespace")
+			resource := newTestMCPServer("test-ns-gone")
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+			reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme(), APIReader: interceptedClient}
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "test-ns-gone", Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+
+		It("should return error when namespace lookup has a transient failure", func() {
+			interceptedClient := interceptor.NewClient(wrappedClient, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.Namespace); ok {
+						return fmt.Errorf("transient API error")
+					}
+					return k8sClient.Get(ctx, key, obj, opts...)
+				},
+			})
+
+			By("Creating an MCPServer in the default namespace")
+			resource := newTestMCPServer("test-ns-err")
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, resource) }()
+
+			reconciler := &MCPServerReconciler{Client: interceptedClient, Scheme: k8sClient.Scheme(), APIReader: interceptedClient}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "test-ns-err", Namespace: "default"},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("transient API error"))
 		})
 	})
 })

--- a/internal/controller/mcpserver_controller_termination_test.go
+++ b/internal/controller/mcpserver_controller_termination_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("MCPServer Controller - Namespace Termination", func() {
+	ctx := context.Background()
+
+	Context("When the MCPServer is being deleted", func() {
+		const resourceName = "test-deletion-skip"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		It("should skip reconciliation when the MCPServer has a DeletionTimestamp", func() {
+			By("Creating an MCPServer with a finalizer")
+			resource := newTestMCPServer(resourceName)
+			resource.Finalizers = []string{"test.finalizer/block-deletion"}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			By("Deleting the MCPServer to set DeletionTimestamp")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("Reconciling the deleting MCPServer")
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			By("Verifying no Deployment was created")
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, typeNamespacedName, deployment)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			By("Cleaning up the finalizer")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+			resource.Finalizers = nil
+			Expect(k8sClient.Update(ctx, resource)).To(Succeed())
+		})
+	})
+
+	Context("When the namespace is being terminated", func() {
+		const namespaceName = "test-ns-terminating"
+		const resourceName = "test-ns-term-skip"
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: namespaceName,
+		}
+
+		It("should skip reconciliation when the namespace is terminating", func() {
+			By("Creating a namespace with a finalizer")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       namespaceName,
+					Finalizers: []string{"test.finalizer/block-deletion"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+			By("Creating an MCPServer in the namespace")
+			resource := newTestMCPServer(resourceName)
+			resource.Namespace = namespaceName
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+			By("Deleting the namespace to set its DeletionTimestamp")
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+
+			By("Reconciling the MCPServer in the terminating namespace")
+			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			By("Verifying no Deployment was created")
+			deployment := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, typeNamespacedName, deployment)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			By("Cleaning up the namespace finalizer")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespaceName}, ns)).To(Succeed())
+			ns.Finalizers = nil
+			Expect(k8sClient.Update(ctx, ns)).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
When a namespace containing MCPServers is deleted, the reconciler attempted resource creation in the terminating namespace, producing ERROR-level log lines with full stack traces. Add an early return in Reconcile when the MCPServer has a DeletionTimestamp or when the namespace is terminating/gone. This eliminates the log spam without changing any functional behavior - watches will re-trigger if needed.

Fixes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MCPServer cleanup handling when the resource or its namespace is being deleted.
  - Reconciliation now pauses safely when the namespace is unavailable or terminating.
  - Prevented unnecessary Deployment creation during resource and namespace deletion.
  - Transient namespace lookup errors are now reported for retry.
  - Added required permissions to read namespace information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->