### PR TITLE
fix(e2e): TestImageUpdate uses a distinct image ref

### DIFF
--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -47,7 +47,7 @@ const configHashAnnotation = "mcp.x-k8s.io/config-hash"
 // --- Spec Update Tests ---
 
 func TestImageUpdate(t *testing.T) {
-	imageRef := "quay.io/matzew/mcp-everything:2026.7.10"
+	imageRef := "quay.io/matzew/mcp-everything:2026.8.12"
 
 	feature := features.New("MCPServer image update").
 		WithLabel(category.Label, category.Lifecycle).
@@ -56,14 +56,19 @@ func TestImageUpdate(t *testing.T) {
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			return f.SetupMCPServer(ctx, t, cfg, "img-update", true)
 		}).
-		Assess("update image to digest ref", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("update image to tag ref", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
+
+			oldImage := server.Spec.Source.ContainerImage.Ref
+			if oldImage == imageRef {
+				t.Fatalf("test misconfigured: initial image %q is the same as update target", oldImage)
+			}
 
 			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
 				s.Spec.Source.ContainerImage.Ref = imageRef
 			})
-			t.Log("updated image to digest ref")
+			t.Logf("updated image from %s to %s", oldImage, imageRef)
 
 			return ctx
 		}).
@@ -72,6 +77,14 @@ func TestImageUpdate(t *testing.T) {
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerReconciledAndReady(ctx, t, r, server)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to re-fetch MCPServer: %v", err)
+			}
+			if server.Status.ObservedGeneration < server.Generation {
+				t.Fatalf("expected observedGeneration >= %d, got %d",
+					server.Generation, server.Status.ObservedGeneration)
+			}
 
 			dep := &appsv1.Deployment{}
 			if err := r.Get(ctx, server.Name, server.Namespace, dep); err != nil {
@@ -86,7 +99,8 @@ func TestImageUpdate(t *testing.T) {
 				t.Fatalf("expected image %q, got %q", imageRef, actualImage)
 			}
 
-			t.Logf("Deployment image updated to %s", actualImage)
+			t.Logf("Deployment image updated to %s (observedGeneration=%d)",
+				actualImage, server.Status.ObservedGeneration)
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {


### PR DESCRIPTION
The default e2e image and the update target were both :2026.7.10, making the test a no-op. Use :2026.8.12 as the update target so the controller actually reconciles an image change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end image reconciliation coverage to use the newer MCP Everything container image.
  * Improved test alignment with the current container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->