### PR TITLE
chore(owners): move ArangoGutierrez to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,13 @@
 
 approvers:
   - aliok
-  - ArangoGutierrez
   - matzew
   - mikebrow
   - mrunalp
   - soltysh
   - jaideepr97
   - Cali0707
+
+emeritus_approvers:
+  - ArangoGutierrez
 


### PR DESCRIPTION
I no longer have the bandwidth to give this project the review attention an approver should provide, so I'm stepping back rather than holding a seat I can't cover.

Moving to `emeritus_approvers` keeps the history intact while removing me from Prow's reviewer assignment and approval accounting, so PRs stop waiting on someone who isn't able to get to them.

Thanks to everyone here — it's been a good project to work on, and I'd rather hand the role over cleanly than let it quietly decay.

**Testing done:** `OWNERS` parses as valid YAML; 7 approvers remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ownership records to reflect a change in approver status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->