### PR TITLE
test: generate TLS test certs at runtime to avoid secret-detection alerts

### DIFF
--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"crypto/tls"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"strings"
@@ -39,8 +40,8 @@ import (
 )
 
 func generateSelfSignedCAPEMOnly() []byte {
-	pem, _ := generateSelfSignedCAPEM()
-	return pem
+	caPEM, _ := generateSelfSignedCAPEM()
+	return caPEM
 }
 
 var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
@@ -1569,7 +1570,7 @@ var _ = Describe("MCPServer Controller - TLS Handshake", func() {
 				Namespace: "default",
 			},
 			Data: map[string][]byte{
-				"ca.crt": []byte("-----BEGIN PRIVATE KEY-----\nYWJj\n-----END PRIVATE KEY-----\n"),
+				"ca.crt": pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not-a-cert")}),
 			},
 		}
 		Expect(k8sClient.Create(ctx, secret)).To(Succeed())

--- a/test/e2e/tls_validation_test.go
+++ b/test/e2e/tls_validation_test.go
@@ -20,6 +20,13 @@ package e2e
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
 	"time"
 
@@ -36,25 +43,38 @@ import (
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/speed"
 )
 
-var testCAPEM = []byte(`-----BEGIN CERTIFICATE-----
-MIIBgzCCASmgAwIBAgIUXeHgADE6XFO/hNfBfLGyt/Cw880wCgYIKoZIzj0EAwIw
-FjEUMBIGA1UEAwwLZTJlLXRlc3QtY2EwIBcNMjYwODIwMTE1MzAzWhgPMjEyNjA3
-MjcxMTUzMDNaMBYxFDASBgNVBAMMC2UyZS10ZXN0LWNhMFkwEwYHKoZIzj0CAQYI
-KoZIzj0DAQcDQgAEJsnZ8e9zLYa1egP6tJD0c/JmUPVjwW0T6lJU2frN7mdgrn8o
-cgxOZzaiTQRJ2uq0k9C3aPI5BO+LHfsjWS//D6NTMFEwHQYDVR0OBBYEFKE196tU
-ZJCrHMN5C3SDH8a/NoGQMB8GA1UdIwQYMBaAFKE196tUZJCrHMN5C3SDH8a/NoGQ
-MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAJDaTjLMUzD7RyFz
-DTp3kKM7fYOneB7wdmUEuLjKSbzoAiAcfvPPfSLAc3EJ/khzG88fElJco2gGiYlt
-Um8SPRQMrQ==
------END CERTIFICATE-----
-`)
+func generateTestCACert(t *testing.T) (caPEM []byte, keyPEM []byte) {
+	t.Helper()
 
-var testPrivKeyPEM = []byte(`-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIKuqL95aBIB8Nfj1xV93YUtmqoMLr6NFDJJhJnQV0abRoAoGCCqGSM49
-AwEHoUQDQgAEJsnZ8e9zLYa1egP6tJD0c/JmUPVjwW0T6lJU2frN7mdgrn8ocgxO
-ZzaiTQRJ2uq0k9C3aPI5BO+LHfsjWS//Dw==
------END EC PRIVATE KEY-----
-`)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate EC key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "e2e-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal EC key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return caPEM, keyPEM
+}
 
 func TestTLSMissingCABundleSecret(t *testing.T) {
 	t.Parallel()
@@ -173,6 +193,7 @@ func TestTLSInvalidPEMInCABundle(t *testing.T) {
 
 func TestTLSMissingCACrtKey(t *testing.T) {
 	t.Parallel()
+	testCAPEM, _ := generateTestCACert(t)
 	feature := features.New("TLS validation rejects Secret missing ca.crt key").
 		WithLabel(category.Label, category.Resilience).
 		WithLabel(speed.Label, speed.Fast).
@@ -233,6 +254,7 @@ func TestTLSMissingCACrtKey(t *testing.T) {
 
 func TestTLSInsecureSkipVerifyWithCABundleConflict(t *testing.T) {
 	t.Parallel()
+	testCAPEM, _ := generateTestCACert(t)
 	feature := features.New("TLS validation rejects insecureSkipVerify with caBundleSecret").
 		WithLabel(category.Label, category.Resilience).
 		WithLabel(speed.Label, speed.Fast).
@@ -324,13 +346,14 @@ func TestTLSRecoveryFromMissingCASecret(t *testing.T) {
 			ns := server.Namespace
 			r := cfg.Client().Resources()
 
+			caPEM, _ := generateTestCACert(t)
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "recovery-ca",
 					Namespace: ns,
 				},
 				Data: map[string][]byte{
-					"ca.crt": testCAPEM,
+					"ca.crt": caPEM,
 				},
 			}
 			if err := r.Create(ctx, secret); err != nil {
@@ -354,6 +377,7 @@ func TestTLSRecoveryFromMissingCASecret(t *testing.T) {
 
 func TestTLSNonCertificatePEM(t *testing.T) {
 	t.Parallel()
+	_, testPrivKeyPEM := generateTestCACert(t)
 	feature := features.New("TLS validation rejects non-certificate PEM block").
 		WithLabel(category.Label, category.Resilience).
 		WithLabel(speed.Label, speed.Fast).


### PR DESCRIPTION
  - Replace hardcoded PEM-encoded certificate and private key literals in test/e2e/tls_validation_test.go with a generateTestCACert(t) helper that creates throwaway EC P-256 key pairs at test time
  - Replace hardcoded PRIVATE KEY PEM header in internal/controller/mcpserver_controller_handshake_test.go with pem.EncodeToMemory to build the block at runtime
  - Fix import-shadowing lint warning introduced by the new encoding/pem import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved TLS validation coverage by generating temporary certificate authorities and private keys at runtime.
  * Updated certificate and private-key fixtures to use properly encoded PEM data.
  * Strengthened scenarios for missing keys, conflicting credentials, recovery, and invalid certificate formats.
  * Improved test reliability by reducing dependence on hard-coded certificate material.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->