### PR TITLE
docs: fix numbered list rendering in quickstart guide

### DIFF
--- a/site-src/guides/quickstart.md
+++ b/site-src/guides/quickstart.md
@@ -211,6 +211,7 @@ EOF
 ```
 
 This creates:
+
 1. **ServiceAccount** (`mcp-viewer`) - Identity for the MCP server pods
 2. **ClusterRoleBinding** - Binds the ServiceAccount to the built-in `view` ClusterRole
 3. **ConfigMap** - Server configuration with read-only mode and specific toolsets


### PR DESCRIPTION
### Problem

The numbered list in [quickstart guide](https://mcp-lifecycle-operator.sigs.k8s.io/guides/quickstart/#production-example-mcp-server-with-rbac) under section `Production Example: MCP Server with RBAC` is rendered as a single line

<img width="798" height="144" alt="image" src="https://github.com/user-attachments/assets/abd4caf4-7051-4c60-9ea4-158f64e4461c" />

### Fix

Added the missing blank line so the list renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved spacing in the RBAC quickstart example for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->