### PR TITLE
fix: reconcile based on pod watcher not infinite requeues

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,11 +161,18 @@ func main() {
 		metricsServerOptions.KeyName = metricsCertKey
 	}
 
+	cacheOptions, err := controller.CacheOptions()
+	if err != nil {
+		setupLog.Error(err, "unable to build cache options")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
+		Cache:                  cacheOptions,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "bed7462b.x-k8s.io",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,18 +9,12 @@ rules:
   resources:
   - configmaps
   - namespaces
+  - pods
   - secrets
   verbs:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/cache.go
+++ b/internal/controller/cache.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CacheOptions returns the manager cache configuration.
+//
+// The controller watches Pods to surface container-level failure diagnostics
+// (image pull failures, crash loops, OOM kills) on the Ready condition. Pods are
+// the only object type where an unscoped informer would make memory scale with
+// cluster size rather than with MCPServer count, so the informer is both:
+//
+//   - restricted server-side to pods this operator manages, via the presence of
+//     LabelKeyMCPServer, and
+//   - trimmed to the fields the diagnostics actually read.
+//
+// Tests should build their manager from this function rather than duplicating the
+// configuration, otherwise they validate a copy instead of what production runs.
+func CacheOptions() (cache.Options, error) {
+	managedPods, err := labels.NewRequirement(LabelKeyMCPServer, selection.Exists, nil)
+	if err != nil {
+		return cache.Options{}, fmt.Errorf("building managed pod selector: %w", err)
+	}
+
+	return cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}: {
+				Label:     labels.NewSelector().Add(*managedPods),
+				Transform: stripPodForDiagnostics,
+			},
+		},
+	}, nil
+}
+
+// stripPodForDiagnostics strips away all fields not needed for error diagnostics.
+//
+// This keeps the memory footprint of the pod cache small. Note this applies to
+// every Pod read through the cache: anything that later needs Pod.Spec must widen
+// this transform rather than assume the field is populated.
+func stripPodForDiagnostics(obj any) (any, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	pod.Spec = corev1.PodSpec{}
+	pod.ManagedFields = nil
+	pod.Annotations = nil
+	pod.Status = corev1.PodStatus{
+		ContainerStatuses:     pod.Status.ContainerStatuses,
+		InitContainerStatuses: pod.Status.InitContainerStatuses,
+	}
+
+	return pod, nil
+}

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -107,9 +107,6 @@ const (
 
 // Reconciliation constants.
 const (
-	// requeueDelayDeploymentUnavailable is the delay before requeuing when a deployment is not yet available.
-	requeueDelayDeploymentUnavailable = 15 * time.Second
-
 	// eventActionConfigurationValidation is the reporting action for configuration validation outcomes.
 	eventActionConfigurationValidation = "ConfigurationValidation"
 	// eventActionConfigurationAccepted is the reporting action when Accepted becomes True.
@@ -181,7 +178,7 @@ type MCPServerReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
@@ -402,12 +399,8 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		"accepted", acceptedCondition.Status,
 		"ready", readyCondition.Status)
 
-	// If Deployment is not yet available, requeue to check again later
-	if readyCondition.Status == metav1.ConditionFalse && readyCondition.Reason == ReasonDeploymentUnavailable {
-		logger.Info("Deployment not yet available, requeuing to check again",
-			"requeueAfter", requeueDelayDeploymentUnavailable)
-		return ctrl.Result{RequeueAfter: requeueDelayDeploymentUnavailable}, nil
-	}
+	// Deployment progress is driven by the Deployment and Pod watches rather than a
+	// timed requeue; pod-level failures surface via podDiagnosticsChangedPredicate.
 
 	// If MCP endpoint is not yet reachable, requeue with exponential backoff up to a max retry count.
 	if readyCondition.Status == metav1.ConditionFalse && readyCondition.Reason == ReasonMCPEndpointUnavailable {
@@ -733,6 +726,11 @@ func (r *MCPServerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&networkingv1.NetworkPolicy{}).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.findMCPServersForPod),
+			builder.WithPredicates(podDiagnosticsChangedPredicate()),
+		).
 		WatchesMetadata(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.findMCPServersForConfigMap),

