### PR TITLE
fix: let other controllers co-manage the generated Deployment

### DIFF
--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -112,8 +113,15 @@ func (r *MCPServerReconciler) reconcileDeployment(
 	if needsUpdate {
 		logger.Info("Updating Deployment", "name", existingDeployment.Name)
 		existingDeployment.Spec.Replicas = deployment.Spec.Replicas
-		existingDeployment.Spec.Template.Labels = deployment.Spec.Template.Labels
-		existingDeployment.Spec.Template.Annotations = deployment.Spec.Template.Annotations
+		// Merge rather than assign. Another controller may co-manage this
+		// Deployment - adding workload labels that trigger sidecar injection,
+		// for example - and assigning the maps wholesale would delete its keys
+		// on every reconcile, leaving the two controllers overwriting each
+		// other indefinitely. The pod spec itself stays a wholesale assignment:
+		// it is generated entirely from the MCPServer, and replacing it is what
+		// lets fields be removed when the spec drops them.
+		mergeIntoMap(&existingDeployment.Spec.Template.Labels, deployment.Spec.Template.Labels)
+		mergeManagedAnnotations(&existingDeployment.Spec.Template.Annotations, deployment.Spec.Template.Annotations)
 		existingDeployment.Spec.Template.Spec = deployment.Spec.Template.Spec
 		if err := applyCustomDeploymentMetadata(mcpServer, existingDeployment); err != nil {
 			return nil, fmt.Errorf("applying custom metadata failed; %w", err)
@@ -167,8 +175,16 @@ func deploymentNeedsUpdate(mcpServer *mcpv1alpha1.MCPServer, existing, desired *
 		!equality.Semantic.DeepEqual(oldPodSpec.Containers[0].ReadinessProbe, newPodSpec.Containers[0].ReadinessProbe) ||
 		oldPodSpec.ServiceAccountName != newPodSpec.ServiceAccountName ||
 		!equality.Semantic.DeepEqual(existing.Spec.Replicas, desired.Spec.Replicas) ||
-		!equality.Semantic.DeepEqual(existing.Spec.Template.Labels, desired.Spec.Template.Labels) ||
-		!equality.Semantic.DeepEqual(existing.Spec.Template.Annotations, desired.Spec.Template.Annotations) ||
+		// Only the operator's own keys are compared. Comparing the whole map
+		// would treat a co-managing controller's label as drift, and since the
+		// desired object never contains that label the comparison could never
+		// come out equal - every reconcile would rewrite the Deployment
+		// forever. Keys the operator manages through extraLabels and
+		// extraAnnotations are handled by the two checks below, which know
+		// which keys it previously owned and so can still detect a removal.
+		!mapContainsAll(existing.Spec.Template.Labels, desired.Spec.Template.Labels) ||
+		!mapContainsAll(existing.Spec.Template.Annotations, desired.Spec.Template.Annotations) ||
+		!reservedAnnotationsMatch(existing.Spec.Template.Annotations, desired.Spec.Template.Annotations) ||
 		deploymentAnnotationsChanged(mcpServer, existing) ||
 		deploymentLabelsChanged(mcpServer, existing) ||
 		ownershipChanged
@@ -220,6 +236,62 @@ func tlsEnvVarOverridden(name string, tlsVars []corev1.EnvVar) bool {
 		}
 	}
 	return false
+}
+
+// mergeIntoMap copies src over dst, allocating dst when it is nil. Keys present
+// in dst but not in src are left alone: they belong to somebody else.
+func mergeIntoMap(dst *map[string]string, src map[string]string) {
+	if len(src) == 0 {
+		return
+	}
+	if *dst == nil {
+		*dst = make(map[string]string, len(src))
+	}
+	maps.Copy(*dst, src)
+}
+
+// mapContainsAll reports whether m holds every entry of want with the same
+// value. Extra entries in m are ignored - they are not this operator's to
+// reconcile.
+func mapContainsAll(m, want map[string]string) bool {
+	for key, wantValue := range want {
+		if value, ok := m[key]; !ok || value != wantValue {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeManagedAnnotations merges src into dst, and additionally drops keys under
+// the reserved mcp.x-k8s.io/ prefix that src no longer sets. That prefix belongs
+// to this operator outright, so unlike foreign annotations those keys have to be
+// removable: it is how the config hash disappears once the last ConfigMap or
+// Secret reference is dropped from the MCPServer.
+func mergeManagedAnnotations(dst *map[string]string, src map[string]string) {
+	for key := range *dst {
+		if !strings.HasPrefix(key, reservedAnnotationPrefix) {
+			continue
+		}
+		if _, ok := src[key]; !ok {
+			delete(*dst, key)
+		}
+	}
+	mergeIntoMap(dst, src)
+}
+
+// reservedAnnotationsMatch reports whether existing carries any reserved
+// annotation that desired no longer sets, which mapContainsAll cannot see
+// because it only looks at keys the desired object still has.
+func reservedAnnotationsMatch(existing, desired map[string]string) bool {
+	for key := range existing {
+		if !strings.HasPrefix(key, reservedAnnotationPrefix) {
+			continue
+		}
+		if _, ok := desired[key]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func managedWorkloadLabels(mcpServerName string) map[string]string {

--- a/internal/controller/mcpserver_controller_deployment_coexistence_test.go
+++ b/internal/controller/mcpserver_controller_deployment_coexistence_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+)
+
+// Field ownership coexistence tests.
+//
+// Another controller may legitimately co-manage the Deployment this operator
+// generates, adding workload labels and pod template annotations of its own to
+// trigger sidecar injection. This operator reconciles the fields it generates
+// and leaves everything else alone: it must neither delete foreign metadata nor
+// treat the presence of foreign metadata as drift that needs correcting.
+var _ = Describe("MCPServer Controller - foreign field ownership", func() {
+	const (
+		foreignTypeLabel       = "kagenti.io/type"
+		foreignConfigHashAnnot = "kagenti.io/config-hash"
+		foreignMTLSModeAnnot   = "kagenti.io/mtls-mode"
+	)
+
+	ctx := context.Background()
+
+	get := func(name string) *appsv1.Deployment {
+		deployment := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx,
+			types.NamespacedName{Name: name, Namespace: "default"}, deployment)).To(Succeed())
+		return deployment
+	}
+
+	getMCPServer := func(name string) *mcpv1alpha1.MCPServer {
+		mcpServer := &mcpv1alpha1.MCPServer{}
+		Expect(k8sClient.Get(ctx,
+			types.NamespacedName{Name: name, Namespace: "default"}, mcpServer)).To(Succeed())
+		return mcpServer
+	}
+
+	// writeForeignMetadata simulates the peer controller: a read-modify-write
+	// that only sets its own keys, exactly as the AgentRuntime controller does.
+	writeForeignMetadata := func(name string) {
+		deployment := get(name)
+		if deployment.Labels == nil {
+			deployment.Labels = map[string]string{}
+		}
+		deployment.Labels[foreignTypeLabel] = "tool"
+		if deployment.Spec.Template.Labels == nil {
+			deployment.Spec.Template.Labels = map[string]string{}
+		}
+		deployment.Spec.Template.Labels[foreignTypeLabel] = "tool"
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = map[string]string{}
+		}
+		deployment.Spec.Template.Annotations[foreignConfigHashAnnot] = "abc123def456"
+		deployment.Spec.Template.Annotations[foreignMTLSModeAnnot] = "disabled"
+		Expect(k8sClient.Update(ctx, deployment)).To(Succeed())
+	}
+
+	newReconciler := func() *MCPServerReconciler {
+		return &MCPServerReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), APIReader: k8sClient}
+	}
+
+	createServer := func(name string, mutate func(*mcpv1alpha1.MCPServer)) *mcpv1alpha1.MCPServer {
+		resource := newTestMCPServer(name)
+		if mutate != nil {
+			mutate(resource)
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		DeferCleanup(func() {
+			mcpServer := &mcpv1alpha1.MCPServer{}
+			key := types.NamespacedName{Name: name, Namespace: "default"}
+			if err := k8sClient.Get(ctx, key, mcpServer); err == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		})
+		return getMCPServer(name)
+	}
+
+	setup := func(name string) (*mcpv1alpha1.MCPServer, *MCPServerReconciler) {
+		mcpServer := createServer(name, nil)
+		reconciler := newReconciler()
+		_, err := reconciler.reconcileDeployment(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+		return mcpServer, reconciler
+	}
+
+	It("preserves foreign labels and annotations written by another controller", func() {
+		const name = "test-foreign-preserved"
+		mcpServer, reconciler := setup(name)
+
+		By("a peer controller adding its own workload and pod template metadata")
+		writeForeignMetadata(name)
+
+		By("reconciling again")
+		_, err := reconciler.reconcileDeployment(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := get(name)
+		Expect(deployment.Labels).To(HaveKeyWithValue(foreignTypeLabel, "tool"))
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(foreignTypeLabel, "tool"))
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(foreignConfigHashAnnot, "abc123def456"))
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(foreignMTLSModeAnnot, "disabled"))
+
+		By("this operator's own fields still being present")
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(LabelKeyApp, ManagedWorkloadName))
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(LabelKeyMCPServer, name))
+	})
+
+	It("does not churn the deployment when foreign metadata is present", func() {
+		const name = "test-foreign-no-churn"
+		mcpServer, reconciler := setup(name)
+
+		By("a peer controller adding its own metadata")
+		writeForeignMetadata(name)
+
+		settled := get(name)
+		generation, resourceVersion := settled.Generation, settled.ResourceVersion
+
+		By("reconciling repeatedly with no MCPServer change")
+		for i := range 3 {
+			_, err := reconciler.reconcileDeployment(ctx, mcpServer)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("reconcile %d failed", i))
+		}
+
+		current := get(name)
+		Expect(current.Generation).To(Equal(generation),
+			"reconciling must be a no-op when only foreign metadata differs; "+
+				"a bumped generation means the operator and the peer are fighting")
+		Expect(current.ResourceVersion).To(Equal(resourceVersion),
+			"the operator must not write at all in steady state")
+	})
+
+	It("still propagates MCPServer changes while preserving foreign metadata", func() {
+		const name = "test-foreign-with-update"
+		_, reconciler := setup(name)
+
+		writeForeignMetadata(name)
+
+		By("changing a field this operator owns")
+		mcpServer := getMCPServer(name)
+		mcpServer.Spec.Source.ContainerImage.Ref = "docker.io/library/updated-image:v2"
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		_, err := reconciler.reconcileDeployment(ctx, getMCPServer(name))
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := get(name)
+		Expect(deployment.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+		Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("docker.io/library/updated-image:v2"))
+
+		By("the peer controller's fields still surviving")
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(foreignTypeLabel, "tool"))
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(foreignConfigHashAnnot, "abc123def456"))
+		Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(foreignMTLSModeAnnot, "disabled"))
+	})
+
+	It("restores its own managed labels when another actor removes them", func() {
+		const name = "test-managed-labels-restored"
+		mcpServer, reconciler := setup(name)
+
+		// Only the app label is stripped: the mcp-server label is part of
+		// spec.selector, and the API server rejects a template that no longer
+		// matches its own selector.
+		By("another actor stripping a label this operator owns")
+		deployment := get(name)
+		delete(deployment.Spec.Template.Labels, LabelKeyApp)
+		Expect(k8sClient.Update(ctx, deployment)).To(Succeed())
+		Expect(get(name).Spec.Template.Labels).NotTo(HaveKey(LabelKeyApp))
+
+		_, err := reconciler.reconcileDeployment(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(get(name).Spec.Template.Labels).To(HaveKeyWithValue(LabelKeyApp, ManagedWorkloadName))
+	})
+
+	It("removes an extraLabel the user removed, leaving the peer's label alone", func() {
+		const name = "test-extra-label-removal"
+		mcpServer := createServer(name, func(m *mcpv1alpha1.MCPServer) {
+			m.Spec.ExtraLabels = map[string]string{"team": "platform"}
+		})
+		reconciler := newReconciler()
+		_, err := reconciler.reconcileDeployment(ctx, mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(get(name).Spec.Template.Labels).To(HaveKeyWithValue("team", "platform"))
+
+		By("a peer controller adding its own metadata alongside it")
+		writeForeignMetadata(name)
+
+		By("removing the extra label from the MCPServer")
+		mcpServer = getMCPServer(name)
+		mcpServer.Spec.ExtraLabels = nil
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		_, err = reconciler.reconcileDeployment(ctx, getMCPServer(name))
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := get(name)
+		Expect(deployment.Spec.Template.Labels).NotTo(HaveKey("team"))
+		Expect(deployment.Labels).NotTo(HaveKey("team"))
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(foreignTypeLabel, "tool"))
+	})
+
+	// Deployments already in the field were created by an earlier release. This
+	// operator keeps writing them with Update, so there is no ownership handover
+	// to get wrong - but the removal path is worth pinning down all the same.
+	It("removes fields on a Deployment created before the upgrade", func() {
+		const name = "test-preexisting-removal"
+		mcpServer := createServer(name, func(m *mcpv1alpha1.MCPServer) {
+			m.Spec.ExtraLabels = map[string]string{"team": "platform"}
+			m.Spec.Runtime = mcpv1alpha1.RuntimeConfig{
+				Security: mcpv1alpha1.SecurityConfig{ServiceAccountName: "my-sa"},
+			}
+		})
+		reconciler := newReconciler()
+
+		By("an earlier release having created the Deployment")
+		legacy, err := reconciler.createDeployment(mcpServer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reconciler.applyConfigHash(ctx, mcpServer, legacy)).To(Succeed())
+		Expect(applyCustomDeploymentMetadata(mcpServer, legacy)).To(Succeed())
+		Expect(controllerutil.SetControllerReference(mcpServer, legacy, k8sClient.Scheme())).To(Succeed())
+		Expect(k8sClient.Create(ctx, legacy)).To(Succeed())
+
+		By("a peer controller adding its own metadata")
+		writeForeignMetadata(name)
+
+		By("the user clearing both settings")
+		mcpServer = getMCPServer(name)
+		mcpServer.Spec.ExtraLabels = nil
+		mcpServer.Spec.Runtime = mcpv1alpha1.RuntimeConfig{}
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		_, err = reconciler.reconcileDeployment(ctx, getMCPServer(name))
+		Expect(err).NotTo(HaveOccurred())
+
+		deployment := get(name)
+		Expect(deployment.Spec.Template.Labels).NotTo(HaveKey("team"))
+		Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
+		Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue(foreignTypeLabel, "tool"))
+	})
+})


