### PR TITLE
fix(e2e): use standardized labels in TestServiceSelectorDrift

### DIFF
--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -378,8 +378,9 @@ func TestServicePortDrift(t *testing.T) {
 func TestServiceSelectorDrift(t *testing.T) {
 	t.Parallel()
 	feature := features.New("MCPServer Service selector drift correction").
-		WithLabel("type", "reconciliation").
-		WithLabel("scenario", "drift-service-selector").
+		WithLabel(category.Label, category.Lifecycle).
+		WithLabel(speed.Label, speed.Moderate).
+		WithLabel(scenario.Label, scenario.Drift).
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			return f.SetupMCPServer(ctx, t, cfg, "drift-selector", true)
 		}).


### PR DESCRIPTION
Replace non-standard labels (type=reconciliation, scenario=drift-service-selector) with the framework-provided category/speed/scenario labels so the test can be selected by the smoke/extended profiles.

Fixes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated reconciliation end-to-end test labels to use standardized categories, speed, and scenario values.
  * Improved consistency and reliability of service selector drift test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->