--- a/internal/controller/mcpserver_controller_conditions.go
+++ b/internal/controller/mcpserver_controller_conditions.go
@@ -27,7 +27,9 @@ import (
 	v1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // reconcileReadyCondition determines the Ready condition for an MCPServer by
@@ -111,7 +113,7 @@ func (r *MCPServerReconciler) getPodFailureMessage(
 	}
 
 	podList := &corev1.PodList{}
-	if err := r.APIReader.List(ctx, podList,
+	if err := r.List(ctx, podList,
 		client.InNamespace(deployment.Namespace),
 		client.MatchingLabelsSelector{Selector: selector},
 	); err != nil {
@@ -169,60 +171,198 @@ func extractDeploymentState(deployment *appsv1.Deployment) deploymentState {
 	return state
 }
 
+// failureKind enumerates the container failure states this controller recognises.
+type failureKind string
+
+const (
+	failureImagePull   failureKind = "ImagePull"
+	failureCrashLoop   failureKind = "CrashLoop"
+	failureConfigError failureKind = "ConfigError"
+	failureOOMKilled   failureKind = "OOMKilled"
+	failureNotReady    failureKind = "NotReady"
+)
+
+// containerFailure is the structured description of why a container is unhealthy.
+// Both the human-readable condition message and the pod-watch fingerprint are
+// projections of this value, so the set of recognised failure states is defined
+// in exactly one place: classifyContainer.
+type containerFailure struct {
+	Kind      failureKind
+	Pod       string
+	Container string
+	Init      bool
+	Image     string
+	Detail    string // Waiting.Message, where it carries useful information
+	ExitCode  *int32
+	Restarts  int32 // snapshot for diagnostics; restart-only updates do not trigger reconciliation
+}
+
+// classifyContainer checks a single container status for known failure patterns.
+// Returns false when the container is not in a recognised failure state.
+func classifyContainer(cs corev1.ContainerStatus, podName string, init bool) (containerFailure, bool) {
+	f := containerFailure{
+		Pod:       podName,
+		Container: cs.Name,
+		Init:      init,
+		Image:     cs.Image,
+		Restarts:  cs.RestartCount,
+	}
+
+	if w := cs.State.Waiting; w != nil {
+		switch w.Reason {
+		case WaitingReasonImagePullBackOff, WaitingReasonErrImagePull:
+			f.Kind, f.Detail = failureImagePull, w.Message
+			return f, true
+		case WaitingReasonCrashLoopBackOff:
+			f.Kind = failureCrashLoop
+			if t := cs.LastTerminationState.Terminated; t != nil {
+				f.ExitCode = ptr.To(t.ExitCode)
+			}
+			// Waiting.Message is dropped here: it embeds a changing back-off
+			// duration, which would churn the fingerprint below.
+			return f, true
+		case WaitingReasonCreateContainerConfigError:
+			f.Kind, f.Detail = failureConfigError, w.Message
+			return f, true
+		}
+	}
+
+	if t := cs.State.Terminated; t != nil && t.Reason == TerminatedReasonOOMKilled {
+		f.Kind, f.ExitCode = failureOOMKilled, ptr.To(t.ExitCode)
+		return f, true
+	}
+
+	// Running but not ready with restarts indicates a probe failure.
+	// We require RestartCount > 0 to avoid false positives during initial startup
+	// when the readiness probe hasn't passed yet.
+	if cs.State.Running != nil && !cs.Ready && cs.RestartCount > 0 {
+		f.Kind = failureNotReady
+		return f, true
+	}
+
+	return containerFailure{}, false
+}
+
+// Message renders the human-readable diagnostic surfaced on the Ready condition.
+func (f containerFailure) Message() string {
+	switch f.Kind {
+	case failureImagePull:
+		return fmt.Sprintf("Image pull failed for %q: %s (pod: %s)", f.Image, f.Detail, f.Pod)
+	case failureCrashLoop:
+		if f.ExitCode != nil {
+			return fmt.Sprintf("Container crashing: exit code %d, restarts: %d (pod: %s)",
+				*f.ExitCode, f.Restarts, f.Pod)
+		}
+		return fmt.Sprintf("Container crashing: restarts: %d (pod: %s)",
+			f.Restarts, f.Pod)
+	case failureConfigError:
+		return fmt.Sprintf("Container config error: %s (pod: %s)", f.Detail, f.Pod)
+	case failureOOMKilled:
+		return fmt.Sprintf("Container OOMKilled: exit code %d, restarts: %d (pod: %s)",
+			ptr.Deref(f.ExitCode, 0), f.Restarts, f.Pod)
+	case failureNotReady:
+		return fmt.Sprintf("Container not passing health checks: restarts: %d (pod: %s)",
+			f.Restarts, f.Pod)
+	}
+	return ""
+}
+
+// Signature fingerprints everything that affects the reported diagnosis except
+// Restarts, which ticks constantly and would cause reconcile churn in the pod
+// watch predicate. Field-driven rather than branch-driven: a new failureKind is
+// fingerprinted correctly without changing this method.
+func (f containerFailure) Signature() string {
+	exit := "none"
+	if f.ExitCode != nil {
+		exit = fmt.Sprintf("%d", *f.ExitCode)
+	}
+	return fmt.Sprintf("%s|%s|%t|%s|%s|%s",
+		f.Kind, f.Container, f.Init, f.Image, f.Detail, exit)
+}
+
+// firstFailure returns the failure that would be reported for a pod, preferring
+// init containers, matching the order used when rendering the condition message.
+func firstFailure(pod *corev1.Pod) (containerFailure, bool) {
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if f, ok := classifyContainer(cs, pod.Name, true); ok {
+			return f, true
+		}
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if f, ok := classifyContainer(cs, pod.Name, false); ok {
+			return f, true
+		}
+	}
+
+	return containerFailure{}, false
+}
+
 // analyzePodFailures inspects pod container statuses to build a human-readable
 // message describing why pods are unhealthy. Returns "" if no specific failure
 // can be identified. Only the first failure across all pods is returned to keep
 // the status condition message concise.
 func analyzePodFailures(pods []corev1.Pod) string {
-	for _, pod := range pods {
-		for _, cs := range pod.Status.InitContainerStatuses {
-			if msg := analyzeContainerStatus(cs, pod.Name); msg != "" {
-				return msg
-			}
-		}
-
-		for _, cs := range pod.Status.ContainerStatuses {
-			if msg := analyzeContainerStatus(cs, pod.Name); msg != "" {
-				return msg
-			}
+	for i := range pods {
+		if f, ok := firstFailure(&pods[i]); ok {
+			return f.Message()
 		}
 	}
 
 	return ""
 }
 
-// analyzeContainerStatus checks a single container status for known failure
-// patterns and returns a human-readable message, or "" if none is found.
-func analyzeContainerStatus(cs corev1.ContainerStatus, podName string) string {
-	if w := cs.State.Waiting; w != nil {
-		switch w.Reason {
-		case WaitingReasonImagePullBackOff, WaitingReasonErrImagePull:
-			return fmt.Sprintf("Image pull failed for %q: %s (pod: %s)", cs.Image, w.Message, podName)
-		case WaitingReasonCrashLoopBackOff:
-			if t := cs.LastTerminationState.Terminated; t != nil {
-				return fmt.Sprintf("Container crashing: exit code %d, restarts: %d (pod: %s)",
-					t.ExitCode, cs.RestartCount, podName)
+// podFailureSignature returns a stable fingerprint of the failure a pod would
+// report, or "" when it is healthy. Used by the pod watch predicate to trigger a
+// reconcile only when the reported diagnosis would actually change.
+func podFailureSignature(pod *corev1.Pod) string {
+	f, ok := firstFailure(pod)
+	if !ok {
+		return ""
+	}
+	return f.Signature()
+}
+
+// podDiagnosticsChangedPredicate filters pod events down to those that would
+// change the diagnostic message on the Ready condition.
+//
+// Pods report status frequently (restart counters, probe results), and the
+// Deployment they belong to stops reporting changes once it settles into a failed
+// state. Without this filter the watch would either reconcile far more often than
+// the timed requeue it replaces, or miss the pod-level transitions entirely.
+func podDiagnosticsChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		// Informer sync emits Create for pods that already exist, which is how an
+		// operator restart picks up an in-progress failure. Healthy pods fingerprint
+		// to "" and are ignored.
+		CreateFunc: func(e event.CreateEvent) bool {
+			pod, ok := e.Object.(*corev1.Pod)
+			return ok && podFailureSignature(pod) != ""
+		},
+
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, okOld := e.ObjectOld.(*corev1.Pod)
+			newPod, okNew := e.ObjectNew.(*corev1.Pod)
+			if !okOld || !okNew {
+				return false
 			}
-			return fmt.Sprintf("Container crashing: restarts: %d (pod: %s)",
-				cs.RestartCount, podName)
-		case WaitingReasonCreateContainerConfigError:
-			return fmt.Sprintf("Container config error: %s (pod: %s)", w.Message, podName)
-		}
+			return podFailureSignature(oldPod) != podFailureSignature(newPod)
+		},
+
+		// A failing pod going away invalidates the message derived from it. A
+		// healthy pod going away changes ReadyReplicas, which the Deployment watch
+		// already covers.
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if e.DeleteStateUnknown {
+				// Final state was missed; reconcile rather than risk a stale message.
+				return true
+			}
+			pod, ok := e.Object.(*corev1.Pod)
+			return ok && podFailureSignature(pod) != ""
+		},
+
+		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
-	if t := cs.State.Terminated; t != nil {
-		if t.Reason == TerminatedReasonOOMKilled {
-			return fmt.Sprintf("Container OOMKilled: exit code %d, restarts: %d (pod: %s)",
-				t.ExitCode, cs.RestartCount, podName)
-		}
-	}
-	// Running but not ready with restarts indicates a probe failure.
-	// We require RestartCount > 0 to avoid false positives during initial startup
-	// when the readiness probe hasn't passed yet.
-	if cs.State.Running != nil && !cs.Ready && cs.RestartCount > 0 {
-		return fmt.Sprintf("Container not passing health checks: restarts: %d (pod: %s)",
-			cs.RestartCount, podName)
-	}
-	return ""
 }
 
 // newCondition creates a new metav1.Condition with the current timestamp.

--- a/internal/controller/mcpserver_controller_conditions.go
+++ b/internal/controller/mcpserver_controller_conditions.go
@@ -216,7 +216,7 @@ func classifyContainer(cs corev1.ContainerStatus, podName string, init bool) (co
 		case WaitingReasonCrashLoopBackOff:
 			f.Kind = failureCrashLoop
 			if t := cs.LastTerminationState.Terminated; t != nil {
-				f.ExitCode = ptr.To(t.ExitCode)
+				f.ExitCode = new(t.ExitCode)
 			}
 			// Waiting.Message is dropped here: it embeds a changing back-off
 			// duration, which would churn the fingerprint below.
@@ -228,7 +228,7 @@ func classifyContainer(cs corev1.ContainerStatus, podName string, init bool) (co
 	}
 
 	if t := cs.State.Terminated; t != nil && t.Reason == TerminatedReasonOOMKilled {
-		f.Kind, f.ExitCode = failureOOMKilled, ptr.To(t.ExitCode)
+		f.Kind, f.ExitCode = failureOOMKilled, new(t.ExitCode)
 		return f, true
 	}
 

--- a/internal/controller/mcpserver_controller_conditions_test.go
+++ b/internal/controller/mcpserver_controller_conditions_test.go
@@ -342,14 +342,14 @@ func healthyContainerStatus() corev1.ContainerStatus {
 	}
 }
 
-func imagePullContainerStatus(msg string) corev1.ContainerStatus {
+func imagePullContainerStatus() corev1.ContainerStatus {
 	return corev1.ContainerStatus{
 		Name:  "c",
 		Image: "ghcr.io/bad/image:v1",
 		State: corev1.ContainerState{
 			Waiting: &corev1.ContainerStateWaiting{
 				Reason:  WaitingReasonImagePullBackOff,
-				Message: msg,
+				Message: "manifest unknown",
 			},
 		},
 	}
@@ -407,7 +407,7 @@ var _ = Describe("podFailureSignature", func() {
 	})
 
 	It("should change when the failure kind changes", func() {
-		imgPull := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		imgPull := podWithContainerStatus("p", imagePullContainerStatus())
 		crash := podWithContainerStatus("p", crashLoopContainerStatus(1, 1))
 		Expect(podFailureSignature(imgPull)).NotTo(Equal(podFailureSignature(crash)))
 	})
@@ -415,7 +415,7 @@ var _ = Describe("podFailureSignature", func() {
 	It("should prefer init container failures", func() {
 		pod := podWithContainerStatus("p", crashLoopContainerStatus(1, 1))
 		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{
-			imagePullContainerStatus("manifest unknown"),
+			imagePullContainerStatus(),
 		}
 		Expect(podFailureSignature(pod)).To(ContainSubstring(string(failureImagePull)))
 	})
@@ -431,7 +431,7 @@ var _ = Describe("podDiagnosticsChangedPredicate", func() {
 				Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
 			},
 		})
-		after := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		after := podWithContainerStatus("p", imagePullContainerStatus())
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after})).To(BeTrue())
 	})
 
@@ -448,20 +448,20 @@ var _ = Describe("podDiagnosticsChangedPredicate", func() {
 	})
 
 	It("should fire when a failure clears", func() {
-		before := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		before := podWithContainerStatus("p", imagePullContainerStatus())
 		after := podWithContainerStatus("p", healthyContainerStatus())
 		Expect(pred.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after})).To(BeTrue())
 	})
 
 	It("should fire on create only for pods that are already failing", func() {
-		failing := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		failing := podWithContainerStatus("p", imagePullContainerStatus())
 		healthy := podWithContainerStatus("p", healthyContainerStatus())
 		Expect(pred.Create(event.CreateEvent{Object: failing})).To(BeTrue())
 		Expect(pred.Create(event.CreateEvent{Object: healthy})).To(BeFalse())
 	})
 
 	It("should fire on delete of a failing pod, or whenever the final state was missed", func() {
-		failing := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		failing := podWithContainerStatus("p", imagePullContainerStatus())
 		healthy := podWithContainerStatus("p", healthyContainerStatus())
 		Expect(pred.Delete(event.DeleteEvent{Object: failing})).To(BeTrue())
 		Expect(pred.Delete(event.DeleteEvent{Object: healthy})).To(BeFalse())

--- a/internal/controller/mcpserver_controller_conditions_test.go
+++ b/internal/controller/mcpserver_controller_conditions_test.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -321,6 +322,150 @@ var _ = Describe("analyzePodFailures", func() {
 	It("should return empty string for empty pod list", func() {
 		result := analyzePodFailures(nil)
 		Expect(result).To(BeEmpty())
+	})
+})
+
+// podWithContainerStatus builds a pod carrying a single container status, which is
+// all podFailureSignature inspects.
+func podWithContainerStatus(name string, cs corev1.ContainerStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status:     corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{cs}},
+	}
+}
+
+func healthyContainerStatus() corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:  "c",
+		Ready: true,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}
+}
+
+func imagePullContainerStatus(msg string) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:  "c",
+		Image: "ghcr.io/bad/image:v1",
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{
+				Reason:  WaitingReasonImagePullBackOff,
+				Message: msg,
+			},
+		},
+	}
+}
+
+func crashLoopContainerStatus(exitCode, restarts int32) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name:         "c",
+		RestartCount: restarts,
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: WaitingReasonCrashLoopBackOff},
+		},
+		LastTerminationState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: exitCode},
+		},
+	}
+}
+
+var _ = Describe("podFailureSignature", func() {
+	It("should return empty for a healthy container", func() {
+		Expect(podFailureSignature(podWithContainerStatus("healthy", healthyContainerStatus()))).To(BeEmpty())
+	})
+
+	It("should return empty for a container that is not ready but has never restarted", func() {
+		pod := podWithContainerStatus("starting", corev1.ContainerStatus{
+			Name:         "c",
+			RestartCount: 0,
+			State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		})
+		Expect(podFailureSignature(pod)).To(BeEmpty())
+	})
+
+	It("should stay stable while only the restart counter changes", func() {
+		before := podWithContainerStatus("crash", crashLoopContainerStatus(1, 5))
+		after := podWithContainerStatus("crash", crashLoopContainerStatus(1, 6))
+		Expect(podFailureSignature(before)).NotTo(BeEmpty())
+		Expect(podFailureSignature(before)).To(Equal(podFailureSignature(after)))
+	})
+
+	It("should change when the exit code changes", func() {
+		before := podWithContainerStatus("crash", crashLoopContainerStatus(1, 5))
+		after := podWithContainerStatus("crash", crashLoopContainerStatus(137, 5))
+		Expect(podFailureSignature(before)).NotTo(Equal(podFailureSignature(after)))
+	})
+
+	It("should distinguish a missing last-terminated state from exit code zero", func() {
+		withExitZero := podWithContainerStatus("crash", crashLoopContainerStatus(0, 1))
+		noTermination := podWithContainerStatus("crash", corev1.ContainerStatus{
+			Name: "c",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: WaitingReasonCrashLoopBackOff},
+			},
+		})
+		Expect(podFailureSignature(withExitZero)).NotTo(Equal(podFailureSignature(noTermination)))
+	})
+
+	It("should change when the failure kind changes", func() {
+		imgPull := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		crash := podWithContainerStatus("p", crashLoopContainerStatus(1, 1))
+		Expect(podFailureSignature(imgPull)).NotTo(Equal(podFailureSignature(crash)))
+	})
+
+	It("should prefer init container failures", func() {
+		pod := podWithContainerStatus("p", crashLoopContainerStatus(1, 1))
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{
+			imagePullContainerStatus("manifest unknown"),
+		}
+		Expect(podFailureSignature(pod)).To(ContainSubstring(string(failureImagePull)))
+	})
+})
+
+var _ = Describe("podDiagnosticsChangedPredicate", func() {
+	pred := podDiagnosticsChangedPredicate()
+
+	It("should fire when the failure reason changes", func() {
+		before := podWithContainerStatus("p", corev1.ContainerStatus{
+			Name: "c",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"},
+			},
+		})
+		after := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after})).To(BeTrue())
+	})
+
+	It("should not fire when only the restart counter ticks", func() {
+		before := podWithContainerStatus("p", crashLoopContainerStatus(1, 5))
+		after := podWithContainerStatus("p", crashLoopContainerStatus(1, 6))
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after})).To(BeFalse())
+	})
+
+	It("should not fire for routine healthy pod updates", func() {
+		before := podWithContainerStatus("p", healthyContainerStatus())
+		after := podWithContainerStatus("p", healthyContainerStatus())
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after})).To(BeFalse())
+	})
+
+	It("should fire when a failure clears", func() {
+		before := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		after := podWithContainerStatus("p", healthyContainerStatus())
+		Expect(pred.Update(event.UpdateEvent{ObjectOld: before, ObjectNew: after})).To(BeTrue())
+	})
+
+	It("should fire on create only for pods that are already failing", func() {
+		failing := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		healthy := podWithContainerStatus("p", healthyContainerStatus())
+		Expect(pred.Create(event.CreateEvent{Object: failing})).To(BeTrue())
+		Expect(pred.Create(event.CreateEvent{Object: healthy})).To(BeFalse())
+	})
+
+	It("should fire on delete of a failing pod, or whenever the final state was missed", func() {
+		failing := podWithContainerStatus("p", imagePullContainerStatus("manifest unknown"))
+		healthy := podWithContainerStatus("p", healthyContainerStatus())
+		Expect(pred.Delete(event.DeleteEvent{Object: failing})).To(BeTrue())
+		Expect(pred.Delete(event.DeleteEvent{Object: healthy})).To(BeFalse())
+		Expect(pred.Delete(event.DeleteEvent{Object: healthy, DeleteStateUnknown: true})).To(BeTrue())
 	})
 })
 