### PR DESCRIPTION
## What this fixes

`reconcileDeployment` assigns the whole pod template on every update:

```go
existingDeployment.Spec.Template.Labels = deployment.Spec.Template.Labels
existingDeployment.Spec.Template.Annotations = deployment.Spec.Template.Annotations
```

and `deploymentNeedsUpdate` compares those maps with `equality.Semantic.DeepEqual`.

Together these make the operator hostile to any other controller that writes to the Deployment it generates. The assignment deletes the other controller's keys; the comparison then treats their reappearance as drift. Because the desired object never contains a foreign key, the `DeepEqual` can never come out equal, so **every** reconcile rewrites the Deployment. The two controllers overwrite each other indefinitely: `generation` climbs without bound and the workload flips between a ReplicaSet carrying the foreign metadata and one without it, restarting pods each time.

This is not hypothetical. It reproduces with sidecar-injection controllers that add a workload label to the pod template and expect it to stay — for example Kagenti's `AgentRuntime` controller, which sets `kagenti.io/type` plus config-hash and mTLS-mode annotations so a mutating webhook injects an AuthBridge sidecar at pod creation. The peer controller is well behaved: it does a `retry.RetryOnConflict` read-modify-write that sets only its own keys. The conflict is one-sided.

Measured on a live cluster with the current code, a peer re-asserting its label four times:

