### PR TITLE
build: bump Go toolchain to 1.26.6 for stdlib vuln fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.1/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} golang:1.26.4 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.6 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -25,7 +25,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd
 
 # Build the manager binary with debug symbols
-FROM golang:1.26.4 AS debug-builder
+FROM golang:1.26.6 AS debug-builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -39,7 +39,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -gcflags="all=-N -l" -o manager ./cmd
 
 # Debug image with Delve
-FROM golang:1.26.4 AS debug
+FROM golang:1.26.6 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.3
 WORKDIR /
 COPY --from=debug-builder /workspace/manager .

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary

- Bump `toolchain` in `go.mod` from `go1.26.5` to `go1.26.6` to address six standard-library vulnerabilities reported by govulncheck (GO-2026-6218, GO-2026-6091, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026).
- Align Dockerfile build stages with `golang:1.26.6` so container builds use the same patched stdlib.

## Test plan

- [x] `make govulncheck` — passes with no vulnerabilities found
<img width="846" height="142" alt="image" src="https://github.com/user-attachments/assets/44927c40-bd8b-453b-afb7-de06e405b701" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go runtime and build environment to version 1.26.6.
  * No user-facing functionality or configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->