### PR TITLE
examples: add kube-agentic-networking integration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,14 @@ Deploys the [Everything MCP Server](https://github.com/modelcontextprotocol/serv
 
 See [everything-mcp-server/README.md](./everything-mcp-server/README.md) for details.
 
+## agentic-networking
+
+Demonstrates exposing an MCPServer's generated Service through
+[kube-agentic-networking](https://github.com/kubernetes-sigs/kube-agentic-networking)
+Gateway API routing (`Gateway` + `XBackend` + `HTTPRoute`).
+
+See [agentic-networking/README.md](./agentic-networking/README.md) for details.
+
 ## Quick Start
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ See [everything-mcp-server/README.md](./everything-mcp-server/README.md) for det
 
 Demonstrates exposing an MCPServer's generated Service through
 [kube-agentic-networking](https://github.com/kubernetes-sigs/kube-agentic-networking)
-Gateway API routing (`Gateway` + `XBackend` + `HTTPRoute`).
+Gateway API routing (`Gateway` + `HTTPRoute`, via a direct Service `backendRef`).
 
 See [agentic-networking/README.md](./agentic-networking/README.md) for details.
 

--- a/examples/agentic-networking/README.md
+++ b/examples/agentic-networking/README.md
@@ -1,0 +1,160 @@
+# Agentic Networking Example
+
+This example demonstrates deploying an MCP server with the MCP Lifecycle
+Operator and exposing it through
+[kube-agentic-networking](https://github.com/kubernetes-sigs/kube-agentic-networking),
+a Kubernetes SIG project that provides Gateway API-based routing for agent/MCP
+traffic.
+
+## What this demonstrates
+
+- **MCP Lifecycle Operator** owns the lifecycle of the MCP server: it reconciles
+  an `MCPServer` resource into a Deployment and a Service (`everything-mcp-server`,
+  exposing port 3001). The MCP application behind that Service serves MCP
+  traffic at the `/mcp` path.
+- **kube-agentic-networking** routes to that Service through an `XBackend`. The
+  `XBackend` references the Service by name/port/path, an `HTTPRoute` routes
+  traffic from a `Gateway` to that `XBackend`, and the kube-agentic-networking
+  controller programs an Envoy proxy accordingly.
+
+```
+MCPServer --(operator creates)--> Service (everything-mcp-server:3001/mcp)
+                                        ^
+                                        | referenced by
+                                    XBackend (everything-mcp-backend)
+                                        ^
+                                        | backendRefs
+                                    HTTPRoute (everything-mcp-route)
+                                        ^
+                                        | parentRefs
+                                    Gateway (everything-mcp-gateway)
+```
+
+This example intentionally stops at routing. kube-agentic-networking also
+supports MCP method-level authorization via `XAccessPolicy` — see
+[Optional: tool-level authorization](#optional-tool-level-authorization) below
+for a pointer, but no `XAccessPolicy` is included here.
+
+## Prerequisites
+
+- A Kubernetes cluster.
+- **MCP Lifecycle Operator** CRDs installed and the controller running (`make install`,
+  `make run` — see the [main README](../../README.md)).
+- **kube-agentic-networking** installed according to its current official
+  quickstart / installation instructions:
+  <https://github.com/kubernetes-sigs/kube-agentic-networking>
+  (hosted quickstart: <https://kube-agentic-networking.sigs.k8s.io/guides/quickstart/>).
+  Installing it provisions the `kube-agentic-networking` `GatewayClass` used by
+  this example, along with the CRDs and controller it depends on. Follow the
+  upstream instructions in full rather than installing pieces individually —
+  the setup does more than install CRDs and a Deployment.
+
+## Deployment
+
+1. Deploy the MCP server:
+
+   ```bash
+   kubectl apply -f examples/agentic-networking/mcpserver.yaml
+   ```
+
+2. Wait for it to become ready:
+
+   ```bash
+   kubectl wait --for=condition=Ready mcpserver/everything-mcp-server -n default --timeout=2m
+   kubectl get mcpserver everything-mcp-server -n default
+   ```
+
+3. Deploy the Gateway API / kube-agentic-networking resources:
+
+   ```bash
+   kubectl apply -f examples/agentic-networking/networking.yaml
+   ```
+
+## Verification
+
+### MCP Lifecycle Operator side
+
+```bash
+# MCPServer should show Ready=True and Accepted=True
+kubectl get mcpserver everything-mcp-server -n default
+
+# The operator-managed Service (created automatically for the MCPServer)
+kubectl get svc everything-mcp-server -n default
+```
+
+### kube-agentic-networking side
+
+```bash
+kubectl get xbackend everything-mcp-backend -n default -o yaml
+```
+
+Confirm `spec.mcp` matches the Service above (`serviceName: everything-mcp-server`,
+`port: 3001`, `path: /mcp`). XBackend currently does not expose a readiness
+condition. Verify that its spec references the expected Service, and use the
+Gateway and HTTPRoute status conditions below to verify routing reconciliation.
+
+```bash
+kubectl get gateway everything-mcp-gateway -n default -o yaml
+# or, just the conditions and assigned address:
+kubectl get gateway everything-mcp-gateway -n default \
+  -o jsonpath='{.status.conditions}{"\n"}{.status.addresses}{"\n"}'
+```
+
+Look for `Programmed=True` and `Accepted=True` in `status.conditions`, and at
+least one entry under `status.addresses`.
+
+```bash
+kubectl get httproute everything-mcp-route -n default -o yaml
+```
+
+Look at `status.parents[].conditions` for `Accepted=True` and
+`ResolvedRefs=True`.
+
+## Traffic verification through the Gateway
+
+This example does not include a copy/paste `curl` command for sending an actual
+MCP request through the Gateway. The current kube-agentic-networking quickstart
+puts the Gateway listener behind kube-agentic-networking's built-in SPIFFE-based
+mTLS identity system, which requires client certificates issued through the
+Kubernetes `PodCertificateRequest`/`ClusterTrustBundle` APIs. Those APIs are
+alpha and, in kube-agentic-networking's own development setup, require a
+purpose-built kind cluster with `PodCertificateRequest`, `ClusterTrustBundle`,
+and `ClusterTrustBundleProjection` feature gates enabled — not something a
+generic cluster has by default.
+
+To exercise real traffic through the Gateway (including issuing an identity for
+your test client), follow kube-agentic-networking's own quickstart:
+<https://kube-agentic-networking.sigs.k8s.io/guides/quickstart/>. Its "Bring
+Your Own Agent" section documents how to point an existing workload at a
+Gateway once that identity infrastructure is set up.
+
+### Troubleshooting the MCP backend directly (bypasses the Gateway)
+
+This checks that the MCP server itself is healthy — it does **not** exercise
+kube-agentic-networking's routing or authorization path:
+
+```bash
+kubectl port-forward svc/everything-mcp-server -n default 3001:3001
+```
+
+Then connect with an MCP client at `http://localhost:3001/mcp`.
+
+## Optional: tool-level authorization
+
+kube-agentic-networking also supports fine-grained, MCP method-level
+authorization through the `XAccessPolicy` resource — for example, allowing a
+given `ServiceAccount` to call only specific tools (`tools/call` with specific
+tool-name params) on the backend defined here. This example does not include
+one. See:
+
+- The `XAccessPolicy` API:
+  <https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/api/v1alpha1/accesspolicy_types.go>
+- A worked example targeting an `XBackend`:
+  <https://github.com/kubernetes-sigs/kube-agentic-networking/blob/main/site-src/guides/quickstart/policy/e2e.yaml>
+
+## Cleanup
+
+```bash
+kubectl delete -f examples/agentic-networking/networking.yaml
+kubectl delete -f examples/agentic-networking/mcpserver.yaml
+```

--- a/examples/agentic-networking/README.md
+++ b/examples/agentic-networking/README.md
@@ -12,16 +12,13 @@ traffic.
   an `MCPServer` resource into a Deployment and a Service (`everything-mcp-server`,
   exposing port 3001). The MCP application behind that Service serves MCP
   traffic at the `/mcp` path.
-- **kube-agentic-networking** routes to that Service through an `XBackend`. The
-  `XBackend` references the Service by name/port/path, an `HTTPRoute` routes
-  traffic from a `Gateway` to that `XBackend`, and the kube-agentic-networking
-  controller programs an Envoy proxy accordingly.
+- **kube-agentic-networking** routes directly to that Service: an `HTTPRoute`
+  backendRef points at the Service by name/port, the `HTTPRoute` attaches to a
+  `Gateway`, and the kube-agentic-networking controller programs an Envoy
+  proxy accordingly.
 
-```
+```text
 MCPServer --(operator creates)--> Service (everything-mcp-server:3001/mcp)
-                                        ^
-                                        | referenced by
-                                    XBackend (everything-mcp-backend)
                                         ^
                                         | backendRefs
                                     HTTPRoute (everything-mcp-route)
@@ -30,10 +27,10 @@ MCPServer --(operator creates)--> Service (everything-mcp-server:3001/mcp)
                                     Gateway (everything-mcp-gateway)
 ```
 
-This example intentionally stops at routing. kube-agentic-networking also
-supports MCP method-level authorization via `XAccessPolicy` — see
+This example intentionally stops at routing, using a direct Service
+`backendRef` rather than kube-agentic-networking's `XBackend` resource — see
 [Optional: tool-level authorization](#optional-tool-level-authorization) below
-for a pointer, but no `XAccessPolicy` is included here.
+for why that matters if you want to add policy later.
 
 ## Prerequisites
 
@@ -84,14 +81,9 @@ kubectl get svc everything-mcp-server -n default
 
 ### kube-agentic-networking side
 
-```bash
-kubectl get xbackend everything-mcp-backend -n default -o yaml
-```
-
-Confirm `spec.mcp` matches the Service above (`serviceName: everything-mcp-server`,
-`port: 3001`, `path: /mcp`). XBackend currently does not expose a readiness
-condition. Verify that its spec references the expected Service, and use the
-Gateway and HTTPRoute status conditions below to verify routing reconciliation.
+This example routes directly to the Service, so there is no intermediate
+backend resource to inspect here — use the Gateway and HTTPRoute status
+conditions below to verify routing reconciliation.
 
 ```bash
 kubectl get gateway everything-mcp-gateway -n default -o yaml
@@ -115,12 +107,13 @@ Look at `status.parents[].conditions` for `Accepted=True` and
 This example does not include a copy/paste `curl` command for sending an actual
 MCP request through the Gateway. The current kube-agentic-networking quickstart
 puts the Gateway listener behind kube-agentic-networking's built-in SPIFFE-based
-mTLS identity system, which requires client certificates issued through the
-Kubernetes `PodCertificateRequest`/`ClusterTrustBundle` APIs. Those APIs are
-alpha and, in kube-agentic-networking's own development setup, require a
-purpose-built kind cluster with `PodCertificateRequest`, `ClusterTrustBundle`,
-and `ClusterTrustBundleProjection` feature gates enabled — not something a
-generic cluster has by default.
+mTLS identity system, which requires client certificates issued through
+Kubernetes certificate APIs (`PodCertificateRequest`, `ClusterTrustBundle`)
+that are Beta and disabled by default — not something a generic cluster has
+enabled out of the box. The exact feature gates and `--runtime-config` flags
+needed can shift between Kubernetes releases, so rather than duplicate them
+here, follow kube-agentic-networking's own versioned quickstart below, which
+sets up a cluster with the current requirements already applied.
 
 To exercise real traffic through the Gateway (including issuing an identity for
 your test client), follow kube-agentic-networking's own quickstart:
@@ -144,7 +137,9 @@ Then connect with an MCP client at `http://localhost:3001/mcp`.
 kube-agentic-networking also supports fine-grained, MCP method-level
 authorization through the `XAccessPolicy` resource — for example, allowing a
 given `ServiceAccount` to call only specific tools (`tools/call` with specific
-tool-name params) on the backend defined here. This example does not include
+tool-name params). This currently requires routing through an `XBackend`
+rather than a direct Service `backendRef`: `XAccessPolicy` can only target an
+`XBackend` or a `Gateway`, not a plain Service. This example does not include
 one. See:
 
 - The `XAccessPolicy` API:

--- a/examples/agentic-networking/mcpserver.yaml
+++ b/examples/agentic-networking/mcpserver.yaml
@@ -1,0 +1,13 @@
+apiVersion: mcp.x-k8s.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: everything-mcp-server
+  namespace: default
+spec:
+  source:
+    type: ContainerImage
+    containerImage:
+      ref: quay.io/matzew/mcp-everything@sha256:537cdedad807bb56140caca9c332d3577b16e533584164bbc3f27abac7b5ba15
+  config:
+    port: 3001
+    path: /mcp

--- a/examples/agentic-networking/networking.yaml
+++ b/examples/agentic-networking/networking.yaml
@@ -1,0 +1,50 @@
+---
+# Gateway using the kube-agentic-networking GatewayClass.
+# The controller provisions the Envoy data plane for this Gateway.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: everything-mcp-gateway
+  namespace: default
+spec:
+  gatewayClassName: kube-agentic-networking
+  listeners:
+    - name: https-listener
+      protocol: HTTPS
+      port: 10001
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# XBackend references the Service created by the MCPServer above by name/port/path.
+apiVersion: agentic.networking.x-k8s.io/v0alpha0
+kind: XBackend
+metadata:
+  name: everything-mcp-backend
+  namespace: default
+spec:
+  mcp:
+    serviceName: everything-mcp-server
+    port: 3001
+    path: /mcp
+---
+# HTTPRoute routes /mcp on the Gateway straight through to the XBackend's /mcp path.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: everything-mcp-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: everything-mcp-gateway
+      namespace: default
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      backendRefs:
+        - name: everything-mcp-backend
+          group: agentic.networking.x-k8s.io
+          kind: XBackend
+          namespace: default

--- a/examples/agentic-networking/networking.yaml
+++ b/examples/agentic-networking/networking.yaml
@@ -16,19 +16,10 @@ spec:
         namespaces:
           from: Same
 ---
-# XBackend references the Service created by the MCPServer above by name/port/path.
-apiVersion: agentic.networking.x-k8s.io/v0alpha0
-kind: XBackend
-metadata:
-  name: everything-mcp-backend
-  namespace: default
-spec:
-  mcp:
-    serviceName: everything-mcp-server
-    port: 3001
-    path: /mcp
----
-# HTTPRoute routes /mcp on the Gateway straight through to the XBackend's /mcp path.
+# HTTPRoute routes /mcp on the Gateway straight to the Service created by the
+# MCPServer above. kube-agentic-networking supports HTTPRoute backendRefs
+# directly to a core Service, so no XBackend indirection is needed for plain
+# routing (XBackend is only required to attach a backend-scoped XAccessPolicy).
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -44,7 +35,5 @@ spec:
             type: PathPrefix
             value: /mcp
       backendRefs:
-        - name: everything-mcp-backend
-          group: agentic.networking.x-k8s.io
-          kind: XBackend
-          namespace: default
+        - name: everything-mcp-server
+          port: 3001


### PR DESCRIPTION
## Summary

- add an `agentic-networking` example that connects an operator-managed MCPServer to kube-agentic-networking
- route the generated MCP Service through `XBackend`, `HTTPRoute`, and a `Gateway`
- reuse the existing pinned Everything MCP Server example
- document deployment, status verification, Gateway traffic prerequisites, and optional `XAccessPolicy` authorization

## Related issue

Fixes #33

## Verification

- `make verify`
- `make lint`
- `git diff --check`
- both new YAML manifests parse successfully

## Notes

The example intentionally keeps the core integration focused on:

`MCPServer -> Service -> XBackend -> HTTPRoute -> Gateway`

It does not include an `XAccessPolicy`; method-level authorization is documented as an optional follow-up.

The current kube-agentic-networking quickstart uses SPIFFE-based mTLS and Kubernetes certificate APIs for actual Gateway traffic. This PR therefore documents resource/status verification and points to the upstream quickstart for full data-plane testing rather than duplicating or inventing its identity setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agentic networking example for exposing an MCP server through Gateway API routing.
  * Added deployment manifests for the MCP server, HTTPS Gateway, backend configuration, and HTTP route.
  * Added guidance for prerequisites, deployment, verification, troubleshooting, optional authorization, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->