```
round 1: gen 5  -> 5    peer label=[GONE]
round 2: gen 7  -> 7    peer label=[GONE]
round 3: gen 9  -> 9    peer label=[GONE]
round 4: gen 11 -> 11   peer label=[GONE]
ReplicaSets: 3
```

Note that fixing only the assignment is **not** sufficient — the loop keeps running, just without data loss.

## What this changes

- Merge `spec.template.metadata.labels` and `.annotations` instead of assigning them. Keys the operator does not generate are left alone.
- Compare only the operator's own desired keys in `deploymentNeedsUpdate`. Extra keys are ignored. `extraLabels` / `extraAnnotations` removal is unchanged: it still goes through the existing `mcp.x-k8s.io/managed-extra-*` bookkeeping annotations, which record which keys were owned last time.
- Keep annotations under the reserved `mcp.x-k8s.io/` prefix removable. They belong to this operator outright, and the config hash has to disappear when the last ConfigMap or Secret reference is dropped. (The existing config-hash test catches this if you forget it.)
- `spec.template.spec` remains a wholesale assignment. It is generated entirely from the MCPServer, and replacing it is what allows fields to be removed when the spec stops asking for them.

76 lines of production change in one file.

Same measurement after the change, on a Deployment created by the previous build:

```
round 1..4: gen 12->12, 13->13, 14->14, 15->15   peer label=[tool] config-hash=[deadbeef1234]
spec change still applies:  replicas=2, peer keys preserved
extraLabels add:            team=[platform], peer preserved
extraLabels remove:         team=[], peer=[tool] hash=[deadbeef1234]
steady state 45s:           gen 18->18   resourceVersion 20097158->20097158
```

