### PR TITLE
Test/e2e v1beta1 conversion

### DIFF
--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/scenario"
@@ -60,11 +60,11 @@ func TestStorageConfigMap(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "storage-cm", true,
-				f.WithStorage(mcpv1alpha1.StorageMount{
+				f.WithStorage(mcpv1beta1.StorageMount{
 					Path:        "/etc/mcp-config",
-					Permissions: mcpv1alpha1.MountPermissionsReadOnly,
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeConfigMap,
+					Permissions: mcpv1beta1.MountPermissionsReadOnly,
+					Source: mcpv1beta1.StorageSource{
+						Type: mcpv1beta1.StorageTypeConfigMap,
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "test-config"},
 						},
@@ -133,11 +133,11 @@ func TestStorageSecret(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "storage-secret", true,
-				f.WithStorage(mcpv1alpha1.StorageMount{
+				f.WithStorage(mcpv1beta1.StorageMount{
 					Path:        "/etc/mcp-secrets",
-					Permissions: mcpv1alpha1.MountPermissionsReadOnly,
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeSecret,
+					Permissions: mcpv1beta1.MountPermissionsReadOnly,
+					Source: mcpv1beta1.StorageSource{
+						Type: mcpv1beta1.StorageTypeSecret,
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: "test-secret",
 						},
@@ -196,11 +196,11 @@ func TestStorageEmptyDir(t *testing.T) {
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			sizeLimit := resource.MustParse("100Mi")
 			return f.SetupMCPServer(ctx, t, cfg, "storage-empty", true,
-				f.WithStorage(mcpv1alpha1.StorageMount{
+				f.WithStorage(mcpv1beta1.StorageMount{
 					Path:        "/tmp/scratch",
-					Permissions: mcpv1alpha1.MountPermissionsReadWrite,
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeEmptyDir,
+					Permissions: mcpv1beta1.MountPermissionsReadWrite,
+					Source: mcpv1beta1.StorageSource{
+						Type: mcpv1beta1.StorageTypeEmptyDir,
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &sizeLimit,
 						},
@@ -269,11 +269,11 @@ func TestStorageRecursiveReadOnly(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "storage-rro", true,
-				f.WithStorage(mcpv1alpha1.StorageMount{
+				f.WithStorage(mcpv1beta1.StorageMount{
 					Path:        "/etc/rro-config",
-					Permissions: mcpv1alpha1.MountPermissionsRecursiveReadOnly,
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeConfigMap,
+					Permissions: mcpv1beta1.MountPermissionsRecursiveReadOnly,
+					Source: mcpv1beta1.StorageSource{
+						Type: mcpv1beta1.StorageTypeConfigMap,
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "rro-config"},
 						},
@@ -347,31 +347,31 @@ func TestStorageMultipleMounts(t *testing.T) {
 			sizeLimit := resource.MustParse("50Mi")
 			return f.SetupMCPServer(ctx, t, cfg, "storage-multi", true,
 				f.WithStorage(
-					mcpv1alpha1.StorageMount{
+					mcpv1beta1.StorageMount{
 						Path:        "/etc/config",
-						Permissions: mcpv1alpha1.MountPermissionsReadOnly,
-						Source: mcpv1alpha1.StorageSource{
-							Type: mcpv1alpha1.StorageTypeConfigMap,
+						Permissions: mcpv1beta1.MountPermissionsReadOnly,
+						Source: mcpv1beta1.StorageSource{
+							Type: mcpv1beta1.StorageTypeConfigMap,
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "multi-cm"},
 							},
 						},
 					},
-					mcpv1alpha1.StorageMount{
+					mcpv1beta1.StorageMount{
 						Path:        "/etc/secrets",
-						Permissions: mcpv1alpha1.MountPermissionsReadOnly,
-						Source: mcpv1alpha1.StorageSource{
-							Type: mcpv1alpha1.StorageTypeSecret,
+						Permissions: mcpv1beta1.MountPermissionsReadOnly,
+						Source: mcpv1beta1.StorageSource{
+							Type: mcpv1beta1.StorageTypeSecret,
 							Secret: &corev1.SecretVolumeSource{
 								SecretName: "multi-secret",
 							},
 						},
 					},
-					mcpv1alpha1.StorageMount{
+					mcpv1beta1.StorageMount{
 						Path:        "/tmp/data",
-						Permissions: mcpv1alpha1.MountPermissionsReadWrite,
-						Source: mcpv1alpha1.StorageSource{
-							Type:     mcpv1alpha1.StorageTypeEmptyDir,
+						Permissions: mcpv1beta1.MountPermissionsReadWrite,
+						Source: mcpv1beta1.StorageSource{
+							Type:     mcpv1beta1.StorageTypeEmptyDir,
 							EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: &sizeLimit},
 						},
 					},
@@ -474,19 +474,19 @@ func TestCustomPort(t *testing.T) {
 			t.Log("Service has port 9090")
 			return ctx
 		}).
-		Assess("status address is unset when not Ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("status address is unset when not Available", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerCondition(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, 3*time.Minute)
+				"Available", metav1.ConditionFalse, 3*time.Minute)
 
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to get MCPServer: %v", err)
 			}
 
 			f.AssertAddressUnset(t, server)
-			t.Log("status.address.url is unset while Ready=False")
+			t.Log("status.address.url is unset while Available=False")
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -524,17 +524,17 @@ func TestSamePortDifferentNamespaces(t *testing.T) {
 			ctx = context.WithValue(ctx, f.ContextKey("serverB"), serverB)
 
 			r := cfg.Client().Resources()
-			f.WaitForMCPServerCondition(ctx, t, r, serverB, "Ready", metav1.ConditionTrue)
-			t.Log("both MCPServers are Ready")
+			f.WaitForMCPServerCondition(ctx, t, r, serverB, "Available", metav1.ConditionTrue)
+			t.Log("both MCPServers are Available")
 
 			return ctx
 		}).
 		Assess("both servers have independent Deployments and Services", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			serverA := f.ServerFromContext(ctx)
-			serverB := ctx.Value(f.ContextKey("serverB")).(*mcpv1alpha1.MCPServer)
+			serverB := ctx.Value(f.ContextKey("serverB")).(*mcpv1beta1.MCPServer)
 			r := cfg.Client().Resources()
 
-			for _, server := range []*mcpv1alpha1.MCPServer{serverA, serverB} {
+			for _, server := range []*mcpv1beta1.MCPServer{serverA, serverB} {
 				dep := &appsv1.Deployment{}
 				if err := r.Get(ctx, server.Name, server.Namespace, dep); err != nil {
 					t.Fatalf("Deployment not found for %s/%s: %v", server.Namespace, server.Name, err)
@@ -559,7 +559,7 @@ func TestSamePortDifferentNamespaces(t *testing.T) {
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// Clean up server B and its namespace
-			serverB := ctx.Value(f.ContextKey("serverB")).(*mcpv1alpha1.MCPServer)
+			serverB := ctx.Value(f.ContextKey("serverB")).(*mcpv1beta1.MCPServer)
 			r := cfg.Client().Resources()
 			if err := r.Delete(ctx, serverB); err != nil {
 				t.Logf("failed to delete server B: %v", err)
@@ -886,7 +886,7 @@ func TestCustomMetadataUpdate(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1beta1.MCPServer) {
 				s.Spec.ExtraLabels = map[string]string{"team": "beta", "tier": "backend"}
 			})
 			t.Log("updated MCPServer labels to {team:beta, tier:backend}")

--- a/test/e2e/conversion_test.go
+++ b/test/e2e/conversion_test.go
@@ -1,0 +1,173 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
+	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
+	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
+	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/speed"
+)
+
+// TestConversionWebhookRoundTrip exercises the deployed conversion webhook
+// (not the in-process conversion functions unit-tested in the api package):
+// a v1alpha1 MCPServer is applied with a typed v1alpha1 client, then re-fetched
+// at v1beta1 (the storage version). It asserts the spec round-trips and that the
+// controller reconciles the converted object identically to a native v1beta1 one.
+func TestConversionWebhookRoundTrip(t *testing.T) {
+	t.Parallel()
+	const (
+		name = "convert-alpha"
+		port = int32(8080)
+	)
+
+	feature := features.New("v1alpha1 MCPServer round-trips through the deployed conversion webhook").
+		WithLabel(category.Label, category.Configuration).
+		WithLabel(speed.Label, speed.Moderate).
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns, ok := ctx.Value(f.NsKey).(string)
+			if !ok || ns == "" {
+				t.Fatal("namespace not found in context; ensure BeforeEachTest has run")
+			}
+			r := cfg.Client().Resources()
+
+			// Build and apply a v1alpha1 object. The API server stores it as
+			// v1beta1, invoking the deployed conversion webhook on write.
+			alpha := &mcpv1alpha1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+				Spec: mcpv1alpha1.MCPServerSpec{
+					Source: mcpv1alpha1.Source{
+						Type: mcpv1alpha1.SourceTypeContainerImage,
+						ContainerImage: &mcpv1alpha1.ContainerImageSource{
+							Ref: f.DefaultMCPServerImage,
+						},
+					},
+					Config: mcpv1alpha1.ServerConfig{
+						Port:      port,
+						Arguments: []string{"--port", "8080", "--read-only"},
+					},
+				},
+			}
+			if err := r.Create(ctx, alpha); err != nil {
+				t.Fatalf("failed to create v1alpha1 MCPServer: %v", err)
+			}
+			t.Logf("created v1alpha1 MCPServer %s/%s", ns, name)
+			return ctx
+		}).
+		Assess("re-fetch at v1beta1 returns equivalent spec", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns := ctx.Value(f.NsKey).(string)
+			r := cfg.Client().Resources()
+
+			// Re-fetch the same object as v1beta1 (conversion on read).
+			beta := &mcpv1beta1.MCPServer{}
+			if err := r.Get(ctx, name, ns, beta); err != nil {
+				t.Fatalf("failed to get MCPServer at v1beta1: %v", err)
+			}
+
+			if beta.Spec.Source.Type != mcpv1beta1.SourceTypeContainerImage {
+				t.Errorf("source type not preserved: got %q", beta.Spec.Source.Type)
+			}
+			if beta.Spec.Source.ContainerImage == nil {
+				t.Fatal("containerImage dropped during conversion")
+			}
+			if got := beta.Spec.Source.ContainerImage.Ref; got != f.DefaultMCPServerImage {
+				t.Errorf("image ref not preserved: got %q, want %q", got, f.DefaultMCPServerImage)
+			}
+			if beta.Spec.Config.Port != port {
+				t.Errorf("port not preserved: got %d, want %d", beta.Spec.Config.Port, port)
+			}
+			t.Logf("v1alpha1 object read back at v1beta1 with equivalent spec (image=%s port=%d)",
+				beta.Spec.Source.ContainerImage.Ref, beta.Spec.Config.Port)
+			return ctx
+		}).
+		Assess("re-fetch at v1alpha1 exercises the reverse conversion path", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns := ctx.Value(f.NsKey).(string)
+			r := cfg.Client().Resources()
+
+			// The object is stored as v1beta1, so a Get at v1alpha1 goes through
+			// the webhook (v1beta1 -> v1alpha1). This is the only path that
+			// exercises the reverse conversion; a v1beta1 Get reads storage
+			// directly and would let a regression here pass unnoticed.
+			alpha := &mcpv1alpha1.MCPServer{}
+			if err := r.Get(ctx, name, ns, alpha); err != nil {
+				t.Fatalf("failed to get MCPServer at v1alpha1: %v", err)
+			}
+
+			if alpha.Spec.Source.Type != mcpv1alpha1.SourceTypeContainerImage {
+				t.Errorf("source type not preserved: got %q", alpha.Spec.Source.Type)
+			}
+			if alpha.Spec.Source.ContainerImage == nil {
+				t.Fatal("containerImage dropped during reverse conversion")
+			}
+			if got := alpha.Spec.Source.ContainerImage.Ref; got != f.DefaultMCPServerImage {
+				t.Errorf("image ref not preserved: got %q, want %q", got, f.DefaultMCPServerImage)
+			}
+			if alpha.Spec.Config.Port != port {
+				t.Errorf("port not preserved: got %d, want %d", alpha.Spec.Config.Port, port)
+			}
+			wantArgs := []string{"--port", "8080", "--read-only"}
+			if !slices.Equal(alpha.Spec.Config.Arguments, wantArgs) {
+				t.Errorf("arguments not preserved: got %v, want %v", alpha.Spec.Config.Arguments, wantArgs)
+			}
+			t.Logf("v1beta1 object read back at v1alpha1 with equivalent spec (image=%s port=%d args=%v)",
+				alpha.Spec.Source.ContainerImage.Ref, alpha.Spec.Config.Port, alpha.Spec.Config.Arguments)
+			return ctx
+		}).
+		Assess("converted object reconciles to Available and Verified", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns := ctx.Value(f.NsKey).(string)
+			r := cfg.Client().Resources()
+
+			beta := &mcpv1beta1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+			f.WaitForMCPServerCondition(ctx, t, r, beta, "Available", metav1.ConditionTrue, 3*time.Minute)
+			f.WaitForMCPServerCondition(ctx, t, r, beta, "Verified", metav1.ConditionTrue, 3*time.Minute)
+
+			if err := r.Get(ctx, name, ns, beta); err != nil {
+				t.Fatalf("failed to re-fetch MCPServer: %v", err)
+			}
+			f.AssertAddressURL(t, beta, port)
+			t.Logf("converted MCPServer reconciled: Available=True, Verified=True, address=%s", beta.Status.Address.URL)
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feature)
+}
+
+// TestConversionWebhookUnreachable documents the webhook-unavailable failure
+// contract (Contract C). Exercising it would require tearing down the deployed
+// conversion webhook, which destabilizes the shared cluster for the parallel
+// suite. It is therefore skipped rather than silently omitted: the negative path
+// (API request fails with a clear error rather than returning a field-dropped
+// object) is covered by the webhook's own unit tests and by the CRD's
+// failurePolicy=Fail, which the deploy step asserts is configured.
+func TestConversionWebhookUnreachable(t *testing.T) {
+	t.Skip("webhook-unreachable path is not exercised in the shared e2e cluster; " +
+		"see Contract C in specs/006-v1beta1-e2e/contracts/e2e-scenarios.md")
+}

--- a/test/e2e/failure_scenarios_test.go
+++ b/test/e2e/failure_scenarios_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/scenario"
@@ -48,22 +48,22 @@ func TestImagePullFailure(t *testing.T) {
 				f.WithImage("invalid.example.com/nonexistent/image:v0.0.1"),
 			)
 		}).
-		Assess("Ready condition reports image pull failure", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Available condition reports image pull failure", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionMessageContains(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "DeploymentUnavailable", "Image pull failed",
+				"Available", metav1.ConditionFalse, "DeploymentUnavailable", "Image pull failed",
 				3*time.Minute)
 
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to get MCPServer: %v", err)
 			}
-			ready := f.GetMCPServerCondition(server, "Ready")
-			t.Logf("Ready condition: status=%s reason=%s message=%q", ready.Status, ready.Reason, ready.Message)
+			available := f.GetMCPServerCondition(server, "Available")
+			t.Logf("Available condition: status=%s reason=%s message=%q", available.Status, available.Reason, available.Message)
 
 			if server.Status.Address != nil && server.Status.Address.URL != "" {
-				t.Fatalf("expected status.address.url to be unset when Ready=False, got %q", server.Status.Address.URL)
+				t.Fatalf("expected status.address.url to be unset when Available=False, got %q", server.Status.Address.URL)
 			}
 
 			return ctx
@@ -87,7 +87,7 @@ func TestImagePullFailure(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.AssertConditionStable(ctx, t, r, server, "Ready", metav1.ConditionFalse, 15*time.Second)
+			f.AssertConditionStable(ctx, t, r, server, "Available", metav1.ConditionFalse, 15*time.Second)
 
 			return ctx
 		}).
@@ -113,26 +113,26 @@ func TestContainerCrashLoop(t *testing.T) {
 				f.WithSecurityContext(&corev1.SecurityContext{}),
 			)
 		}).
-		Assess("Ready condition reports crash loop", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Available condition reports crash loop", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionMessageContains(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "DeploymentUnavailable", "Container crashing",
+				"Available", metav1.ConditionFalse, "DeploymentUnavailable", "Container crashing",
 				4*time.Minute)
 
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to get MCPServer: %v", err)
 			}
-			ready := f.GetMCPServerCondition(server, "Ready")
-			t.Logf("Ready condition: status=%s reason=%s message=%q", ready.Status, ready.Reason, ready.Message)
+			available := f.GetMCPServerCondition(server, "Available")
+			t.Logf("Available condition: status=%s reason=%s message=%q", available.Status, available.Reason, available.Message)
 
-			if !strings.Contains(ready.Message, "exit code") {
-				t.Errorf("expected message to contain exit code details, got %q", ready.Message)
+			if !strings.Contains(available.Message, "exit code") {
+				t.Errorf("expected message to contain exit code details, got %q", available.Message)
 			}
 
 			if server.Status.Address != nil && server.Status.Address.URL != "" {
-				t.Fatalf("expected status.address.url to be unset when Ready=False, got %q", server.Status.Address.URL)
+				t.Fatalf("expected status.address.url to be unset when Available=False, got %q", server.Status.Address.URL)
 			}
 
 			return ctx
@@ -156,23 +156,34 @@ func TestMCPHandshakeFailure(t *testing.T) {
 				f.WithPath("/not-mcp"),
 			)
 		}).
-		Assess("Ready condition reports MCP endpoint unavailable", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Verified condition reports MCP endpoint unavailable", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionReason(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "MCPEndpointUnavailable",
+				"Verified", metav1.ConditionFalse, "EndpointUnavailable",
 				5*time.Minute)
 
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to get MCPServer: %v", err)
 			}
-			ready := f.GetMCPServerCondition(server, "Ready")
-			t.Logf("Ready condition: status=%s reason=%s message=%q", ready.Status, ready.Reason, ready.Message)
+			verified := f.GetMCPServerCondition(server, "Verified")
+			t.Logf("Verified condition: status=%s reason=%s message=%q", verified.Status, verified.Reason, verified.Message)
 
-			if !strings.Contains(ready.Message, "MCP endpoint is not serving a valid MCP protocol") {
-				t.Errorf("expected message about MCP protocol failure, got %q", ready.Message)
+			if !strings.Contains(verified.Message, "MCP endpoint is not serving a valid MCP protocol") {
+				t.Errorf("expected message about MCP protocol failure, got %q", verified.Message)
 			}
+
+			// The workload itself is healthy (only the MCP endpoint is wrong),
+			// so the two-condition contract is Available=True with Verified=False.
+			available := f.GetMCPServerCondition(server, "Available")
+			if available == nil || available.Status != metav1.ConditionTrue {
+				t.Error("expected Available=True (workload is up; only the MCP endpoint is invalid)")
+			}
+
+			// status.address is published only when Verified=True; a failed
+			// handshake must not leak an address.
+			f.AssertAddressUnset(t, server)
 
 			return ctx
 		}).
@@ -237,12 +248,12 @@ func TestMissingConfigMapReference(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("Ready condition is False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Available condition is False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionReason(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "ConfigurationInvalid",
+				"Available", metav1.ConditionFalse, "ConfigurationInvalid",
 				30*time.Second)
 
 			return ctx
@@ -293,12 +304,12 @@ func TestMissingSecretReference(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("Ready condition is False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Available condition is False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionReason(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "ConfigurationInvalid",
+				"Available", metav1.ConditionFalse, "ConfigurationInvalid",
 				30*time.Second)
 
 			return ctx
@@ -319,10 +330,10 @@ func TestMissingStorageConfigMapReference(t *testing.T) {
 		WithLabel(scenario.Label, scenario.Failure).
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			return f.SetupMCPServer(ctx, t, cfg, "missing-storage", false,
-				f.WithStorage(mcpv1alpha1.StorageMount{
+				f.WithStorage(mcpv1beta1.StorageMount{
 					Path: "/etc/mcp-config",
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeConfigMap,
+					Source: mcpv1beta1.StorageSource{
+						Type: mcpv1beta1.StorageTypeConfigMap,
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: "nonexistent-storage-cm",
@@ -342,12 +353,12 @@ func TestMissingStorageConfigMapReference(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("Ready condition is False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Available condition is False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionReason(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "ConfigurationInvalid",
+				"Available", metav1.ConditionFalse, "ConfigurationInvalid",
 				30*time.Second)
 
 			return ctx
@@ -411,9 +422,10 @@ func TestRecoveryFromMissingConfigMap(t *testing.T) {
 				"Accepted", metav1.ConditionTrue, 2*time.Minute)
 			t.Log("Accepted=True after ConfigMap creation")
 
-			f.WaitForMCPServerCondition(ctx, t, r, server,
-				"Ready", metav1.ConditionTrue, 3*time.Minute)
-			t.Log("Ready=True — full recovery complete")
+			// Full recovery means the workload is back up (Available) and the
+			// MCP handshake succeeds again (Verified), not just Available.
+			f.WaitForMCPServerReconciledAndReady(ctx, t, r, server, 3*time.Minute)
+			t.Log("Available=True and Verified=True - full recovery complete")
 
 			return ctx
 		}).
@@ -436,14 +448,14 @@ func TestRecoveryFromImagePullFailure(t *testing.T) {
 				f.WithImage("invalid.example.com/nonexistent/image:v0.0.1"),
 			)
 		}).
-		Assess("initially Ready=False with image pull failure", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("initially Available=False with image pull failure", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionMessageContains(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "DeploymentUnavailable", "Image pull failed",
+				"Available", metav1.ConditionFalse, "DeploymentUnavailable", "Image pull failed",
 				3*time.Minute)
-			t.Log("confirmed Ready=False with image pull failure")
+			t.Log("confirmed Available=False with image pull failure")
 
 			return ctx
 		}).
@@ -451,13 +463,13 @@ func TestRecoveryFromImagePullFailure(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1beta1.MCPServer) {
 				s.Spec.Source.ContainerImage.Ref = f.DefaultMCPServerImage
 			})
 			t.Log("updated image to default MCP server image")
 
 			f.WaitForMCPServerReconciledAndReady(ctx, t, r, server, 5*time.Minute)
-			t.Log("Ready=True — recovery from image pull failure complete")
+			t.Log("Available=True and Verified=True - recovery from image pull failure complete")
 
 			return ctx
 		}).

--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -26,11 +26,11 @@ import (
 
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 )
 
 // AssertAddressURL verifies the MCPServer's status address URL matches the expected port and path.
-func AssertAddressURL(t *testing.T, server *mcpv1alpha1.MCPServer, port int32) {
+func AssertAddressURL(t *testing.T, server *mcpv1beta1.MCPServer, port int32) {
 	t.Helper()
 	path := server.Spec.Config.Path
 	if path == "" {
@@ -47,7 +47,7 @@ func AssertAddressURL(t *testing.T, server *mcpv1alpha1.MCPServer, port int32) {
 }
 
 // AssertAddressUnset verifies status.address.url is not published (issue #302).
-func AssertAddressUnset(t *testing.T, server *mcpv1alpha1.MCPServer) {
+func AssertAddressUnset(t *testing.T, server *mcpv1beta1.MCPServer) {
 	t.Helper()
 	if server.Status.Address != nil && server.Status.Address.URL != "" {
 		t.Fatalf("expected status.address.url to be unset, got %q", server.Status.Address.URL)
@@ -57,7 +57,7 @@ func AssertAddressUnset(t *testing.T, server *mcpv1alpha1.MCPServer) {
 // AssertConditionStable re-fetches the MCPServer repeatedly for the given duration
 // and fails if the condition ever deviates from the expected status.
 func AssertConditionStable(ctx context.Context, t *testing.T, r *resources.Resources,
-	server *mcpv1alpha1.MCPServer, condType string, status metav1.ConditionStatus, duration ...time.Duration) {
+	server *mcpv1beta1.MCPServer, condType string, status metav1.ConditionStatus, duration ...time.Duration) {
 	t.Helper()
 	d := 10 * time.Second
 	if len(duration) > 0 {
@@ -85,7 +85,7 @@ func AssertConditionStable(ctx context.Context, t *testing.T, r *resources.Resou
 }
 
 // GetMCPServerCondition returns a pointer to the named condition, or nil.
-func GetMCPServerCondition(server *mcpv1alpha1.MCPServer, condType string) *metav1.Condition {
+func GetMCPServerCondition(server *mcpv1beta1.MCPServer, condType string) *metav1.Condition {
 	for i := range server.Status.Conditions {
 		if server.Status.Conditions[i].Type == condType {
 			return &server.Status.Conditions[i]

--- a/test/e2e/framework/builders.go
+++ b/test/e2e/framework/builders.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 )
 
 const (
@@ -30,108 +30,108 @@ const (
 )
 
 // MCPServerOption configures an MCPServer for testing.
-type MCPServerOption func(*mcpv1alpha1.MCPServer)
+type MCPServerOption func(*mcpv1beta1.MCPServer)
 
 // WithPort sets the MCPServer port.
 func WithPort(port int32) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Config.Port = port
 	}
 }
 
 // WithImage sets the container image ref.
 func WithImage(ref string) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Source.ContainerImage.Ref = ref
 	}
 }
 
 // WithArguments sets the MCPServer container arguments.
 func WithArguments(args ...string) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Config.Arguments = args
 	}
 }
 
 // WithEnvFrom sets the MCPServer envFrom sources.
 func WithEnvFrom(envFrom ...corev1.EnvFromSource) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Config.EnvFrom = envFrom
 	}
 }
 
 // WithStorage sets the MCPServer storage mounts.
-func WithStorage(storage ...mcpv1alpha1.StorageMount) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+func WithStorage(storage ...mcpv1beta1.StorageMount) MCPServerOption {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Config.Storage = storage
 	}
 }
 
 // WithPath sets the MCPServer HTTP path.
 func WithPath(path string) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Config.Path = path
 	}
 }
 
 // WithSecurityContext sets the container security context.
 func WithSecurityContext(sc *corev1.SecurityContext) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Runtime.Security.SecurityContext = sc
 	}
 }
 
 // WithPodSecurityContext sets the pod-level security context.
 func WithPodSecurityContext(psc *corev1.PodSecurityContext) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Runtime.Security.PodSecurityContext = psc
 	}
 }
 
 // WithTransport sets the MCPServer transport configuration.
-func WithTransport(transport *mcpv1alpha1.TransportConfig) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+func WithTransport(transport *mcpv1beta1.TransportConfig) MCPServerOption {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Transport = transport
 	}
 }
 
 // WithExtraLabels sets custom labels on the MCPServer.
 func WithExtraLabels(labels map[string]string) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.ExtraLabels = labels
 	}
 }
 
 // WithExtraAnnotations sets custom annotations on the MCPServer.
 func WithExtraAnnotations(annotations map[string]string) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.ExtraAnnotations = annotations
 	}
 }
 
 // WithReplicas sets the number of pod replicas.
 func WithReplicas(n int32) MCPServerOption {
-	return func(s *mcpv1alpha1.MCPServer) {
+	return func(s *mcpv1beta1.MCPServer) {
 		s.Spec.Runtime.Replicas = &n
 	}
 }
 
 // NewMCPServer creates an MCPServer with sensible defaults for e2e tests.
 // Defaults: image=DefaultMCPServerImage, port=8080, args=["--port","8080","--read-only"].
-func NewMCPServer(name, namespace string, opts ...MCPServerOption) *mcpv1alpha1.MCPServer {
-	server := &mcpv1alpha1.MCPServer{
+func NewMCPServer(name, namespace string, opts ...MCPServerOption) *mcpv1beta1.MCPServer {
+	server := &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: mcpv1alpha1.MCPServerSpec{
-			Source: mcpv1alpha1.Source{
-				Type: mcpv1alpha1.SourceTypeContainerImage,
-				ContainerImage: &mcpv1alpha1.ContainerImageSource{
+		Spec: mcpv1beta1.MCPServerSpec{
+			Source: mcpv1beta1.Source{
+				Type: mcpv1beta1.SourceTypeContainerImage,
+				ContainerImage: &mcpv1beta1.ContainerImageSource{
 					Ref: DefaultMCPServerImage,
 				},
 			},
-			Config: mcpv1alpha1.ServerConfig{
+			Config: mcpv1beta1.ServerConfig{
 				Port:      8080,
 				Arguments: []string{"--port", "8080", "--read-only"},
 			},

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -38,7 +38,8 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
+	mcpcontroller "github.com/kubernetes-sigs/mcp-lifecycle-operator/internal/controller"
 )
 
 // ContextKey is used to store values in context.
@@ -51,13 +52,14 @@ const (
 
 // ServerFromContext extracts the MCPServer stored by SetupMCPServer.
 // Returns nil if the server was never stored in context.
-func ServerFromContext(ctx context.Context) *mcpv1alpha1.MCPServer {
-	s, _ := ctx.Value(ServerKey).(*mcpv1alpha1.MCPServer)
+func ServerFromContext(ctx context.Context) *mcpv1beta1.MCPServer {
+	s, _ := ctx.Value(ServerKey).(*mcpv1beta1.MCPServer)
 	return s
 }
 
-// SetupMCPServer creates an MCPServer, optionally waits for Ready, and stores it in context.
-// Pass waitForReady=true to block until the server reaches Ready=True before returning.
+// SetupMCPServer creates an MCPServer, optionally waits for it to become available,
+// and stores it in context. Pass waitForReady=true to block until the server reaches
+// Available=True before returning.
 func SetupMCPServer(ctx context.Context, t *testing.T, cfg *envconf.Config, name string, waitForReady bool, opts ...MCPServerOption) context.Context {
 	t.Helper()
 	ns, ok := ctx.Value(NsKey).(string)
@@ -73,8 +75,8 @@ func SetupMCPServer(ctx context.Context, t *testing.T, cfg *envconf.Config, name
 	t.Logf("created MCPServer %s/%s", ns, server.Name)
 
 	if waitForReady {
-		WaitForMCPServerCondition(ctx, t, r, server, "Ready", metav1.ConditionTrue)
-		t.Log("MCPServer is Ready")
+		WaitForMCPServerCondition(ctx, t, r, server, mcpcontroller.ConditionTypeAvailable, metav1.ConditionTrue)
+		t.Log("MCPServer is Available")
 	}
 
 	return context.WithValue(ctx, ServerKey, server)
@@ -83,7 +85,7 @@ func SetupMCPServer(ctx context.Context, t *testing.T, cfg *envconf.Config, name
 // WaitForMCPServerCondition polls until the named condition reaches the desired status.
 // An optional timeout can be provided; defaults to 3 minutes.
 func WaitForMCPServerCondition(ctx context.Context, t *testing.T, r *resources.Resources,
-	server *mcpv1alpha1.MCPServer, condType string, status metav1.ConditionStatus, timeout ...time.Duration) {
+	server *mcpv1beta1.MCPServer, condType string, status metav1.ConditionStatus, timeout ...time.Duration) {
 	t.Helper()
 	d := 3 * time.Minute
 	if len(timeout) > 0 {
@@ -91,7 +93,7 @@ func WaitForMCPServerCondition(ctx context.Context, t *testing.T, r *resources.R
 	}
 	err := wait.For(
 		conditions.New(r).ResourceMatch(server, func(obj k8s.Object) bool {
-			s := obj.(*mcpv1alpha1.MCPServer)
+			s := obj.(*mcpv1beta1.MCPServer)
 			for _, c := range s.Status.Conditions {
 				if c.Type == condType && c.Status == status {
 					return true
@@ -109,10 +111,13 @@ func WaitForMCPServerCondition(ctx context.Context, t *testing.T, r *resources.R
 }
 
 // WaitForMCPServerReconciledAndReady polls until the controller has reconciled the
-// current generation (observedGeneration >= generation) and Ready=True.
-// Use this after mutating the MCPServer spec to avoid seeing stale Ready from before the update.
+// current generation (observedGeneration >= generation) and the server is fully
+// ready: both Available=True (workload up) and Verified=True (MCP handshake
+// succeeded). Available alone leaves status.address unpublished, so callers that
+// assert full readiness must wait on both conditions.
+// Use this after mutating the MCPServer spec to avoid seeing stale status from before the update.
 func WaitForMCPServerReconciledAndReady(ctx context.Context, t *testing.T, r *resources.Resources,
-	server *mcpv1alpha1.MCPServer, timeout ...time.Duration) {
+	server *mcpv1beta1.MCPServer, timeout ...time.Duration) {
 	t.Helper()
 	d := 3 * time.Minute
 	if len(timeout) > 0 {
@@ -120,32 +125,36 @@ func WaitForMCPServerReconciledAndReady(ctx context.Context, t *testing.T, r *re
 	}
 	err := wait.For(
 		conditions.New(r).ResourceMatch(server, func(obj k8s.Object) bool {
-			s := obj.(*mcpv1alpha1.MCPServer)
+			s := obj.(*mcpv1beta1.MCPServer)
 			if s.Status.ObservedGeneration < s.Generation {
 				return false
 			}
+			var available, verified bool
 			for _, c := range s.Status.Conditions {
-				if c.Type == "Ready" && c.Status == metav1.ConditionTrue {
-					return true
+				switch {
+				case c.Type == mcpcontroller.ConditionTypeAvailable && c.Status == metav1.ConditionTrue:
+					available = true
+				case c.Type == mcpcontroller.ConditionTypeVerified && c.Status == metav1.ConditionTrue:
+					verified = true
 				}
 			}
-			return false
+			return available && verified
 		}),
 		wait.WithTimeout(d),
 		wait.WithInterval(2*time.Second),
 	)
 	if err != nil {
-		t.Fatalf("MCPServer %s/%s: timed out waiting for reconciled Ready: %v",
+		t.Fatalf("MCPServer %s/%s: timed out waiting for reconciled Available=True and Verified=True: %v",
 			server.Namespace, server.Name, err)
 	}
 }
 
 // WaitForMCPServerReconciled polls until the controller has reconciled the
 // current generation (observedGeneration >= generation) without requiring a
-// specific Ready status. Use this after spec mutations where the pod may not
-// become Ready (e.g. port changes when the container image uses a fixed port).
+// specific Available status. Use this after spec mutations where the pod may not
+// become available (e.g. port changes when the container image uses a fixed port).
 func WaitForMCPServerReconciled(ctx context.Context, t *testing.T, r *resources.Resources,
-	server *mcpv1alpha1.MCPServer, timeout ...time.Duration) {
+	server *mcpv1beta1.MCPServer, timeout ...time.Duration) {
 	t.Helper()
 	d := 3 * time.Minute
 	if len(timeout) > 0 {
@@ -153,7 +162,7 @@ func WaitForMCPServerReconciled(ctx context.Context, t *testing.T, r *resources.
 	}
 	err := wait.For(
 		conditions.New(r).ResourceMatch(server, func(obj k8s.Object) bool {
-			s := obj.(*mcpv1alpha1.MCPServer)
+			s := obj.(*mcpv1beta1.MCPServer)
 			return s.Status.ObservedGeneration >= s.Generation
 		}),
 		wait.WithTimeout(d),
@@ -169,7 +178,7 @@ func WaitForMCPServerReconciled(ctx context.Context, t *testing.T, r *resources.
 // WaitForMCPServerConditionReason polls until the named condition reaches the desired status and reason.
 // An optional timeout can be provided; defaults to 3 minutes.
 func WaitForMCPServerConditionReason(ctx context.Context, t *testing.T, r *resources.Resources,
-	server *mcpv1alpha1.MCPServer, condType string, status metav1.ConditionStatus, reason string, timeout ...time.Duration) {
+	server *mcpv1beta1.MCPServer, condType string, status metav1.ConditionStatus, reason string, timeout ...time.Duration) {
 	t.Helper()
 	d := 3 * time.Minute
 	if len(timeout) > 0 {
@@ -177,7 +186,7 @@ func WaitForMCPServerConditionReason(ctx context.Context, t *testing.T, r *resou
 	}
 	err := wait.For(
 		conditions.New(r).ResourceMatch(server, func(obj k8s.Object) bool {
-			s := obj.(*mcpv1alpha1.MCPServer)
+			s := obj.(*mcpv1beta1.MCPServer)
 			for _, c := range s.Status.Conditions {
 				if c.Type == condType && c.Status == status && c.Reason == reason {
 					return true
@@ -198,7 +207,7 @@ func WaitForMCPServerConditionReason(ctx context.Context, t *testing.T, r *resou
 // status and reason, and its message contains the given substring.
 // An optional timeout can be provided; defaults to 3 minutes.
 func WaitForMCPServerConditionMessageContains(ctx context.Context, t *testing.T, r *resources.Resources,
-	server *mcpv1alpha1.MCPServer, condType string, status metav1.ConditionStatus, reason string,
+	server *mcpv1beta1.MCPServer, condType string, status metav1.ConditionStatus, reason string,
 	messageSubstring string, timeout ...time.Duration) {
 	t.Helper()
 	d := 3 * time.Minute
@@ -207,7 +216,7 @@ func WaitForMCPServerConditionMessageContains(ctx context.Context, t *testing.T,
 	}
 	err := wait.For(
 		conditions.New(r).ResourceMatch(server, func(obj k8s.Object) bool {
-			s := obj.(*mcpv1alpha1.MCPServer)
+			s := obj.(*mcpv1beta1.MCPServer)
 			for _, c := range s.Status.Conditions {
 				if c.Type == condType && c.Status == status && c.Reason == reason &&
 					strings.Contains(c.Message, messageSubstring) {

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/scenario"
@@ -45,12 +45,16 @@ func TestMCPServerHappyPath(t *testing.T) {
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			return f.SetupMCPServer(ctx, t, cfg, "test-server", false)
 		}).
-		Assess("MCPServer becomes Ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("MCPServer becomes Available and Verified", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.WaitForMCPServerCondition(ctx, t, r, server, "Ready", metav1.ConditionTrue)
-			t.Log("MCPServer is Ready")
+			// Wait for full readiness (Available + Verified). status.address is
+			// only published once Verified=True, so the later "status fields are
+			// populated correctly" step (AssertAddressURL) would race a bare
+			// Available wait.
+			f.WaitForMCPServerReconciledAndReady(ctx, t, r, server)
+			t.Log("MCPServer is Available and Verified")
 
 			return ctx
 		}).
@@ -126,7 +130,7 @@ func TestMCPServerUpdatePort(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1beta1.MCPServer) {
 				s.Spec.Config.Port = 3002
 			})
 			t.Log("updated MCPServer port to 3002")
@@ -184,7 +188,7 @@ func TestMCPServerUpdatePort(t *testing.T) {
 				t.Fatal("expected a container port 3002 in the Deployment")
 			}
 
-			t.Logf("port update verified: address unset (not Ready), servicePort=%d, containerPort=3002",
+			t.Logf("port update verified: address unset (not Available), servicePort=%d, containerPort=3002",
 				svc.Spec.Ports[0].Port)
 
 			return ctx

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 )
 
@@ -50,8 +51,14 @@ func TestMain(m *testing.M) {
 
 	testenv = env.NewWithConfig(cfg)
 
-	// Register MCPServer types so the client can work with them.
-	if err := mcpv1alpha1.AddToScheme(cfg.Client().Resources().GetScheme()); err != nil {
+	// Register MCPServer types (both versions) so the client can work with
+	// them: v1beta1 is the storage version used by the bulk of the suite, and
+	// v1alpha1 is needed by the conversion test to exercise the deployed webhook.
+	scheme := cfg.Client().Resources().GetScheme()
+	if err := mcpv1beta1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
 		panic(err)
 	}
 

--- a/test/e2e/mcp_handshake_test.go
+++ b/test/e2e/mcp_handshake_test.go
@@ -53,9 +53,14 @@ func TestMCPHandshake(t *testing.T) {
 			t.Logf("MCP server pod %s is Running", pod.Name)
 			return ctx
 		}).
-		Assess("Accepted and Ready conditions are True", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Accepted, Available, and Verified conditions are True", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
+
+			// Setup only waits for Available=True, so Verified may still be
+			// transitioning. Wait for full readiness (Available + Verified)
+			// before asserting the conditions to avoid a flake.
+			f.WaitForMCPServerReconciledAndReady(ctx, t, r, server, 3*time.Minute)
 
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to get MCPServer: %v", err)
@@ -66,13 +71,21 @@ func TestMCPHandshake(t *testing.T) {
 				t.Fatal("Accepted condition is not True")
 			}
 
-			ready := f.GetMCPServerCondition(server, "Ready")
-			if ready == nil || ready.Status != metav1.ConditionTrue {
-				t.Fatal("Ready condition is not True")
+			// Full readiness is the two-condition contract: Available (workload
+			// up) and Verified (MCP handshake succeeded). Assert both, not just
+			// Verified, so a regression in either condition is caught.
+			available := f.GetMCPServerCondition(server, "Available")
+			if available == nil || available.Status != metav1.ConditionTrue {
+				t.Fatal("Available condition is not True")
+			}
+
+			verified := f.GetMCPServerCondition(server, "Verified")
+			if verified == nil || verified.Status != metav1.ConditionTrue {
+				t.Fatal("Verified condition is not True")
 			}
 
 			f.AssertAddressURL(t, server, mcpServerPort)
-			t.Logf("MCPServer status: address=%s, Accepted=True, Ready=True", server.Status.Address.URL)
+			t.Logf("MCPServer status: address=%s, Accepted=True, Available=True, Verified=True", server.Status.Address.URL)
 
 			return ctx
 		}).

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/speed"
@@ -143,7 +143,7 @@ func TestNetworkPolicyPortUpdate(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1beta1.MCPServer) {
 				s.Spec.Config.Port = 3002
 			})
 			t.Log("updated MCPServer port to 3002")

--- a/test/e2e/reconciliation_test.go
+++ b/test/e2e/reconciliation_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/scenario"
@@ -66,7 +66,7 @@ func TestImageUpdate(t *testing.T) {
 				t.Fatalf("test misconfigured: initial image %q is the same as update target", oldImage)
 			}
 
-			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1beta1.MCPServer) {
 				s.Spec.Source.ContainerImage.Ref = imageRef
 			})
 			t.Logf("updated image from %s to %s", oldImage, imageRef)
@@ -136,13 +136,13 @@ func TestStorageAddition(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
-				s.Spec.Config.Storage = []mcpv1alpha1.StorageMount{
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1beta1.MCPServer) {
+				s.Spec.Config.Storage = []mcpv1beta1.StorageMount{
 					{
 						Path:        "/etc/added-config",
-						Permissions: mcpv1alpha1.MountPermissionsReadOnly,
-						Source: mcpv1alpha1.StorageSource{
-							Type: mcpv1alpha1.StorageTypeConfigMap,
+						Permissions: mcpv1beta1.MountPermissionsReadOnly,
+						Source: mcpv1beta1.StorageSource{
+							Type: mcpv1beta1.StorageTypeConfigMap,
 							ConfigMap: &corev1.ConfigMapVolumeSource{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "add-config"},
 							},
@@ -220,11 +220,11 @@ func TestStorageRemoval(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "storage-rm", true,
-				f.WithStorage(mcpv1alpha1.StorageMount{
+				f.WithStorage(mcpv1beta1.StorageMount{
 					Path:        "/etc/remove-config",
-					Permissions: mcpv1alpha1.MountPermissionsReadOnly,
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeConfigMap,
+					Permissions: mcpv1beta1.MountPermissionsReadOnly,
+					Source: mcpv1beta1.StorageSource{
+						Type: mcpv1beta1.StorageTypeConfigMap,
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "remove-config"},
 						},
@@ -236,7 +236,7 @@ func TestStorageRemoval(t *testing.T) {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
-			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1alpha1.MCPServer) {
+			f.UpdateWithRetry(ctx, t, r, server, func(s *mcpv1beta1.MCPServer) {
 				s.Spec.Config.Storage = nil
 			})
 			t.Log("removed storage mount")
@@ -468,8 +468,8 @@ func TestDeploymentDeletion(t *testing.T) {
 				t.Fatalf("controller did not recreate Deployment: %v", err)
 			}
 
-			f.WaitForMCPServerCondition(ctx, t, r, server, "Ready", metav1.ConditionTrue)
-			t.Logf("Deployment recreated with new UID=%s, MCPServer is Ready", newDep.UID)
+			f.WaitForMCPServerCondition(ctx, t, r, server, "Available", metav1.ConditionTrue)
+			t.Logf("Deployment recreated with new UID=%s, MCPServer is Available", newDep.UID)
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -519,8 +519,8 @@ func TestServiceDeletion(t *testing.T) {
 				t.Fatalf("controller did not recreate Service: %v", err)
 			}
 
-			f.WaitForMCPServerCondition(ctx, t, r, server, "Ready", metav1.ConditionTrue)
-			t.Logf("Service recreated with new UID=%s, MCPServer is Ready", newSvc.UID)
+			f.WaitForMCPServerCondition(ctx, t, r, server, "Available", metav1.ConditionTrue)
+			t.Logf("Service recreated with new UID=%s, MCPServer is Available", newSvc.UID)
 			return ctx
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -720,8 +720,8 @@ func TestConfigMapDataUpdateTriggersRestart(t *testing.T) {
 			newHash := dep.Spec.Template.Annotations[configHashAnnotation]
 			t.Logf("config hash changed from %s to %s", initialHash, newHash)
 
-			f.WaitForMCPServerCondition(ctx, t, r, server, "Ready", metav1.ConditionTrue)
-			t.Log("MCPServer is Ready after config hash update")
+			f.WaitForMCPServerCondition(ctx, t, r, server, "Available", metav1.ConditionTrue)
+			t.Log("MCPServer is Available after config hash update")
 
 			return ctx
 		}).

--- a/test/e2e/tls_handshake_test.go
+++ b/test/e2e/tls_handshake_test.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/speed"
@@ -161,36 +161,36 @@ func TestTLSHandshake(t *testing.T) {
 					"--tls-cert", "/certs/tls.crt",
 					"--tls-key", "/certs/tls.key",
 				),
-				f.WithStorage(mcpv1alpha1.StorageMount{
+				f.WithStorage(mcpv1beta1.StorageMount{
 					Path: "/certs",
-					Source: mcpv1alpha1.StorageSource{
-						Type: mcpv1alpha1.StorageTypeSecret,
+					Source: mcpv1beta1.StorageSource{
+						Type: mcpv1beta1.StorageTypeSecret,
 						Secret: &corev1.SecretVolumeSource{
 							SecretName: tlsSecretName,
 						},
 					},
 				}),
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:        true,
-						CABundleSecret: &mcpv1alpha1.SecretReference{Name: caSecretName},
+						CABundleSecret: &mcpv1beta1.SecretReference{Name: caSecretName},
 					},
 				}),
 			)
 		}).
-		Assess("Ready=True with successful TLS handshake", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Verified=True with successful TLS handshake", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerCondition(ctx, t, r, server,
-				"Ready", metav1.ConditionTrue, 5*time.Minute)
+				"Verified", metav1.ConditionTrue, 5*time.Minute)
 
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to get MCPServer: %v", err)
 			}
 
-			ready := f.GetMCPServerCondition(server, "Ready")
-			t.Logf("Ready condition: status=%s reason=%s", ready.Status, ready.Reason)
+			verified := f.GetMCPServerCondition(server, "Verified")
+			t.Logf("Verified condition: status=%s reason=%s", verified.Status, verified.Reason)
 
 			return ctx
 		}).

--- a/test/e2e/tls_validation_test.go
+++ b/test/e2e/tls_validation_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
-	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	f "github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/category"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/test/e2e/framework/labels/scenario"
@@ -84,10 +84,10 @@ func TestTLSMissingCABundleSecret(t *testing.T) {
 		WithLabel(scenario.Label, scenario.Failure).
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			return f.SetupMCPServer(ctx, t, cfg, "tls-missing-ca", false,
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:        true,
-						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "nonexistent-ca-secret"},
+						CABundleSecret: &mcpv1beta1.SecretReference{Name: "nonexistent-ca-secret"},
 					},
 				}),
 			)
@@ -113,12 +113,12 @@ func TestTLSMissingCABundleSecret(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("Ready=False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Available=False with reason ConfigurationInvalid", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerConditionReason(ctx, t, r, server,
-				"Ready", metav1.ConditionFalse, "ConfigurationInvalid",
+				"Available", metav1.ConditionFalse, "ConfigurationInvalid",
 				30*time.Second)
 
 			return ctx
@@ -158,10 +158,10 @@ func TestTLSInvalidPEMInCABundle(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "tls-bad-pem", false,
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:        true,
-						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "bad-pem-ca"},
+						CABundleSecret: &mcpv1beta1.SecretReference{Name: "bad-pem-ca"},
 					},
 				}),
 			)
@@ -219,10 +219,10 @@ func TestTLSMissingCACrtKey(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "tls-wrong-key", false,
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:        true,
-						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "wrong-key-ca"},
+						CABundleSecret: &mcpv1beta1.SecretReference{Name: "wrong-key-ca"},
 					},
 				}),
 			)
@@ -280,11 +280,11 @@ func TestTLSInsecureSkipVerifyWithCABundleConflict(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "tls-conflict", false,
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:            true,
 						InsecureSkipVerify: true,
-						CABundleSecret:     &mcpv1alpha1.SecretReference{Name: "conflict-ca"},
+						CABundleSecret:     &mcpv1beta1.SecretReference{Name: "conflict-ca"},
 					},
 				}),
 			)
@@ -322,10 +322,10 @@ func TestTLSRecoveryFromMissingCASecret(t *testing.T) {
 		WithLabel(scenario.Label, scenario.Recovery).
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			return f.SetupMCPServer(ctx, t, cfg, "tls-recovery", false,
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:        true,
-						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "recovery-ca"},
+						CABundleSecret: &mcpv1beta1.SecretReference{Name: "recovery-ca"},
 					},
 				}),
 			)
@@ -403,10 +403,10 @@ func TestTLSNonCertificatePEM(t *testing.T) {
 			}
 
 			return f.SetupMCPServer(ctx, t, cfg, "tls-privkey", false,
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:        true,
-						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "privkey-as-ca"},
+						CABundleSecret: &mcpv1beta1.SecretReference{Name: "privkey-as-ca"},
 					},
 				}),
 			)
@@ -444,10 +444,10 @@ func TestTLSDisabledIgnoresStaleCARef(t *testing.T) {
 		WithLabel(scenario.Label, scenario.Deploy).
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			return f.SetupMCPServer(ctx, t, cfg, "tls-disabled", true,
-				f.WithTransport(&mcpv1alpha1.TransportConfig{
-					TLS: &mcpv1alpha1.TLSClientConfig{
+				f.WithTransport(&mcpv1beta1.TransportConfig{
+					TLS: &mcpv1beta1.TLSClientConfig{
 						Enabled:        false,
-						CABundleSecret: &mcpv1alpha1.SecretReference{Name: "nonexistent-ignored"},
+						CABundleSecret: &mcpv1beta1.SecretReference{Name: "nonexistent-ignored"},
 					},
 				}),
 			)
@@ -467,12 +467,12 @@ func TestTLSDisabledIgnoresStaleCARef(t *testing.T) {
 
 			return ctx
 		}).
-		Assess("Ready=True with HTTP handshake", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("Verified=True with HTTP handshake", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			server := f.ServerFromContext(ctx)
 			r := cfg.Client().Resources()
 
 			f.WaitForMCPServerCondition(ctx, t, r, server,
-				"Ready", metav1.ConditionTrue, 2*time.Minute)
+				"Verified", metav1.ConditionTrue, 2*time.Minute)
 
 			if err := r.Get(ctx, server.Name, server.Namespace, server); err != nil {
 				t.Fatalf("failed to get MCPServer: %v", err)


### PR DESCRIPTION
Switches the e2e suite to `v1beta1` and adds coverage for the conversion webhook, now that the controllers and storage version have moved to `v1beta1` (#334).

- Move the e2e framework builders, typed helpers, and assertions from `v1alpha1` to `v1beta1`
- Register both API versions in the test client scheme
- Update all existing e2e call sites to construct and assert against `v1beta1` `MCPServer` objects (asserting the `Available` condition)
- Add `conversion_test.go`: apply a `v1alpha1` `MCPServer`, re-fetch it at `v1beta1` through the deployed conversion webhook, and assert equivalent spec fields and `Available=True`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for API version conversion, including round-trip conversion and reconciliation.
  - Updated lifecycle, storage, networking, TLS, handshake, and failure-recovery scenarios to validate availability and verification status.
  - Added checks confirming unavailable or unverified servers do not publish an address.
  - Improved validation of configuration errors, endpoint failures, and recovery behavior.
  - Updated test coverage to support both API versions during conversion testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->