--- a/internal/controller/mcpserver_controller_confighash.go
+++ b/internal/controller/mcpserver_controller_confighash.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -179,6 +180,17 @@ func (r *MCPServerReconciler) findMCPServersForConfigMap(ctx context.Context, co
 // using the field index for efficient lookup.
 func (r *MCPServerReconciler) findMCPServersForSecret(ctx context.Context, secret client.Object) []reconcile.Request {
 	return r.findMCPServersForResource(ctx, secret.GetName(), secret.GetNamespace(), secretIndexKey)
+}
+
+func (r *MCPServerReconciler) findMCPServersForPod(ctx context.Context, pod client.Object) []reconcile.Request {
+	name, ok := pod.GetLabels()[LabelKeyMCPServer]
+	if !ok || name == "" {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: pod.GetNamespace()},
+	}}
 }
 
 // extractConfigMapNames is an index extractor that returns all ConfigMap names

--- a/internal/controller/mcpserver_controller_predicate_test.go
+++ b/internal/controller/mcpserver_controller_predicate_test.go
@@ -23,11 +23,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
 )
 
 var _ = Describe("MCPServer Predicate Filtering", Ordered, func() {
@@ -39,10 +44,14 @@ var _ = Describe("MCPServer Predicate Filtering", Ordered, func() {
 		var mgrCtx context.Context
 		mgrCtx, mgrCancel = context.WithCancel(ctx)
 
+		cacheOptions, err := CacheOptions()
+		Expect(err).NotTo(HaveOccurred())
+
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 			Scheme:                 scheme.Scheme,
 			Metrics:                metricsserver.Options{BindAddress: "0"},
 			HealthProbeBindAddress: "0",
+			Cache:                  cacheOptions,
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -145,5 +154,65 @@ var _ = Describe("MCPServer Predicate Filtering", Ordered, func() {
 			}
 			return dep.Spec.Template.Spec.Containers[0].Image
 		}, 10*time.Second).Should(Equal("docker.io/library/updated-image:latest"))
+	})
+
+	It("should surface pod-level failure detail on the Ready condition", func() {
+		mcpServer := newTestMCPServer("predicate-pod-diagnostics")
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, mcpServer)
+		}()
+
+		serverKey := types.NamespacedName{Name: mcpServer.Name, Namespace: mcpServer.Namespace}
+
+		dep := &appsv1.Deployment{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, serverKey, dep)
+		}, 10*time.Second).Should(Succeed())
+
+		By("Reporting the Deployment as rolling out with no ready replicas")
+		dep.Status.Conditions = []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionTrue,
+		}}
+		Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mcpServer.Name + "-pod",
+				Namespace: mcpServer.Namespace,
+				Labels:    managedWorkloadSelector(mcpServer.Name),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "ghcr.io/bad/image:v1"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+		By("Reporting an image pull failure on the pod")
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "c",
+			Image: "ghcr.io/bad/image:v1",
+			State: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason:  WaitingReasonImagePullBackOff,
+					Message: `Back-off pulling image "ghcr.io/bad/image:v1"`,
+				},
+			},
+		}}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
+		By("Expecting the specific pod failure rather than the generic Deployment message")
+		Eventually(func() string {
+			server := &mcpv1alpha1.MCPServer{}
+			if err := k8sClient.Get(ctx, serverKey, server); err != nil {
+				return ""
+			}
+			cond := meta.FindStatusCondition(server.Status.Conditions, ConditionTypeReady)
+			if cond == nil {
+				return ""
+			}
+			return cond.Message
+		}, 15*time.Second).Should(ContainSubstring("Image pull failed"))
 	})
 })

