### PR TITLE
test: add e2e tests for TLS validation paths

### DIFF
--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserveraddress.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserveraddress.go
@@ -24,7 +24,8 @@ package v1alpha1
 // MCPServerAddress contains the address information for the MCPServer.
 type MCPServerAddressApplyConfiguration struct {
 	// URL is the cluster-internal address of the MCP server service.
-	// Format: http://<servicename>.<namespace>.svc.cluster.local:<port>/<path>
+	// Format: <scheme>://<servicename>.<namespace>.svc.cluster.local:<port>/<path>
+	// The scheme is "https" when TLS is enabled, "http" otherwise.
 	URL *string `json:"url,omitempty"`
 }
 

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -442,7 +442,8 @@ type MCPConfig struct {
 // MCPServerAddress contains the address information for the MCPServer.
 type MCPServerAddress struct {
 	// URL is the cluster-internal address of the MCP server service.
-	// Format: http://<servicename>.<namespace>.svc.cluster.local:<port>/<path>
+	// Format: <scheme>://<servicename>.<namespace>.svc.cluster.local:<port>/<path>
+	// The scheme is "https" when TLS is enabled, "http" otherwise.
 	// +optional
 	URL string `json:"url,omitempty"`
 }

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -1752,7 +1752,8 @@ spec:
                   url:
                     description: |-
                       URL is the cluster-internal address of the MCP server service.
-                      Format: http://<servicename>.<namespace>.svc.cluster.local:<port>/<path>
+                      Format: <scheme>://<servicename>.<namespace>.svc.cluster.local:<port>/<path>
+                      The scheme is "https" when TLS is enabled, "http" otherwise.
                     type: string
                 type: object
               conditions:

--- a/test/e2e/framework/builders.go
+++ b/test/e2e/framework/builders.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	DefaultMCPServerImage   = "quay.io/matzew/mcp-everything@sha256:537cdedad807bb56140caca9c332d3577b16e533584164bbc3f27abac7b5ba15" // :2026.7.10
-	AlternateMCPServerImage = "quay.io/matzew/mcp-everything@sha256:d93b35b4f0d2f9b9d4c7b49aecfbebd73ce1933b18e03875698bca9615c178f8" // :2026.8.13
-	BusyboxImage            = "docker.io/library/busybox@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0"     // :1.37
+	DefaultMCPServerImage    = "quay.io/matzew/mcp-everything@sha256:537cdedad807bb56140caca9c332d3577b16e533584164bbc3f27abac7b5ba15"            // :2026.7.10
+	AlternateMCPServerImage  = "quay.io/matzew/mcp-everything@sha256:d93b35b4f0d2f9b9d4c7b49aecfbebd73ce1933b18e03875698bca9615c178f8"            // :2026.8.13
+	BusyboxImage             = "docker.io/library/busybox@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0"                // :1.37
+	KubernetesMCPServerImage = "quay.io/containers/kubernetes_mcp_server@sha256:3a4bee3f07c1c81458f9810b160d9123d9edd91a6602d2b3c91baf7c24277090" // :v0.0.66
 )
 
 // MCPServerOption configures an MCPServer for testing.
