### PR TITLE
fix(e2e): Use exact observedGeneration equality in TestImage

### DIFF
--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -82,8 +82,8 @@ func TestImageUpdate(t *testing.T) {
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to re-fetch MCPServer: %v", err)
 			}
-			if server.Status.ObservedGeneration < server.Generation {
-				t.Fatalf("expected observedGeneration >= %d, got %d",
+			if server.Status.ObservedGeneration != server.Generation {
+				t.Fatalf("expected observedGeneration == %d, got %d",
 					server.Generation, server.Status.ObservedGeneration)
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/316