### PR TITLE
Pin release image to v0.3.0

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
 - logging_config.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+images:
+- name: controller
+  newName: registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator
+  newTag: v0.3.0


### PR DESCRIPTION
> Generated with [Claude Code](https://claude.ai/code)

## Summary
- Pins the controller image to `registry.k8s.io/mcp-lifecycle-operator/mcp-lifecycle-operator:v0.3.0` via `kustomize edit set image` in `config/manager/kustomization.yaml`
- Part of the [v0.3.0 release checklist](https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/361)

## Test plan
- [ ] CI passes on the release branch
- [ ] Verify `kustomize build config/default` produces the correct image reference

🤖 Generated with [Claude Code](https://claude.ai/code)

closes #361 partially