### PR TITLE
fix(e2e): reconcile stale ClusterRoleBinding in TestMetricsEndpoint

### DIFF
--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -87,7 +87,15 @@ func TestMetricsEndpoint(t *testing.T) {
 				if !apierrors.IsAlreadyExists(err) {
 					t.Fatalf("failed to create ClusterRoleBinding: %v", err)
 				}
-				t.Log("ClusterRoleBinding for metrics access already exists")
+				existing := &rbacv1.ClusterRoleBinding{}
+				if err := r.Get(ctx, metricsRoleBinding, "", existing); err != nil {
+					t.Fatalf("failed to get existing ClusterRoleBinding: %v", err)
+				}
+				existing.Subjects = crb.Subjects
+				if err := r.Update(ctx, existing); err != nil {
+					t.Fatalf("failed to update stale ClusterRoleBinding: %v", err)
+				}
+				t.Log("updated stale ClusterRoleBinding to match current operator")
 			} else {
 				t.Log("created ClusterRoleBinding for metrics access")
 			}


### PR DESCRIPTION
When a previous e2e run is interrupted, the CRB persists with subjects pointing to the old ServiceAccount. On the next run with a different operator namespace, the test creates a token for the new SA but the stale CRB still binds the old one, causing a 403 on the metrics endpoint.

Replace the silent AlreadyExists fallback with a Get+Update so the subjects are always reconciled to match the current operator reference.

Fixes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metrics endpoint setup so existing access bindings are updated with the current operator service account.
  * Improved reliability when configuring metrics access in environments where the binding already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->