### PR TITLE
e2e: skip arm64-unsupported mcp-everything tests

### DIFF
--- a/test/e2e/failure_scenarios_test.go
+++ b/test/e2e/failure_scenarios_test.go
@@ -440,6 +440,11 @@ func TestRecoveryFromImagePullFailure(t *testing.T) {
 			return ctx
 		}).
 		Assess("update to valid image and recover", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Setup used an intentionally invalid image, so SetupMCPServer's
+			// built-in check never saw f.DefaultMCPServerImage; check here
+			// since this step is what actually switches to it.
+			f.SkipIfImageUnsupported(ctx, t, cfg, f.DefaultMCPServerImage)
+
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+// ArchARM64 is the value reported by node.Status.NodeInfo.Architecture for arm64 nodes.
+const ArchARM64 = "arm64"
+
+var (
+	clusterArchOnce sync.Once
+	clusterArchSet  map[string]bool
+	clusterArchErr  error
+)
+
+// DetectClusterArchitectures lists cluster nodes and returns the set of
+// distinct architectures reported via node.Status.NodeInfo.Architecture
+// (e.g. "amd64", "arm64"). The node list is only fetched once per test
+// binary run; subsequent calls return the cached result.
+func DetectClusterArchitectures(ctx context.Context, cfg *envconf.Config) (map[string]bool, error) {
+	clusterArchOnce.Do(func() {
+		var nodes corev1.NodeList
+		if err := cfg.Client().Resources().List(ctx, &nodes); err != nil {
+			clusterArchErr = fmt.Errorf("listing nodes: %w", err)
+			return
+		}
+		archs := make(map[string]bool, len(nodes.Items))
+		for _, n := range nodes.Items {
+			if a := n.Status.NodeInfo.Architecture; a != "" {
+				archs[a] = true
+			}
+		}
+		clusterArchSet = archs
+	})
+	return clusterArchSet, clusterArchErr
+}
+
+// ClusterHasARM64 reports whether the cluster has any arm64 nodes.
+func ClusterHasARM64(ctx context.Context, cfg *envconf.Config) (bool, error) {
+	archs, err := DetectClusterArchitectures(ctx, cfg)
+	if err != nil {
+		return false, err
+	}
+	return archs[ArchARM64], nil
+}
+
+// ClusterPredicate evaluates a condition against the target cluster.
+type ClusterPredicate func(ctx context.Context, cfg *envconf.Config) (bool, error)
+
+// imageSkipPredicates maps a container image ref to the ClusterPredicate that
+// determines whether tests using that image must be skipped on the target
+// cluster. quay.io/matzew/mcp-everything only publishes an amd64 manifest,
+// so it crash-loops on arm64 nodes.
+//
+// FIXME: kubernetes-sigs/mcp-lifecycle-operator#326
+var imageSkipPredicates = map[string]ClusterPredicate{
+	DefaultMCPServerImage:   ClusterHasARM64,
+	AlternateMCPServerImage: ClusterHasARM64,
+}
+
+// imageUnsupported reports whether imageRef is unsupported on the target
+// cluster per imageSkipPredicates. Returns false for unregistered images.
+func imageUnsupported(ctx context.Context, cfg *envconf.Config, imageRef string) (bool, error) {
+	predicate, ok := imageSkipPredicates[imageRef]
+	if !ok {
+		return false, nil
+	}
+	return predicate(ctx, cfg)
+}
+
+// SkipIfImageUnsupported skips the current test when imageRef is registered
+// in imageSkipPredicates and its predicate matches the target cluster.
+func SkipIfImageUnsupported(ctx context.Context, t *testing.T, cfg *envconf.Config, imageRef string) {
+	t.Helper()
+	skip, err := imageUnsupported(ctx, cfg, imageRef)
+	if err != nil {
+		t.Fatalf("failed to evaluate skip predicate for image %s: %v", imageRef, err)
+	}
+	if skip {
+		t.Skipf("skipping: image %s is unsupported on this cluster (kubernetes-sigs/mcp-lifecycle-operator#326)", imageRef)
+	}
+}
+
+// FilterSupportedImages returns imageRefs minus any image whose registered
+// ClusterPredicate matches the target cluster (see imageSkipPredicates).
+func FilterSupportedImages(ctx context.Context, cfg *envconf.Config, imageRefs ...string) ([]string, error) {
+	supported := make([]string, 0, len(imageRefs))
+	for _, ref := range imageRefs {
+		skip, err := imageUnsupported(ctx, cfg, ref)
+		if err != nil {
+			return nil, fmt.Errorf("evaluating skip predicate for image %s: %w", ref, err)
+		}
+		if skip {
+			log.Printf("skipping prewarm of %s: unsupported on this cluster", ref)
+			continue
+		}
+		supported = append(supported, ref)
+	}
+	return supported, nil
+}

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -67,6 +67,9 @@ func SetupMCPServer(ctx context.Context, t *testing.T, cfg *envconf.Config, name
 	r := cfg.Client().Resources()
 
 	server := NewMCPServer(name, ns, opts...)
+	if server.Spec.Source.ContainerImage != nil {
+		SkipIfImageUnsupported(ctx, t, cfg, server.Spec.Source.ContainerImage.Ref)
+	}
 	if err := r.Create(ctx, server); err != nil {
 		t.Fatalf("failed to create MCPServer: %v", err)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -56,12 +56,19 @@ func TestMain(m *testing.M) {
 	}
 
 	// Pre-pull test images so parallel tests don't thundering-herd the
-	// registry with duplicate pulls on a cold node.
-	testenv.Setup(f.PrewarmImages(
+	// registry with duplicate pulls on a cold node. Images unsupported on
+	// this cluster (see f.SkipIfImageUnsupported) are dropped here too,
+	// since prewarming them would fail this Setup step before any test
+	// can run.
+	prewarmImages, err := f.FilterSupportedImages(context.Background(), cfg,
 		f.DefaultMCPServerImage,
 		f.AlternateMCPServerImage,
 		f.BusyboxImage,
-	))
+	)
+	if err != nil {
+		panic(err)
+	}
+	testenv.Setup(f.PrewarmImages(prewarmImages...))
 
 	// Create a unique namespace before each test, delete it after.
 	testenv.BeforeEachTest(func(ctx context.Context, cfg *envconf.Config, t *testing.T) (context.Context, error) {
@@ -171,4 +178,3 @@ func dumpDiagnostics(ctx context.Context, t *testing.T, cfg *envconf.Config, ns 
 
 	t.Log("=== END DIAGNOSTICS ===")
 }
-


### PR DESCRIPTION
### What this does

`quay.io/matzew/mcp-everything` only publishes an `amd64` manifest, so it crash-loops on arm64 nodes. Worse, `TestMain` prewarms it via a DaemonSet on every node as a global `Setup` step, so on an arm64 cluster the whole e2e binary fails before any test runs.

- Detect cluster architecture once (`node.Status.NodeInfo.Architecture`), cached.
- Drop non-multi-arch images from the `TestMain` prewarm list on arm64 clusters, so `Setup` no longer hard-fails the whole suite.
- Skip individual tests that deploy an MCPServer with a non-multi-arch image on arm64, via a `map[image]ClusterPredicate` so this generalizes to future images without new hardcoded arch checks.
- Tests that don't use `mcp-everything` (manager pod checks, invalid-image / busybox failure scenarios) are unaffected and still run on arm64.

Refs #326

Assisted-by: 🤖 claude-sonnet-5@default