## A note on Server-Side Apply

SSA is the usual answer for co-managed objects, and it is probably where this controller should end up. I tried it first and withdrew it, because it cannot be adopted safely for Deployments that already exist.

Those were written with `Update`, so they carry an `operation: Update` managedFields entry covering every field the operator writes. SSA deletes a field only when the applier owns it **alone**, and a first apply whose values match what is stored raises no conflict, so ownership never transfers and that entry co-owns everything permanently. The practical result is that every removal silently becomes a no-op: clearing `extraLabels`, dropping an env var or unsetting `serviceAccountName` would appear to succeed and change nothing.

Repairing that means dropping the stale entry, which means telling this operator's own past entry apart from a legitimate peer's. There is no reliable discriminator — both own overlapping paths. Matching broadly destroys the ownership records of `kube-controller-manager` (which owns `.status` through the status subresource) and of an `Update`-based co-manager, and since deleting an entry is itself a write that wakes the controller through its own Deployment watch, that recreates the same unbounded write loop against a different peer.

If maintainers want SSA here, it is much easier to do from a known starting point — pick a stable field manager and adopt it for newly created Deployments — than to retrofit it onto existing ones. Happy to follow up separately.

## Testing

`go test ./...` passes on this branch (envtest, Kubernetes 1.36.2): `api/v1alpha1`, `cmd`, `internal/controller`, `internal/webhook` and `test/e2e/framework` all ok.

Six regression tests added in `internal/controller/mcpserver_controller_deployment_coexistence_test.go`:

- foreign labels and annotations survive a reconcile
- no churn while foreign metadata is present (asserts `resourceVersion`, not just `generation`, since generation only tracks spec changes)
- MCPServer changes still propagate with foreign metadata intact
- managed labels are restored if another actor strips them
- an `extraLabels` key removed from the spec is removed, leaving a peer's label alone
- removal still works on a Deployment created before this change

Five of the six were confirmed to fail against the unpatched tree before being accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Deployment metadata reconciliation so labels and annotations added by other controllers are preserved.
  * Reduced unnecessary Deployment updates when only externally managed metadata changes.
  * Restored operator-managed metadata when it is removed, while continuing to remove user-removed managed fields.
  * Ensured metadata updates remain synchronized with other Deployment configuration changes.
* **Tests**
  * Added coverage for coexistence with controllers that independently manage Deployment metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->