### PR TITLE
test(e2e): require exact observedGeneration equality

### DIFF
--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -82,8 +82,8 @@ func TestImageUpdate(t *testing.T) {
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to re-fetch MCPServer: %v", err)
 			}
-			if server.Status.ObservedGeneration < server.Generation {
-				t.Fatalf("expected observedGeneration >= %d, got %d",
+			if server.Status.ObservedGeneration != server.Generation {
+				t.Fatalf("expected observedGeneration to equal generation %d, got %d (status lag indicates reconciliation has not caught up to the latest spec)",
 					server.Generation, server.Status.ObservedGeneration)
 			}
 


### PR DESCRIPTION
Fixes #316.

The `TestImageUpdate` E2E assertion in `test/e2e/reconciliation_test.go`
checked `server.Status.ObservedGeneration < server.Generation` and only
fatal'd on a strict lag. With a `<` lower-bound check, the test passes
when the observed generation is strictly *ahead* of the spec generation
— which only happens if the controller bumps the status condition before
finishing the reconciliation that the subsequent deployment assertions
depend on. The whole point of the `WaitForMCPServerReconciledAndReady`
helper is to gate the rest of the test on a status that matches the
spec, so the post-wait assertion should be an *equality* check.

This change:

- Replaces `<` with `!=` and treats any mismatch as a failure.
- Tightens the failure message so a future maintainer reading the
  failed log sees the rationale, not just two numbers: it calls out
  that a mismatch "indicates reconciliation has not caught up to the
  latest spec".

The check is in `Assess("Deployment reflects new image after
reconciliation", ...)` which is gated by the wait helper upstream, so
the equality assertion is what `WaitForMCPServerReconciledAndReady`
is already meant to guarantee — this just makes the contract explicit
at the assertion site.

`go vet ./test/e2e/...` is clean. The test only runs under the e2e
build tag, so the unit suite is unaffected.

Disclosed: this contribution was prepared with the help of Claude (a
large language model). The human in the loop reviewed the diff and
verified that equality is exactly the acceptance criterion named in
the issue body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated image update end-to-end validation to require the observed generation to match the current generation exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->