--- a/internal/controller/mcpserver_controller_test.go
+++ b/internal/controller/mcpserver_controller_test.go
@@ -828,7 +828,7 @@ var _ = Describe("MCPServer Controller", func() {
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
 
-		It("should requeue reconciliation when Deployment is unavailable", func() {
+		It("should not use a timed requeue when Deployment is unavailable", func() {
 			controllerReconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
 
 			By("Initial reconciliation creates deployment")
@@ -856,13 +856,13 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
 
-			By("Reconciling should set Ready=False and requeue")
+			By("Reconciling should set Ready=False without a timed requeue")
 			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+			Expect(result.RequeueAfter).To(BeZero())
 
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())
@@ -952,12 +952,12 @@ var _ = Describe("MCPServer Controller", func() {
 			}
 			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
 
-			By("First reconciliation: unavailable, requeue")
+			By("First reconciliation: unavailable, no timed requeue")
 			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+			Expect(result.RequeueAfter).To(BeZero())
 
 			mcpServer := &mcpv1alpha1.MCPServer{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, mcpServer)).To(Succeed())


### PR DESCRIPTION
Fixes #301 

This change moves from using a time based requeue for deployment failures, which was a fragile heuristic and could cause unbounded requeues to a simpler event driven approach. To make this feasible with pods (of which there can be many), we use a cache that only caches relevant pod fields, rather than the whole pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCPServer readiness conditions now report specific pod failures, including image-pull and container crash issues.
  * Pod status changes are detected automatically, improving reconciliation responsiveness.
  * Cache data is optimized to retain only managed pods and relevant diagnostic information.
  * Expanded permissions enable monitoring pod changes.

* **Bug Fixes**
  * Removed unnecessary timed retries when Deployments are unavailable.
  * Improved failure reporting for init containers and regular containers.
  * Pod failures now take precedence over generic rollout messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->