### PR TITLE
fix(e2e): pin mcp-everything image by digest

### DIFF
--- a/examples/everything-mcp-server/mcpserver.yaml
+++ b/examples/everything-mcp-server/mcpserver.yaml
@@ -7,7 +7,7 @@ spec:
   source:
     type: ContainerImage
     containerImage:
-      ref: quay.io/matzew/mcp-everything:2026.7.10
+      ref: quay.io/matzew/mcp-everything@sha256:537cdedad807bb56140caca9c332d3577b16e533584164bbc3f27abac7b5ba15
   config:
     port: 3001
     path: /mcp

--- a/test/e2e/framework/builders.go
+++ b/test/e2e/framework/builders.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	DefaultMCPServerImage   = "quay.io/matzew/mcp-everything:2026.7.10"
-	AlternateMCPServerImage = "quay.io/matzew/mcp-everything:2026.8.12"
-	BusyboxImage            = "docker.io/library/busybox:1.37"
+	DefaultMCPServerImage   = "quay.io/matzew/mcp-everything@sha256:537cdedad807bb56140caca9c332d3577b16e533584164bbc3f27abac7b5ba15" // :2026.7.10
+	AlternateMCPServerImage = "quay.io/matzew/mcp-everything@sha256:d93b35b4f0d2f9b9d4c7b49aecfbebd73ce1933b18e03875698bca9615c178f8" // :2026.8.13
+	BusyboxImage            = "docker.io/library/busybox@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0"     // :1.37
 )
 
 // MCPServerOption configures an MCPServer for testing.


### PR DESCRIPTION
Replace the tag-based image reference with an immutable digest so the image can be pre-mirrored for disconnected environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the consistency and reproducibility of container-based workflows.
  - Updated bundled example and testing environments to use fixed container versions, helping ensure the same behavior across runs and deployments.
  - Enhanced reliability for automated validation and setup processes by preventing unexpected changes from floating image versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->