@@ -85,6 +86,13 @@ func WithSecurityContext(sc *corev1.SecurityContext) MCPServerOption {
 func WithPodSecurityContext(psc *corev1.PodSecurityContext) MCPServerOption {
 	return func(s *mcpv1alpha1.MCPServer) {
 		s.Spec.Runtime.Security.PodSecurityContext = psc
+	}
+}
+
+// WithTransport sets the MCPServer transport configuration.
+func WithTransport(transport *mcpv1alpha1.TransportConfig) MCPServerOption {
+	return func(s *mcpv1alpha1.MCPServer) {
+		s.Spec.Transport = transport
 	}
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -64,6 +64,7 @@ func TestMain(m *testing.M) {
 		f.DefaultMCPServerImage,
 		f.AlternateMCPServerImage,
 		f.BusyboxImage,
+		f.KubernetesMCPServerImage,
 	)
 	if err != nil {
 		panic(err)

--- a/test/e2e/tls_handshake_test.go
+++ b/test/e2e/tls_handshake_test.go
@@ -1,0 +1,321 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
+	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
+	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/speed"
+)
+
+func generateTLSCertificates(t *testing.T, serviceDNS string) (caCertPEM, serverCertPEM, serverKeyPEM []byte) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "e2e-tls-handshake-ca"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA certificate: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caCertDER)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+	caCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate server key: %v", err)
+	}
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: serviceDNS},
+		DNSNames:     []string{serviceDNS},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create server certificate: %v", err)
+	}
+	serverCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
+
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		t.Fatalf("failed to marshal server key: %v", err)
+	}
+	serverKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+
+	return caCertPEM, serverCertPEM, serverKeyPEM
+}
+
+func TestTLSHandshake(t *testing.T) {
+	t.Parallel()
+	const (
+		serverName    = "tls-handshake"
+		caSecretName  = "tls-ca-bundle"
+		tlsSecretName = "tls-server-cert"
+		serverPort    = int32(8080)
+	)
+
+	feature := features.New("TLS handshake with kubernetes-mcp-server").
+		WithLabel(category.Label, category.Networking).
+		WithLabel(speed.Label, speed.Moderate).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns, ok := ctx.Value(f.NsKey).(string)
+			if !ok || ns == "" {
+				t.Fatal("namespace not found in context")
+			}
+			r := cfg.Client().Resources()
+
+			serviceDNS := fmt.Sprintf("%s.%s.svc.cluster.local", serverName, ns)
+			caCertPEM, serverCertPEM, serverKeyPEM := generateTLSCertificates(t, serviceDNS)
+
+			tlsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tlsSecretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					"tls.crt": serverCertPEM,
+					"tls.key": serverKeyPEM,
+				},
+			}
+			if err := r.Create(ctx, tlsSecret); err != nil {
+				t.Fatalf("failed to create TLS server Secret: %v", err)
+			}
+			t.Log("created server TLS Secret")
+
+			caSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      caSecretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					"ca.crt": caCertPEM,
+				},
+			}
+			if err := r.Create(ctx, caSecret); err != nil {
+				t.Fatalf("failed to create CA bundle Secret: %v", err)
+			}
+			t.Log("created CA bundle Secret")
+
+			return f.SetupMCPServer(ctx, t, cfg, serverName, false,
+				f.WithImage(f.KubernetesMCPServerImage),
+				f.WithPort(serverPort),
+				f.WithArguments(
+					"--port", fmt.Sprintf("%d", serverPort),
+					"--read-only",
+					"--tls-cert", "/certs/tls.crt",
+					"--tls-key", "/certs/tls.key",
+				),
+				f.WithStorage(mcpv1alpha1.StorageMount{
+					Path: "/certs",
+					Source: mcpv1alpha1.StorageSource{
+						Type: mcpv1alpha1.StorageTypeSecret,
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: tlsSecretName,
+						},
+					},
+				}),
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:        true,
+						CABundleSecret: &mcpv1alpha1.SecretReference{Name: caSecretName},
+					},
+				}),
+			)
+		}).
+		Assess("Ready=True with successful TLS handshake", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerCondition(ctx, t, r, server,
+				"Ready", metav1.ConditionTrue, 5*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+
+			ready := f.GetMCPServerCondition(server, "Ready")
+			t.Logf("Ready condition: status=%s reason=%s", ready.Status, ready.Reason)
+
+			return ctx
+		}).
+		Assess("address URL uses HTTPS scheme", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+
+			if server.Status.Address == nil || server.Status.Address.URL == "" {
+				t.Fatal("expected status.address.url to be set")
+			}
+			if !strings.HasPrefix(server.Status.Address.URL, "https://") {
+				t.Fatalf("expected HTTPS URL, got %q", server.Status.Address.URL)
+			}
+			t.Logf("MCPServer address: %s", server.Status.Address.URL)
+
+			return ctx
+		}).
+		Assess("HTTPS request verifies cert chain via port-forward", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			caSecret := &corev1.Secret{}
+			if err := r.Get(ctx, caSecretName, server.Namespace, caSecret); err != nil {
+				t.Fatalf("failed to get CA Secret: %v", err)
+			}
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM(caSecret.Data["ca.crt"]) {
+				t.Fatal("failed to parse CA cert PEM into pool")
+			}
+
+			pod := f.FindPodByLabel(ctx, t, cfg, server.Namespace,
+				fmt.Sprintf("mcp-server=%s", server.Name))
+
+			restCfg := cfg.Client().Resources().GetConfig()
+			transport, upgrader, err := spdy.RoundTripperFor(restCfg)
+			if err != nil {
+				t.Fatalf("failed to create SPDY round tripper: %v", err)
+			}
+			pfURL := fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward",
+				restCfg.Host, server.Namespace, pod.Name)
+			dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport},
+				http.MethodPost, mustParseURL(t, pfURL))
+
+			stopCh := make(chan struct{})
+			readyCh := make(chan struct{})
+			defer close(stopCh)
+
+			pf, err := portforward.New(dialer,
+				[]string{fmt.Sprintf("0:%d", serverPort)},
+				stopCh, readyCh, nil, nil)
+			if err != nil {
+				t.Fatalf("failed to create port-forward: %v", err)
+			}
+
+			errCh := make(chan error, 1)
+			go func() { errCh <- pf.ForwardPorts() }()
+
+			select {
+			case <-readyCh:
+			case err := <-errCh:
+				t.Fatalf("port-forward failed: %v", err)
+			case <-time.After(30 * time.Second):
+				t.Fatal("timed out waiting for port-forward")
+			}
+
+			ports, err := pf.GetPorts()
+			if err != nil || len(ports) == 0 {
+				t.Fatalf("failed to get forwarded ports: %v", err)
+			}
+			localPort := ports[0].Local
+
+			serviceDNS := fmt.Sprintf("%s.%s.svc.cluster.local", server.Name, server.Namespace)
+			httpClient := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						RootCAs:    caCertPool,
+						ServerName: serviceDNS,
+					},
+				},
+				Timeout: 10 * time.Second,
+			}
+
+			targetURL := fmt.Sprintf("https://127.0.0.1:%d/mcp", localPort)
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, targetURL, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				t.Fatalf("HTTPS request failed (cert chain not verified): %v", err)
+			}
+			defer resp.Body.Close()
+
+			t.Logf("HTTPS HEAD %s returned %d (TLS cert chain verified via CA bundle)", targetURL, resp.StatusCode)
+
+			return ctx
+		}).
+		Assess("serverInfo populated from TLS handshake", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+
+			if server.Status.ServerInfo == nil {
+				t.Fatal("expected serverInfo to be populated after TLS handshake")
+			}
+			t.Logf("serverInfo: name=%s version=%s protocol=%s",
+				server.Status.ServerInfo.Name,
+				server.Status.ServerInfo.Version,
+				server.Status.ServerInfo.ProtocolVersion)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}

--- a/test/e2e/tls_validation_test.go
+++ b/test/e2e/tls_validation_test.go
@@ -1,0 +1,468 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
+	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
+	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/scenario"
+	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/speed"
+)
+
+var testCAPEM = []byte(`-----BEGIN CERTIFICATE-----
+MIIBgzCCASmgAwIBAgIUXeHgADE6XFO/hNfBfLGyt/Cw880wCgYIKoZIzj0EAwIw
+FjEUMBIGA1UEAwwLZTJlLXRlc3QtY2EwIBcNMjYwODIwMTE1MzAzWhgPMjEyNjA3
+MjcxMTUzMDNaMBYxFDASBgNVBAMMC2UyZS10ZXN0LWNhMFkwEwYHKoZIzj0CAQYI
+KoZIzj0DAQcDQgAEJsnZ8e9zLYa1egP6tJD0c/JmUPVjwW0T6lJU2frN7mdgrn8o
+cgxOZzaiTQRJ2uq0k9C3aPI5BO+LHfsjWS//D6NTMFEwHQYDVR0OBBYEFKE196tU
+ZJCrHMN5C3SDH8a/NoGQMB8GA1UdIwQYMBaAFKE196tUZJCrHMN5C3SDH8a/NoGQ
+MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAJDaTjLMUzD7RyFz
+DTp3kKM7fYOneB7wdmUEuLjKSbzoAiAcfvPPfSLAc3EJ/khzG88fElJco2gGiYlt
+Um8SPRQMrQ==
+-----END CERTIFICATE-----
+`)
+
+var testPrivKeyPEM = []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIKuqL95aBIB8Nfj1xV93YUtmqoMLr6NFDJJhJnQV0abRoAoGCCqGSM49
+AwEHoUQDQgAEJsnZ8e9zLYa1egP6tJD0c/JmUPVjwW0T6lJU2frN7mdgrn8ocgxO
+ZzaiTQRJ2uq0k9C3aPI5BO+LHfsjWS//Dw==
+-----END EC PRIVATE KEY-----
+`)
+
+func TestTLSMissingCABundleSecret(t *testing.T) {
+	t.Parallel()
+	feature := features.New("TLS validation rejects missing CA bundle Secret").
+		WithLabel(category.Label, category.Resilience).
+		WithLabel(speed.Label, speed.Fast).
+		WithLabel(scenario.Label, scenario.Failure).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.SetupMCPServer(ctx, t, cfg, "tls-missing-ca", false,
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:        true,
+						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "nonexistent-ca-secret"},
+					},
+				}),
+			)
+		}).
+		Assess("Accepted=False with reason Invalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerConditionReason(ctx, t, r, server,
+				"Accepted", metav1.ConditionFalse, "Invalid",
+				2*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+			accepted := f.GetMCPServerCondition(server, "Accepted")
+			t.Logf("Accepted condition: status=%s reason=%s message=%q",
+				accepted.Status, accepted.Reason, accepted.Message)
+
+			if accepted.Message == "" {
+				t.Error("expected Accepted message to mention the missing Secret")
+			}
+
+			return ctx
+		}).
+		Assess("Ready=False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerConditionReason(ctx, t, r, server,
+				"Ready", metav1.ConditionFalse, "ConfigurationInvalid",
+				30*time.Second)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestTLSInvalidPEMInCABundle(t *testing.T) {
+	t.Parallel()
+	feature := features.New("TLS validation rejects invalid PEM in CA bundle").
+		WithLabel(category.Label, category.Resilience).
+		WithLabel(speed.Label, speed.Fast).
+		WithLabel(scenario.Label, scenario.Failure).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns, ok := ctx.Value(f.NsKey).(string)
+			if !ok || ns == "" {
+				t.Fatal("namespace not found in context")
+			}
+			r := cfg.Client().Resources()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bad-pem-ca",
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					"ca.crt": []byte("not-a-valid-pem-certificate"),
+				},
+			}
+			if err := r.Create(ctx, secret); err != nil {
+				t.Fatalf("failed to create Secret: %v", err)
+			}
+
+			return f.SetupMCPServer(ctx, t, cfg, "tls-bad-pem", false,
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:        true,
+						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "bad-pem-ca"},
+					},
+				}),
+			)
+		}).
+		Assess("Accepted=False with reason Invalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerConditionReason(ctx, t, r, server,
+				"Accepted", metav1.ConditionFalse, "Invalid",
+				2*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+			accepted := f.GetMCPServerCondition(server, "Accepted")
+			t.Logf("Accepted condition: status=%s reason=%s message=%q",
+				accepted.Status, accepted.Reason, accepted.Message)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestTLSMissingCACrtKey(t *testing.T) {
+	t.Parallel()
+	feature := features.New("TLS validation rejects Secret missing ca.crt key").
+		WithLabel(category.Label, category.Resilience).
+		WithLabel(speed.Label, speed.Fast).
+		WithLabel(scenario.Label, scenario.Failure).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns, ok := ctx.Value(f.NsKey).(string)
+			if !ok || ns == "" {
+				t.Fatal("namespace not found in context")
+			}
+			r := cfg.Client().Resources()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wrong-key-ca",
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					"tls.crt": testCAPEM,
+				},
+			}
+			if err := r.Create(ctx, secret); err != nil {
+				t.Fatalf("failed to create Secret: %v", err)
+			}
+
+			return f.SetupMCPServer(ctx, t, cfg, "tls-wrong-key", false,
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:        true,
+						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "wrong-key-ca"},
+					},
+				}),
+			)
+		}).
+		Assess("Accepted=False with message mentioning ca.crt", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerConditionMessageContains(ctx, t, r, server,
+				"Accepted", metav1.ConditionFalse, "Invalid", "ca.crt",
+				2*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+			accepted := f.GetMCPServerCondition(server, "Accepted")
+			t.Logf("Accepted condition: status=%s reason=%s message=%q",
+				accepted.Status, accepted.Reason, accepted.Message)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestTLSInsecureSkipVerifyWithCABundleConflict(t *testing.T) {
+	t.Parallel()
+	feature := features.New("TLS validation rejects insecureSkipVerify with caBundleSecret").
+		WithLabel(category.Label, category.Resilience).
+		WithLabel(speed.Label, speed.Fast).
+		WithLabel(scenario.Label, scenario.Failure).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns, ok := ctx.Value(f.NsKey).(string)
+			if !ok || ns == "" {
+				t.Fatal("namespace not found in context")
+			}
+			r := cfg.Client().Resources()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "conflict-ca",
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					"ca.crt": testCAPEM,
+				},
+			}
+			if err := r.Create(ctx, secret); err != nil {
+				t.Fatalf("failed to create Secret: %v", err)
+			}
+
+			return f.SetupMCPServer(ctx, t, cfg, "tls-conflict", false,
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:            true,
+						InsecureSkipVerify: true,
+						CABundleSecret:     &mcpv1alpha1.SecretReference{Name: "conflict-ca"},
+					},
+				}),
+			)
+		}).
+		Assess("Accepted=False with message about mutual exclusivity", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerConditionMessageContains(ctx, t, r, server,
+				"Accepted", metav1.ConditionFalse, "Invalid", "mutually exclusive",
+				2*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+			accepted := f.GetMCPServerCondition(server, "Accepted")
+			t.Logf("Accepted condition: status=%s reason=%s message=%q",
+				accepted.Status, accepted.Reason, accepted.Message)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestTLSRecoveryFromMissingCASecret(t *testing.T) {
+	t.Parallel()
+	feature := features.New("TLS recovery after creating missing CA bundle Secret").
+		WithLabel(category.Label, category.Resilience).
+		WithLabel(speed.Label, speed.Moderate).
+		WithLabel(scenario.Label, scenario.Recovery).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.SetupMCPServer(ctx, t, cfg, "tls-recovery", false,
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:        true,
+						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "recovery-ca"},
+					},
+				}),
+			)
+		}).
+		Assess("initially Accepted=False", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerConditionReason(ctx, t, r, server,
+				"Accepted", metav1.ConditionFalse, "Invalid",
+				2*time.Minute)
+			t.Log("confirmed Accepted=False due to missing CA Secret")
+
+			return ctx
+		}).
+		Assess("create CA Secret and recover to Accepted=True", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			ns := server.Namespace
+			r := cfg.Client().Resources()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "recovery-ca",
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					"ca.crt": testCAPEM,
+				},
+			}
+			if err := r.Create(ctx, secret); err != nil {
+				t.Fatalf("failed to create CA Secret: %v", err)
+			}
+			t.Log("created recovery-ca Secret")
+
+			f.WaitForMCPServerCondition(ctx, t, r, server,
+				"Accepted", metav1.ConditionTrue, 2*time.Minute)
+			t.Log("Accepted=True after CA Secret creation")
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestTLSNonCertificatePEM(t *testing.T) {
+	t.Parallel()
+	feature := features.New("TLS validation rejects non-certificate PEM block").
+		WithLabel(category.Label, category.Resilience).
+		WithLabel(speed.Label, speed.Fast).
+		WithLabel(scenario.Label, scenario.Failure).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns, ok := ctx.Value(f.NsKey).(string)
+			if !ok || ns == "" {
+				t.Fatal("namespace not found in context")
+			}
+			r := cfg.Client().Resources()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "privkey-as-ca",
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					"ca.crt": testPrivKeyPEM,
+				},
+			}
+			if err := r.Create(ctx, secret); err != nil {
+				t.Fatalf("failed to create Secret: %v", err)
+			}
+
+			return f.SetupMCPServer(ctx, t, cfg, "tls-privkey", false,
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:        true,
+						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "privkey-as-ca"},
+					},
+				}),
+			)
+		}).
+		Assess("Accepted=False with message about no valid PEM certificates", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerConditionMessageContains(ctx, t, r, server,
+				"Accepted", metav1.ConditionFalse, "Invalid", "no valid PEM",
+				2*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+			accepted := f.GetMCPServerCondition(server, "Accepted")
+			t.Logf("Accepted condition: status=%s reason=%s message=%q",
+				accepted.Status, accepted.Reason, accepted.Message)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+func TestTLSDisabledIgnoresStaleCARef(t *testing.T) {
+	t.Parallel()
+	feature := features.New("TLS disabled skips CA bundle validation").
+		WithLabel(category.Label, category.Configuration).
+		WithLabel(speed.Label, speed.Moderate).
+		WithLabel(scenario.Label, scenario.Deploy).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.SetupMCPServer(ctx, t, cfg, "tls-disabled", true,
+				f.WithTransport(&mcpv1alpha1.TransportConfig{
+					TLS: &mcpv1alpha1.TLSClientConfig{
+						Enabled:        false,
+						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "nonexistent-ignored"},
+					},
+				}),
+			)
+		}).
+		Assess("Accepted=True despite nonexistent CA Secret", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerCondition(ctx, t, r, server,
+				"Accepted", metav1.ConditionTrue, 2*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+			accepted := f.GetMCPServerCondition(server, "Accepted")
+			t.Logf("Accepted=True (TLS disabled, stale CA ref ignored, message=%q)", accepted.Message)
+
+			return ctx
+		}).
+		Assess("Ready=True with HTTP handshake", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			server := f.ServerFromContext(ctx)
+			r := cfg.Client().Resources()
+
+			f.WaitForMCPServerCondition(ctx, t, r, server,
+				"Ready", metav1.ConditionTrue, 2*time.Minute)
+
+			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
+				t.Fatalf("failed to get MCPServer: %v", err)
+			}
+
+			f.AssertAddressURL(t, server, server.Spec.Config.Port)
+			t.Logf("MCPServer ready at %s", server.Status.Address.URL)
+
+			return ctx
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			return f.TeardownMCPServer(ctx, t, cfg)
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}


### PR DESCRIPTION
- Add 7 e2e tests covering TLS configuration validation: missing CA bundle Secret, invalid PEM, missing `ca.crt` key, `insecureSkipVerify`+`caBundleSecret` mutual
exclusivity, non-certificate PEM block, recovery after creating missing Secret, and TLS-disabled ignoring stale CA refs
- Add `WithTransport` builder option to the e2e framework
- Add `hack/run-e2e-tls.sh` convenience script for running TLS e2e tests with a kind cluster


Needs to go in after https://github.com/kubernetes-sigs/mcp-lifecycle-operator/pull/295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional TLS configuration for secure operator-to-MCP-server communication.
  * Supports HTTPS, CA certificate Secrets, and configurable certificate verification.
  * MCPServer status URLs now support both HTTP and HTTPS schemes.

* **Bug Fixes**
  * Added validation for missing, invalid, or conflicting TLS certificate settings.
  * TLS-disabled servers continue operating correctly despite stale certificate references.

* **Tests**
  * Added end-to-end coverage for TLS validation, recovery, and HTTP/HTTPS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->