### PR TITLE
build: bump toolchain to Go 1.27 and update tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.10.1
+          version: v2.13.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,8 @@ linters:
     - unparam
     - unused
   settings:
+    goconst:
+      ignore-tests: true
     revive:
       rules:
         - name: comment-spacings

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.1/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} golang:1.26.6 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.27.0 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -25,7 +25,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd
 
 # Build the manager binary with debug symbols
-FROM golang:1.26.6 AS debug-builder
+FROM golang:1.27.0 AS debug-builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -39,7 +39,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -gcflags="all=-N -l" -o manager ./cmd
 
 # Debug image with Delve
-FROM golang:1.26.6 AS debug
+FROM golang:1.27.0 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.3
 WORKDIR /
 COPY --from=debug-builder /workspace/manager .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/kubernetes-sigs/kubebuilder/blob/v4.11.1/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} golang:1.27.0 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.27.1 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -25,7 +25,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd
 
 # Build the manager binary with debug symbols
-FROM golang:1.27.0 AS debug-builder
+FROM golang:1.27.1 AS debug-builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -39,7 +39,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -gcflags="all=-N -l" -o manager ./cmd
 
 # Debug image with Delve
-FROM golang:1.27.0 AS debug
+FROM golang:1.27.1 AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.3
 WORKDIR /
 COPY --from=debug-builder /workspace/manager .

--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
-CONTROLLER_TOOLS_VERSION ?= v0.20.0
+CONTROLLER_TOOLS_VERSION ?= v0.21.0
 
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \

--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,13 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
+
+# GO_TOOLCHAIN is the toolchain declared in go.mod. Tools installed via
+# go-install-tool are built with it so their bundled go/types can parse the
+# project's Go version. Without this, 'go install' picks the minimum toolchain
+# satisfying the tool's own go directive (e.g. go1.26.x for controller-tools),
+# whose go/types cannot parse newer stdlib source and fails 'make generate'.
+GO_TOOLCHAIN ?= $(shell awk '/^toolchain /{print $$2; exit}' go.mod)
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
@@ -347,7 +354,7 @@ set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f "$(1)" ;\
-GOBIN="$(LOCALBIN)" go install $${package} ;\
+GOBIN="$(LOCALBIN)" $(if $(GO_TOOLCHAIN),GOTOOLCHAIN=$(GO_TOOLCHAIN)) go install $${package} ;\
 mv "$(LOCALBIN)/$$(basename "$(1)")" "$(1)-$(3)" ;\
 } ;\
 ln -sf "$$(realpath "$(1)-$(3)")" "$(1)"

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.10.1
+GOLANGCI_LINT_VERSION ?= v2.13.0
 
 # GO_TOOLCHAIN is the toolchain declared in go.mod. Tools installed via
 # go-install-tool are built with it so their bundled go/types can parse the

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/healthconfig.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/healthconfig.go
@@ -39,6 +39,7 @@ type HealthConfigApplyConfiguration struct {
 	//
 	// This probe is passed directly to the container spec without transformation,
 	// providing full compatibility with the Kubernetes Probe API.
+	//
 	LivenessProbe *v1.Probe `json:"livenessProbe,omitempty"`
 	// ReadinessProbe defines the readiness probe for the MCP server container.
 	// Kubernetes uses readiness probes to know when a container is ready to start accepting traffic.
@@ -46,6 +47,7 @@ type HealthConfigApplyConfiguration struct {
 	//
 	// This probe is passed directly to the container spec without transformation,
 	// providing full compatibility with the Kubernetes Probe API.
+	//
 	ReadinessProbe *v1.Probe `json:"readinessProbe,omitempty"`
 }
 

--- a/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
+++ b/api/v1alpha1/applyconfiguration/api/v1alpha1/mcpserverstatus.go
@@ -61,6 +61,7 @@ type MCPServerStatusApplyConfiguration struct {
 	// not enumerated here to avoid drift; specific failure details
 	// (ImagePullBackOff, OOMKilled, CrashLoop, etc.) are reported in the message,
 	// not the reason.
+	//
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 

--- a/api/v1alpha1/mcpserver_conversion.go
+++ b/api/v1alpha1/mcpserver_conversion.go
@@ -400,7 +400,7 @@ func splitReadyToAvailableAndVerified(ready metav1.Condition) []metav1.Condition
 			{
 				Type:               conditionTypeAvailable,
 				Status:             metav1.ConditionTrue,
-				Reason:             "Available",
+				Reason:             conditionTypeAvailable,
 				Message:            "Workload is running",
 				ObservedGeneration: ready.ObservedGeneration,
 				LastTransitionTime: ready.LastTransitionTime,
@@ -416,13 +416,13 @@ func splitReadyToAvailableAndVerified(ready metav1.Condition) []metav1.Condition
 		}
 	}
 
-	if ready.Status == metav1.ConditionTrue && ready.Reason == "Available" {
+	if ready.Status == metav1.ConditionTrue && ready.Reason == conditionTypeAvailable {
 		// Fully ready: both available and verified.
 		return []metav1.Condition{
 			{
 				Type:               conditionTypeAvailable,
 				Status:             metav1.ConditionTrue,
-				Reason:             "Available",
+				Reason:             conditionTypeAvailable,
 				Message:            ready.Message,
 				ObservedGeneration: ready.ObservedGeneration,
 				LastTransitionTime: ready.LastTransitionTime,
@@ -524,7 +524,7 @@ func mergeAvailableAndVerifiedToReady(available, verified *metav1.Condition) met
 		return metav1.Condition{
 			Type:               conditionTypeReady,
 			Status:             metav1.ConditionTrue,
-			Reason:             "Available",
+			Reason:             conditionTypeAvailable,
 			Message:            src.Message,
 			ObservedGeneration: src.ObservedGeneration,
 			LastTransitionTime: src.LastTransitionTime,
@@ -549,7 +549,7 @@ func mergeAvailableAndVerifiedToReady(available, verified *metav1.Condition) met
 	return metav1.Condition{
 		Type:               conditionTypeReady,
 		Status:             metav1.ConditionTrue,
-		Reason:             "Available",
+		Reason:             conditionTypeAvailable,
 		Message:            "Workload is running, handshake pending",
 		ObservedGeneration: verified.ObservedGeneration,
 		LastTransitionTime: verified.LastTransitionTime,

--- a/api/v1beta1/applyconfiguration/api/v1beta1/healthconfig.go
+++ b/api/v1beta1/applyconfiguration/api/v1beta1/healthconfig.go
@@ -39,6 +39,7 @@ type HealthConfigApplyConfiguration struct {
 	//
 	// This probe is passed directly to the container spec without transformation,
 	// providing full compatibility with the Kubernetes Probe API.
+	//
 	LivenessProbe *v1.Probe `json:"livenessProbe,omitempty"`
 	// ReadinessProbe defines the readiness probe for the MCP server container.
 	// Kubernetes uses readiness probes to know when a container is ready to start accepting traffic.
@@ -46,6 +47,7 @@ type HealthConfigApplyConfiguration struct {
 	//
 	// This probe is passed directly to the container spec without transformation,
 	// providing full compatibility with the Kubernetes Probe API.
+	//
 	ReadinessProbe *v1.Probe `json:"readinessProbe,omitempty"`
 }
 

--- a/api/v1beta1/applyconfiguration/api/v1beta1/mcpserver.go
+++ b/api/v1beta1/applyconfiguration/api/v1beta1/mcpserver.go
@@ -19,8 +19,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	apiv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
+	internal "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1/applyconfiguration/internal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -71,6 +74,47 @@ func MCPServer(name, namespace string) *MCPServerApplyConfiguration {
 	b.WithKind("MCPServer")
 	b.WithAPIVersion("mcp.x-k8s.io/v1beta1")
 	return b
+}
+
+// ExtractMCPServerFrom extracts the applied configuration owned by fieldManager from
+// mCPServer for the specified subresource. Pass an empty string for subresource to extract
+// the main resource. Common subresources include "status", "scale", etc.
+// mCPServer must be a unmodified MCPServer API object that was retrieved from the Kubernetes API.
+// ExtractMCPServerFrom provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractMCPServerFrom(mCPServer *apiv1beta1.MCPServer, fieldManager string, subresource string) (*MCPServerApplyConfiguration, error) {
+	b := &MCPServerApplyConfiguration{}
+	err := managedfields.ExtractInto(mCPServer, internal.Parser().Type("com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServer"), fieldManager, b, subresource)
+	if err != nil {
+		return nil, err
+	}
+	b.WithName(mCPServer.Name)
+	b.WithNamespace(mCPServer.Namespace)
+
+	b.WithKind("MCPServer")
+	b.WithAPIVersion("mcp.x-k8s.io/v1beta1")
+	return b, nil
+}
+
+// ExtractMCPServer extracts the applied configuration owned by fieldManager from
+// mCPServer. If no managedFields are found in mCPServer for fieldManager, a
+// MCPServerApplyConfiguration is returned with only the Name, Namespace (if applicable),
+// APIVersion and Kind populated. It is possible that no managed fields were found for because other
+// field managers have taken ownership of all the fields previously owned by fieldManager, or because
+// the fieldManager never owned fields any fields.
+// mCPServer must be a unmodified MCPServer API object that was retrieved from the Kubernetes API.
+// ExtractMCPServer provides a way to perform a extract/modify-in-place/apply workflow.
+// Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
+// applied if another fieldManager has updated or force applied any of the previously applied fields.
+func ExtractMCPServer(mCPServer *apiv1beta1.MCPServer, fieldManager string) (*MCPServerApplyConfiguration, error) {
+	return ExtractMCPServerFrom(mCPServer, fieldManager, "")
+}
+
+// ExtractMCPServerStatus extracts the applied configuration owned by fieldManager from
+// mCPServer for the status subresource.
+func ExtractMCPServerStatus(mCPServer *apiv1beta1.MCPServer, fieldManager string) (*MCPServerApplyConfiguration, error) {
+	return ExtractMCPServerFrom(mCPServer, fieldManager, "status")
 }
 
 func (b MCPServerApplyConfiguration) IsApplyConfiguration() {}

--- a/api/v1beta1/applyconfiguration/api/v1beta1/mcpserverstatus.go
+++ b/api/v1beta1/applyconfiguration/api/v1beta1/mcpserverstatus.go
@@ -61,6 +61,7 @@ type MCPServerStatusApplyConfiguration struct {
 	// not enumerated here to avoid drift; specific failure details
 	// (ImagePullBackOff, OOMKilled, CrashLoop, etc.) are reported in the message,
 	// not the reason.
+	//
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 

--- a/api/v1beta1/applyconfiguration/internal/internal.go
+++ b/api/v1beta1/applyconfiguration/internal/internal.go
@@ -39,6 +39,1076 @@ func Parser() *typed.Parser {
 var parserOnce sync.Once
 var parser *typed.Parser
 var schemaYAML = typed.YAMLObject(`types:
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.ContainerImageSource
+  map:
+    fields:
+    - name: imagePullSecrets
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.LocalObjectReference
+          elementRelationship: associative
+          keys:
+          - name
+    - name: pullPolicy
+      type:
+        namedType: io.k8s.api.core.v1.PullPolicy
+    - name: ref
+      type:
+        scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.HealthConfig
+  map:
+    fields:
+    - name: livenessProbe
+      type:
+        namedType: io.k8s.api.core.v1.Probe
+    - name: readinessProbe
+      type:
+        namedType: io.k8s.api.core.v1.Probe
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPConfig
+  map:
+    fields:
+    - name: stateless
+      type:
+        scalar: boolean
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServer
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: kind
+      type:
+        scalar: string
+    - name: metadata
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+    - name: spec
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerSpec
+    - name: status
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerStatus
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerAddress
+  map:
+    fields:
+    - name: url
+      type:
+        scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerCapabilities
+  map:
+    fields:
+    - name: completions
+      type:
+        scalar: boolean
+    - name: logging
+      type:
+        scalar: boolean
+    - name: prompts
+      type:
+        scalar: boolean
+    - name: resources
+      type:
+        scalar: boolean
+    - name: tools
+      type:
+        scalar: boolean
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerInfo
+  map:
+    fields:
+    - name: capabilities
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerCapabilities
+    - name: instructions
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: protocolVersion
+      type:
+        scalar: string
+    - name: version
+      type:
+        scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerSpec
+  map:
+    fields:
+    - name: config
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.ServerConfig
+    - name: extraAnnotations
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: extraLabels
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: mcp
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPConfig
+    - name: network
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.NetworkConfig
+    - name: runtime
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.RuntimeConfig
+    - name: source
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.Source
+    - name: transport
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.TransportConfig
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerStatus
+  map:
+    fields:
+    - name: address
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerAddress
+    - name: conditions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Condition
+          elementRelationship: associative
+          keys:
+          - type
+    - name: deploymentName
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: readyReplicas
+      type:
+        scalar: numeric
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: serverInfo
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MCPServerInfo
+    - name: serviceName
+      type:
+        scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MountPermissions
+  scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.NetworkConfig
+  map:
+    fields:
+    - name: dnsEgressPeer
+      type:
+        namedType: io.k8s.api.networking.v1.NetworkPolicyPeer
+    - name: egressPorts
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPort
+          elementRelationship: atomic
+    - name: egressTo
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPeer
+          elementRelationship: atomic
+    - name: ingressFrom
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.networking.v1.NetworkPolicyPeer
+          elementRelationship: atomic
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.RuntimeConfig
+  map:
+    fields:
+    - name: health
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.HealthConfig
+    - name: replicas
+      type:
+        scalar: numeric
+    - name: resources
+      type:
+        namedType: io.k8s.api.core.v1.ResourceRequirements
+    - name: security
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.SecurityConfig
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.SecretReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.SecurityConfig
+  map:
+    fields:
+    - name: podSecurityContext
+      type:
+        namedType: io.k8s.api.core.v1.PodSecurityContext
+    - name: securityContext
+      type:
+        namedType: io.k8s.api.core.v1.SecurityContext
+    - name: serviceAccountName
+      type:
+        scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.ServerConfig
+  map:
+    fields:
+    - name: arguments
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+    - name: env
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvVar
+          elementRelationship: atomic
+    - name: envFrom
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.EnvFromSource
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+      default: /mcp
+    - name: port
+      type:
+        scalar: numeric
+    - name: storage
+      type:
+        list:
+          elementType:
+            namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.StorageMount
+          elementRelationship: associative
+          keys:
+          - path
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.Source
+  map:
+    fields:
+    - name: containerImage
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.ContainerImageSource
+    - name: type
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.SourceType
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.SourceType
+  scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.StorageMount
+  map:
+    fields:
+    - name: path
+      type:
+        scalar: string
+    - name: permissions
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.MountPermissions
+      default: ReadOnly
+    - name: source
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.StorageSource
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.StorageSource
+  map:
+    fields:
+    - name: configMap
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapVolumeSource
+    - name: emptyDir
+      type:
+        namedType: io.k8s.api.core.v1.EmptyDirVolumeSource
+    - name: secret
+      type:
+        namedType: io.k8s.api.core.v1.SecretVolumeSource
+    - name: type
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.StorageType
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.StorageType
+  scalar: string
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.TLSClientConfig
+  map:
+    fields:
+    - name: caBundleSecret
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.SecretReference
+    - name: enabled
+      type:
+        scalar: boolean
+    - name: insecureSkipVerify
+      type:
+        scalar: boolean
+- name: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.TransportConfig
+  map:
+    fields:
+    - name: tls
+      type:
+        namedType: com.github.kubernetes-sigs.mcp-lifecycle-operator.api.v1beta1.TLSClientConfig
+- name: io.k8s.api.core.v1.AppArmorProfile
+  map:
+    fields:
+    - name: localhostProfile
+      type:
+        scalar: string
+    - name: type
+      type:
+        namedType: io.k8s.api.core.v1.AppArmorProfileType
+- name: io.k8s.api.core.v1.AppArmorProfileType
+  scalar: string
+- name: io.k8s.api.core.v1.Capabilities
+  map:
+    fields:
+    - name: add
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Capability
+          elementRelationship: atomic
+    - name: drop
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Capability
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.Capability
+  scalar: string
+- name: io.k8s.api.core.v1.ConfigMapEnvSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: optional
+      type:
+        scalar: boolean
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.ConfigMapKeySelector
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: optional
+      type:
+        scalar: boolean
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.ConfigMapVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: defaultUser
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: optional
+      type:
+        scalar: boolean
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.EmptyDirVolumeSource
+  map:
+    fields:
+    - name: medium
+      type:
+        namedType: io.k8s.api.core.v1.StorageMedium
+    - name: mode
+      type:
+        scalar: numeric
+    - name: sizeLimit
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.core.v1.EnvFromSource
+  map:
+    fields:
+    - name: configMapRef
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapEnvSource
+    - name: prefix
+      type:
+        scalar: string
+    - name: secretRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretEnvSource
+- name: io.k8s.api.core.v1.EnvVar
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+    - name: valueFrom
+      type:
+        namedType: io.k8s.api.core.v1.EnvVarSource
+- name: io.k8s.api.core.v1.EnvVarSource
+  map:
+    fields:
+    - name: configMapKeyRef
+      type:
+        namedType: io.k8s.api.core.v1.ConfigMapKeySelector
+    - name: fieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ObjectFieldSelector
+    - name: fileKeyRef
+      type:
+        namedType: io.k8s.api.core.v1.FileKeySelector
+    - name: resourceFieldRef
+      type:
+        namedType: io.k8s.api.core.v1.ResourceFieldSelector
+    - name: secretKeyRef
+      type:
+        namedType: io.k8s.api.core.v1.SecretKeySelector
+- name: io.k8s.api.core.v1.ExecAction
+  map:
+    fields:
+    - name: command
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.core.v1.FileKeySelector
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: optional
+      type:
+        scalar: boolean
+      default: false
+    - name: path
+      type:
+        scalar: string
+    - name: volumeName
+      type:
+        scalar: string
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.GRPCAction
+  map:
+    fields:
+    - name: mode
+      type:
+        namedType: io.k8s.api.core.v1.GRPCProbeMode
+    - name: port
+      type:
+        scalar: numeric
+    - name: service
+      type:
+        scalar: string
+      default: ""
+- name: io.k8s.api.core.v1.GRPCProbeMode
+  scalar: string
+- name: io.k8s.api.core.v1.HTTPGetAction
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: httpHeaders
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.HTTPHeader
+          elementRelationship: atomic
+    - name: path
+      type:
+        scalar: string
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: protocol
+      type:
+        namedType: io.k8s.api.core.v1.HTTPProtocol
+    - name: scheme
+      type:
+        namedType: io.k8s.api.core.v1.URIScheme
+- name: io.k8s.api.core.v1.HTTPHeader
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.HTTPProtocol
+  scalar: string
+- name: io.k8s.api.core.v1.KeyToPath
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: mode
+      type:
+        scalar: numeric
+    - name: path
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.LocalObjectReference
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.ObjectFieldSelector
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldPath
+      type:
+        scalar: string
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.PodFSGroupChangePolicy
+  scalar: string
+- name: io.k8s.api.core.v1.PodSELinuxChangePolicy
+  scalar: string
+- name: io.k8s.api.core.v1.PodSecurityContext
+  map:
+    fields:
+    - name: appArmorProfile
+      type:
+        namedType: io.k8s.api.core.v1.AppArmorProfile
+    - name: fsGroup
+      type:
+        scalar: numeric
+    - name: fsGroupChangePolicy
+      type:
+        namedType: io.k8s.api.core.v1.PodFSGroupChangePolicy
+    - name: runAsGroup
+      type:
+        scalar: numeric
+    - name: runAsNonRoot
+      type:
+        scalar: boolean
+    - name: runAsUser
+      type:
+        scalar: numeric
+    - name: seLinuxChangePolicy
+      type:
+        namedType: io.k8s.api.core.v1.PodSELinuxChangePolicy
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+    - name: seccompProfile
+      type:
+        namedType: io.k8s.api.core.v1.SeccompProfile
+    - name: supplementalGroups
+      type:
+        list:
+          elementType:
+            scalar: numeric
+          elementRelationship: atomic
+    - name: supplementalGroupsPolicy
+      type:
+        namedType: io.k8s.api.core.v1.SupplementalGroupsPolicy
+    - name: sysctls
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.Sysctl
+          elementRelationship: atomic
+    - name: windowsOptions
+      type:
+        namedType: io.k8s.api.core.v1.WindowsSecurityContextOptions
+- name: io.k8s.api.core.v1.Probe
+  map:
+    fields:
+    - name: exec
+      type:
+        namedType: io.k8s.api.core.v1.ExecAction
+    - name: failureThreshold
+      type:
+        scalar: numeric
+    - name: grpc
+      type:
+        namedType: io.k8s.api.core.v1.GRPCAction
+    - name: httpGet
+      type:
+        namedType: io.k8s.api.core.v1.HTTPGetAction
+    - name: initialDelaySeconds
+      type:
+        scalar: numeric
+    - name: periodSeconds
+      type:
+        scalar: numeric
+    - name: successThreshold
+      type:
+        scalar: numeric
+    - name: tcpSocket
+      type:
+        namedType: io.k8s.api.core.v1.TCPSocketAction
+    - name: terminationGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: timeoutSeconds
+      type:
+        scalar: numeric
+- name: io.k8s.api.core.v1.ProcMountType
+  scalar: string
+- name: io.k8s.api.core.v1.Protocol
+  scalar: string
+- name: io.k8s.api.core.v1.PullPolicy
+  scalar: string
+- name: io.k8s.api.core.v1.ResourceClaim
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: request
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.ResourceFieldSelector
+  map:
+    fields:
+    - name: containerName
+      type:
+        scalar: string
+    - name: divisor
+      type:
+        namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+    - name: resource
+      type:
+        scalar: string
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.ResourceList
+  map:
+    elementType:
+      namedType: io.k8s.apimachinery.pkg.api.resource.Quantity
+- name: io.k8s.api.core.v1.ResourceRequirements
+  map:
+    fields:
+    - name: claims
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.ResourceClaim
+          elementRelationship: associative
+          keys:
+          - name
+    - name: limits
+      type:
+        namedType: io.k8s.api.core.v1.ResourceList
+    - name: requests
+      type:
+        namedType: io.k8s.api.core.v1.ResourceList
+- name: io.k8s.api.core.v1.SELinuxOptions
+  map:
+    fields:
+    - name: level
+      type:
+        scalar: string
+    - name: role
+      type:
+        scalar: string
+    - name: type
+      type:
+        scalar: string
+    - name: user
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SeccompProfile
+  map:
+    fields:
+    - name: localhostProfile
+      type:
+        scalar: string
+    - name: type
+      type:
+        namedType: io.k8s.api.core.v1.SeccompProfileType
+- name: io.k8s.api.core.v1.SeccompProfileType
+  scalar: string
+- name: io.k8s.api.core.v1.SecretEnvSource
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: optional
+      type:
+        scalar: boolean
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.SecretKeySelector
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+      default: ""
+    - name: optional
+      type:
+        scalar: boolean
+    elementRelationship: atomic
+- name: io.k8s.api.core.v1.SecretVolumeSource
+  map:
+    fields:
+    - name: defaultMode
+      type:
+        scalar: numeric
+    - name: defaultUser
+      type:
+        scalar: numeric
+    - name: items
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.api.core.v1.KeyToPath
+          elementRelationship: atomic
+    - name: optional
+      type:
+        scalar: boolean
+    - name: secretName
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.SecurityContext
+  map:
+    fields:
+    - name: allowPrivilegeEscalation
+      type:
+        scalar: boolean
+    - name: appArmorProfile
+      type:
+        namedType: io.k8s.api.core.v1.AppArmorProfile
+    - name: capabilities
+      type:
+        namedType: io.k8s.api.core.v1.Capabilities
+    - name: privileged
+      type:
+        scalar: boolean
+    - name: procMount
+      type:
+        namedType: io.k8s.api.core.v1.ProcMountType
+    - name: readOnlyRootFilesystem
+      type:
+        scalar: boolean
+    - name: runAsGroup
+      type:
+        scalar: numeric
+    - name: runAsNonRoot
+      type:
+        scalar: boolean
+    - name: runAsUser
+      type:
+        scalar: numeric
+    - name: seLinuxOptions
+      type:
+        namedType: io.k8s.api.core.v1.SELinuxOptions
+    - name: seccompProfile
+      type:
+        namedType: io.k8s.api.core.v1.SeccompProfile
+    - name: windowsOptions
+      type:
+        namedType: io.k8s.api.core.v1.WindowsSecurityContextOptions
+- name: io.k8s.api.core.v1.StorageMedium
+  scalar: string
+- name: io.k8s.api.core.v1.SupplementalGroupsPolicy
+  scalar: string
+- name: io.k8s.api.core.v1.Sysctl
+  map:
+    fields:
+    - name: name
+      type:
+        scalar: string
+    - name: value
+      type:
+        scalar: string
+- name: io.k8s.api.core.v1.TCPSocketAction
+  map:
+    fields:
+    - name: host
+      type:
+        scalar: string
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+- name: io.k8s.api.core.v1.URIScheme
+  scalar: string
+- name: io.k8s.api.core.v1.WindowsSecurityContextOptions
+  map:
+    fields:
+    - name: gmsaCredentialSpec
+      type:
+        scalar: string
+    - name: gmsaCredentialSpecName
+      type:
+        scalar: string
+    - name: hostProcess
+      type:
+        scalar: boolean
+    - name: runAsUserName
+      type:
+        scalar: string
+- name: io.k8s.api.networking.v1.IPBlock
+  map:
+    fields:
+    - name: cidr
+      type:
+        scalar: string
+    - name: except
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.api.networking.v1.NetworkPolicyPeer
+  map:
+    fields:
+    - name: ipBlock
+      type:
+        namedType: io.k8s.api.networking.v1.IPBlock
+    - name: namespaceSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+    - name: podSelector
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+- name: io.k8s.api.networking.v1.NetworkPolicyPort
+  map:
+    fields:
+    - name: endPort
+      type:
+        scalar: numeric
+    - name: port
+      type:
+        namedType: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+    - name: protocol
+      type:
+        namedType: io.k8s.api.core.v1.Protocol
+- name: io.k8s.apimachinery.pkg.api.resource.Quantity
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Condition
+  map:
+    fields:
+    - name: lastTransitionTime
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: message
+      type:
+        scalar: string
+    - name: observedGeneration
+      type:
+        scalar: numeric
+    - name: reason
+      type:
+        scalar: string
+    - name: status
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ConditionStatus
+    - name: type
+      type:
+        scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ConditionStatus
+  scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1
+  map:
+    elementType:
+      scalar: untyped
+      list:
+        elementType:
+          namedType: __untyped_atomic_
+        elementRelationship: atomic
+      map:
+        elementType:
+          namedType: __untyped_deduced_
+        elementRelationship: separable
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+  map:
+    fields:
+    - name: matchExpressions
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement
+          elementRelationship: atomic
+    - name: matchLabels
+      type:
+        map:
+          elementType:
+            scalar: string
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorOperator
+  scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement
+  map:
+    fields:
+    - name: key
+      type:
+        scalar: string
+    - name: operator
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorOperator
+    - name: values
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: fieldsType
+      type:
+        scalar: string
+    - name: fieldsV1
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1
+    - name: manager
+      type:
+        scalar: string
+    - name: operation
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsOperationType
+    - name: subresource
+      type:
+        scalar: string
+    - name: time
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsOperationType
+  scalar: string
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta
+  map:
+    fields:
+    - name: annotations
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: creationTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: deletionGracePeriodSeconds
+      type:
+        scalar: numeric
+    - name: deletionTimestamp
+      type:
+        namedType: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+    - name: finalizers
+      type:
+        list:
+          elementType:
+            scalar: string
+          elementRelationship: associative
+    - name: generateName
+      type:
+        scalar: string
+    - name: generation
+      type:
+        scalar: numeric
+    - name: labels
+      type:
+        map:
+          elementType:
+            scalar: string
+    - name: managedFields
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry
+          elementRelationship: atomic
+    - name: name
+      type:
+        scalar: string
+    - name: namespace
+      type:
+        scalar: string
+    - name: ownerReferences
+      type:
+        list:
+          elementType:
+            namedType: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+          elementRelationship: associative
+          keys:
+          - uid
+    - name: resourceVersion
+      type:
+        scalar: string
+    - name: selfLink
+      type:
+        scalar: string
+    - name: uid
+      type:
+        namedType: io.k8s.apimachinery.pkg.types.UID
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference
+  map:
+    fields:
+    - name: apiVersion
+      type:
+        scalar: string
+    - name: blockOwnerDeletion
+      type:
+        scalar: boolean
+    - name: controller
+      type:
+        scalar: boolean
+    - name: kind
+      type:
+        scalar: string
+    - name: name
+      type:
+        scalar: string
+    - name: uid
+      type:
+        namedType: io.k8s.apimachinery.pkg.types.UID
+    elementRelationship: atomic
+- name: io.k8s.apimachinery.pkg.apis.meta.v1.Time
+  scalar: untyped
+- name: io.k8s.apimachinery.pkg.types.UID
+  scalar: string
+- name: io.k8s.apimachinery.pkg.util.intstr.IntOrString
+  scalar: untyped
+  list:
+    elementType:
+      namedType: __untyped_atomic_
+    elementRelationship: atomic
+  map:
+    elementType:
+      namedType: __untyped_deduced_
+    elementRelationship: separable
 - name: __untyped_atomic_
   scalar: untyped
   list:

--- a/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.x-k8s.io_mcpservers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: mcpservers.mcp.x-k8s.io
 spec:
   group: mcp.x-k8s.io

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
 go 1.26.0
 
-toolchain go1.27.0
+toolchain go1.27.1
 
 require (
 	github.com/go-logr/logr v1.4.4

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-sigs/mcp-lifecycle-operator
 
 go 1.26.0
 
-toolchain go1.26.6
+toolchain go1.27.0
 
 require (
 	github.com/go-logr/logr v1.4.4

--- a/internal/controller/audit.go
+++ b/internal/controller/audit.go
@@ -33,7 +33,7 @@ func auditLog(ctx context.Context) logr.Logger {
 func auditFields(mcpServer *mcpv1alpha1.MCPServer) []any {
 	return []any{
 		"mcpserver", mcpServer.Name,
-		"namespace", mcpServer.Namespace,
+		keyNamespace, mcpServer.Namespace,
 		"generation", mcpServer.Generation,
 		"resourceVersion", mcpServer.ResourceVersion,
 	}
@@ -128,7 +128,7 @@ func auditConfigurationRejected(ctx context.Context, mcpServer *mcpv1alpha1.MCPS
 	auditLog(ctx).Info("audit",
 		append(auditFields(mcpServer),
 			"operation", "ConfigurationRejected",
-			"reason", reason,
+			keyReason, reason,
 			"message", message,
 		)...,
 	)

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -26,6 +26,17 @@ const (
 // in operator-created Deployments.
 const ManagedWorkloadName = "mcp-server"
 
+// Metric label and structured-log field keys. The same value is used both as a
+// Prometheus label name and as a logr key so metrics and logs stay correlated.
+const (
+	keyName      = "name"
+	keyNamespace = "namespace"
+	keyReason    = "reason"
+	keyPhase     = "phase"
+	keyType      = "type"
+	keyStatus    = "status"
+)
+
 // ReconcilePhase is the value for the "phase" label on mcpserver_reconcile_phase_duration_seconds.
 const (
 	ReconcilePhaseValidation    = "validation"

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -222,7 +222,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
-	logger.Info("Reconciling MCPServer", "name", mcpServer.Name, "namespace", mcpServer.Namespace)
+	logger.Info("Reconciling MCPServer", keyName, mcpServer.Name, keyNamespace, mcpServer.Namespace)
 
 	pendingAcceptedEvent := !acceptedConditionIsTrue(mcpServer.Status.Conditions)
 	pendingServerReadyEvent := !readyConditionIsAvailable(mcpServer.Status.Conditions)
@@ -230,10 +230,9 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Validate configuration
 	validationStart := time.Now()
 	if err := r.validateConfig(ctx, mcpServer); err != nil {
-		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseValidation}).Observe(time.Since(validationStart).Seconds())
+		reconcileDuration.With(prometheus.Labels{keyPhase: ReconcilePhaseValidation}).Observe(time.Since(validationStart).Seconds())
 
-		var validationErr *ValidationError
-		if errors.As(err, &validationErr) {
+		if validationErr, ok := errors.AsType[*ValidationError](err); ok {
 			return ctrl.Result{}, r.reconcilePermanentValidationError(ctx, mcpServer, validationErr)
 		}
 
@@ -242,7 +241,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Don't update status - preserve existing Accepted condition
 		return ctrl.Result{}, err
 	}
-	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseValidation}).Observe(time.Since(validationStart).Seconds())
+	reconcileDuration.With(prometheus.Labels{keyPhase: ReconcilePhaseValidation}).Observe(time.Since(validationStart).Seconds())
 
 	// Configuration is valid - create Accepted=True condition
 	acceptedCondition := newCondition(
@@ -266,12 +265,12 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Configuration is valid, proceed with deployment reconciliation
 	deploymentStart := time.Now()
 	existingDeployment, err := r.reconcileDeployment(ctx, mcpServer)
-	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseDeployment}).Observe(time.Since(deploymentStart).Seconds())
+	reconcileDuration.With(prometheus.Labels{keyPhase: ReconcilePhaseDeployment}).Observe(time.Since(deploymentStart).Seconds())
 	if err != nil {
 		deploymentFailuresTotal.With(prometheus.Labels{
-			"name":      mcpServer.Name,
-			"namespace": mcpServer.Namespace,
-			"reason":    MetricReasonReconcileError,
+			keyName:      mcpServer.Name,
+			keyNamespace: mcpServer.Namespace,
+			keyReason:    MetricReasonReconcileError,
 		}).Inc()
 		// Deployment reconciliation failed - update status
 		readyCondition := newCondition(
@@ -314,7 +313,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Reconcile Service
 	serviceStart := time.Now()
 	if err := r.reconcileService(ctx, mcpServer); err != nil {
-		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
+		reconcileDuration.With(prometheus.Labels{keyPhase: ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
 		return r.handleResourceFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err, resourceFailureParams{
 			counter:     serviceFailuresTotal,
 			reason:      ReasonServiceUnavailable,
@@ -324,12 +323,12 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		})
 	}
 
-	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
+	reconcileDuration.With(prometheus.Labels{keyPhase: ReconcilePhaseService}).Observe(time.Since(serviceStart).Seconds())
 
 	// Reconcile NetworkPolicy
 	networkPolicyStart := time.Now()
 	if err := r.reconcileNetworkPolicy(ctx, mcpServer); err != nil {
-		reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
+		reconcileDuration.With(prometheus.Labels{keyPhase: ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
 		return r.handleResourceFailure(ctx, mcpServer, existingDeployment, acceptedCondition, err, resourceFailureParams{
 			counter:     networkPolicyFailuresTotal,
 			reason:      ReasonNetworkPolicyUnavailable,
@@ -338,7 +337,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			emitEvent:   r.emitNetworkPolicyReconcileFailed,
 		})
 	}
-	reconcileDuration.With(prometheus.Labels{"phase": ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
+	reconcileDuration.With(prometheus.Labels{keyPhase: ReconcilePhaseNetworkPolicy}).Observe(time.Since(networkPolicyStart).Seconds())
 
 	// Determine Ready condition based on deployment status
 	readyCondition := r.reconcileReadyCondition(
@@ -482,13 +481,13 @@ func (r *MCPServerReconciler) shouldSkipReconciliation(ctx context.Context, mcpS
 	ns := &corev1.Namespace{}
 	if err := r.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("Namespace not found, skipping reconciliation", "namespace", namespace)
+			logger.Info("Namespace not found, skipping reconciliation", keyNamespace, namespace)
 			return true, nil
 		}
 		return false, err
 	}
 	if ns.DeletionTimestamp != nil {
-		logger.Info("Namespace is terminating, skipping reconciliation", "namespace", namespace)
+		logger.Info("Namespace is terminating, skipping reconciliation", keyNamespace, namespace)
 		return true, nil
 	}
 	return false, nil
@@ -514,9 +513,9 @@ func (r *MCPServerReconciler) reconcilePermanentValidationError(
 		acceptedCondition.Type, string(acceptedCondition.Status), acceptedCondition.Reason)
 
 	validationFailuresTotal.With(prometheus.Labels{
-		"name":      mcpServer.Name,
-		"namespace": mcpServer.Namespace,
-		"reason":    validationErr.Reason,
+		keyName:      mcpServer.Name,
+		keyNamespace: mcpServer.Namespace,
+		keyReason:    validationErr.Reason,
 	}).Inc()
 
 	readyCondition := newCondition(
@@ -552,7 +551,7 @@ func (r *MCPServerReconciler) reconcilePermanentValidationError(
 		r.emitConfigurationInvalid(mcpServer, validationErr)
 	}
 
-	logger.Info("MCPServer configuration is invalid", "reason", validationErr.Reason)
+	logger.Info("MCPServer configuration is invalid", keyReason, validationErr.Reason)
 	auditConfigurationRejected(ctx, mcpServer, validationErr.Reason, validationErr.Message)
 	recordCondition(mcpServer.Name, mcpServer.Namespace,
 		readyCondition.Type, string(readyCondition.Status), readyCondition.Reason)
@@ -639,9 +638,9 @@ func (r *MCPServerReconciler) handleResourceFailure(
 	logger := log.FromContext(ctx)
 
 	params.counter.With(prometheus.Labels{
-		"name":      mcpServer.Name,
-		"namespace": mcpServer.Namespace,
-		"reason":    MetricReasonReconcileError,
+		keyName:      mcpServer.Name,
+		keyNamespace: mcpServer.Namespace,
+		keyReason:    MetricReasonReconcileError,
 	}).Inc()
 
 	readyCondition := newCondition(

--- a/internal/controller/mcpserver_controller_confighash.go
+++ b/internal/controller/mcpserver_controller_confighash.go
@@ -156,7 +156,7 @@ func (r *MCPServerReconciler) findMCPServersForResource(
 	); err != nil {
 		logger.Error(err, "Failed to list MCPServers for resource",
 			"resourceName", resourceName,
-			"namespace", namespace,
+			keyNamespace, namespace,
 			"indexKey", indexKey)
 		return []reconcile.Request{}
 	}

--- a/internal/controller/mcpserver_controller_deployment.go
+++ b/internal/controller/mcpserver_controller_deployment.go
@@ -60,7 +60,7 @@ func (r *MCPServerReconciler) reconcileDeployment(
 	existingDeployment := &appsv1.Deployment{}
 	err = r.Get(ctx, client.ObjectKey{Name: deployment.Name, Namespace: deployment.Namespace}, existingDeployment)
 	if err != nil && apierrors.IsNotFound(err) {
-		logger.Info("Creating Deployment", "name", deployment.Name)
+		logger.Info("Creating Deployment", keyName, deployment.Name)
 		if err := applyCustomDeploymentMetadata(mcpServer, deployment); err != nil {
 			return nil, fmt.Errorf("applying custom metadata failed; %w", err)
 		}
@@ -107,10 +107,10 @@ func (r *MCPServerReconciler) reconcileDeployment(
 
 	needsUpdate := deploymentNeedsUpdate(mcpServer, existingDeployment, deployment, ownershipChanged)
 	if needsUpdate && len(existingDeployment.Spec.Template.Spec.Containers) == 0 {
-		logger.Info("Recovering deployment with empty containers list", "name", existingDeployment.Name)
+		logger.Info("Recovering deployment with empty containers list", keyName, existingDeployment.Name)
 	}
 	if needsUpdate {
-		logger.Info("Updating Deployment", "name", existingDeployment.Name)
+		logger.Info("Updating Deployment", keyName, existingDeployment.Name)
 		existingDeployment.Spec.Replicas = deployment.Spec.Replicas
 		existingDeployment.Spec.Template.Labels = deployment.Spec.Template.Labels
 		existingDeployment.Spec.Template.Annotations = deployment.Spec.Template.Annotations
@@ -130,7 +130,7 @@ func (r *MCPServerReconciler) reconcileDeployment(
 			return nil, err
 		}
 	} else {
-		logger.Info("Deployment already exists and is up to date", "name", deployment.Name)
+		logger.Info("Deployment already exists and is up to date", keyName, deployment.Name)
 	}
 
 	return existingDeployment, nil

--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -45,8 +45,8 @@ func (r *MCPServerReconciler) reconcileHandshake(
 	logger := log.FromContext(ctx)
 
 	metricLabels := prometheus.Labels{
-		"name":      mcpServer.Name,
-		"namespace": mcpServer.Namespace,
+		keyName:      mcpServer.Name,
+		keyNamespace: mcpServer.Namespace,
 	}
 
 	key := mcpServer.Namespace + "/" + mcpServer.Name

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -875,7 +875,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 						Tools:     true,
 						Resources: true,
 						Prompts:   false,
-						Logging:   true,
+						Logging:   true, //nolint:staticcheck // exercising the deprecated Logging field on purpose
 					},
 				}, nil
 			},

--- a/internal/controller/mcpserver_controller_networkpolicy.go
+++ b/internal/controller/mcpserver_controller_networkpolicy.go
@@ -49,7 +49,7 @@ func (r *MCPServerReconciler) reconcileNetworkPolicy(
 	existingNetpol := &networkingv1.NetworkPolicy{}
 	err := r.Get(ctx, client.ObjectKey{Name: netpol.Name, Namespace: netpol.Namespace}, existingNetpol)
 	if err != nil && apierrors.IsNotFound(err) {
-		logger.Info("Creating NetworkPolicy", "name", netpol.Name)
+		logger.Info("Creating NetworkPolicy", keyName, netpol.Name)
 		if err := applyCustomNetworkPolicyMetadata(mcpServer, netpol); err != nil {
 			return fmt.Errorf("applying custom metadata failed; %w", err)
 		}
@@ -58,10 +58,10 @@ func (r *MCPServerReconciler) reconcileNetworkPolicy(
 			return err
 		}
 		if mcpServer.Spec.Network == nil || len(mcpServer.Spec.Network.IngressFrom) == 0 {
-			logger.Info("NetworkPolicy created without ingress source restrictions", "name", netpol.Name)
+			logger.Info("NetworkPolicy created without ingress source restrictions", keyName, netpol.Name)
 		}
 		if mcpServer.Spec.Network == nil || (len(mcpServer.Spec.Network.EgressTo) == 0 && len(mcpServer.Spec.Network.EgressPorts) == 0) {
-			logger.Info("NetworkPolicy created without egress destination restrictions", "name", netpol.Name)
+			logger.Info("NetworkPolicy created without egress destination restrictions", keyName, netpol.Name)
 		}
 		auditNetworkPolicyCreated(ctx, mcpServer, netpol.Name, hasIngressSourceRestriction(netpol), hasEgressDestinationRestriction(netpol))
 		return nil
@@ -95,7 +95,7 @@ func (r *MCPServerReconciler) reconcileNetworkPolicy(
 		networkPolicyAnnotationsChanged(mcpServer, existingNetpol) ||
 		ownershipChanged
 	if needsUpdate {
-		logger.Info("Updating NetworkPolicy", "name", existingNetpol.Name)
+		logger.Info("Updating NetworkPolicy", keyName, existingNetpol.Name)
 		if existingNetpol.Labels == nil {
 			existingNetpol.Labels = make(map[string]string)
 		}
@@ -110,7 +110,7 @@ func (r *MCPServerReconciler) reconcileNetworkPolicy(
 		}
 		auditNetworkPolicyUpdated(ctx, mcpServer, existingNetpol.Name)
 	} else {
-		logger.Info("NetworkPolicy already exists and is up to date", "name", netpol.Name)
+		logger.Info("NetworkPolicy already exists and is up to date", keyName, netpol.Name)
 	}
 
 	return nil

--- a/internal/controller/mcpserver_controller_service.go
+++ b/internal/controller/mcpserver_controller_service.go
@@ -48,7 +48,7 @@ func (r *MCPServerReconciler) reconcileService(
 	existingService := &corev1.Service{}
 	err := r.Get(ctx, client.ObjectKey{Name: service.Name, Namespace: service.Namespace}, existingService)
 	if err != nil && apierrors.IsNotFound(err) {
-		logger.Info("Creating Service", "name", service.Name)
+		logger.Info("Creating Service", keyName, service.Name)
 		if err := applyCustomServiceMetadata(mcpServer, service); err != nil {
 			return fmt.Errorf("applying custom metadata failed; %w", err)
 		}
@@ -96,7 +96,7 @@ func (r *MCPServerReconciler) reconcileService(
 		serviceAnnotationsChanged(mcpServer, existingService) ||
 		ownershipChanged
 	if needsUpdate {
-		logger.Info("Updating Service", "name", existingService.Name)
+		logger.Info("Updating Service", keyName, existingService.Name)
 		if err := applyCustomServiceMetadata(mcpServer, existingService); err != nil {
 			return fmt.Errorf("applying custom service metadata; %w", err)
 		}
@@ -108,7 +108,7 @@ func (r *MCPServerReconciler) reconcileService(
 			return err
 		}
 	} else {
-		logger.Info("Service already exists and is up to date", "name", service.Name)
+		logger.Info("Service already exists and is up to date", keyName, service.Name)
 	}
 
 	return nil

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -32,7 +32,7 @@ var (
 			Name:      "condition_info",
 			Help:      "Current condition state of MCPServer resources. Value is always 1; use labels to filter.",
 		},
-		[]string{"name", "namespace", "type", "status", "reason"},
+		[]string{keyName, keyNamespace, keyType, keyStatus, keyReason},
 	)
 
 	// validationFailuresTotal counts configuration validation failures.
@@ -43,7 +43,7 @@ var (
 			Name:      "validation_failures_total",
 			Help:      "Total number of configuration validation failures.",
 		},
-		[]string{"name", "namespace", "reason"},
+		[]string{keyName, keyNamespace, keyReason},
 	)
 
 	// deploymentFailuresTotal counts deployment reconciliation failures.
@@ -54,7 +54,7 @@ var (
 			Name:      "deployment_failures_total",
 			Help:      "Total number of deployment reconciliation failures.",
 		},
-		[]string{"name", "namespace", "reason"},
+		[]string{keyName, keyNamespace, keyReason},
 	)
 
 	// serviceFailuresTotal counts service reconciliation failures.
@@ -65,7 +65,7 @@ var (
 			Name:      "service_failures_total",
 			Help:      "Total number of service reconciliation failures.",
 		},
-		[]string{"name", "namespace", "reason"},
+		[]string{keyName, keyNamespace, keyReason},
 	)
 
 	// networkPolicyFailuresTotal counts network policy reconciliation failures.
@@ -76,7 +76,7 @@ var (
 			Name:      "networkpolicy_failures_total",
 			Help:      "Total number of network policy reconciliation failures.",
 		},
-		[]string{"name", "namespace", "reason"},
+		[]string{keyName, keyNamespace, keyReason},
 	)
 
 	// reconcileDuration tracks the duration of reconciliation phases.
@@ -88,7 +88,7 @@ var (
 			Help:      "Duration of reconciliation phases in seconds.",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"phase"},
+		[]string{keyPhase},
 	)
 
 	handshakeTotal = prometheus.NewCounterVec(
@@ -97,7 +97,7 @@ var (
 			Name:      "handshake_total",
 			Help:      "Total number of MCP handshake outcomes.",
 		},
-		[]string{"name", "namespace", "result"},
+		[]string{keyName, keyNamespace, "result"},
 	)
 
 	handshakeDuration = prometheus.NewHistogramVec(
@@ -107,7 +107,7 @@ var (
 			Help:      "Duration of MCP handshake operations in seconds.",
 			Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
-		[]string{"name", "namespace"},
+		[]string{keyName, keyNamespace},
 	)
 
 	// capabilityChangesTotal counts MCP server capability changes detected between generations.
@@ -118,7 +118,7 @@ var (
 			Name:      "capability_changes_total",
 			Help:      "Total number of MCP server capability changes detected.",
 		},
-		[]string{"name", "namespace"},
+		[]string{keyName, keyNamespace},
 	)
 )
 
@@ -141,24 +141,24 @@ func init() {
 func recordCondition(name, namespace, condType, status, reason string) {
 	// Delete all status/reason variants for this condition type to ensure only one is active
 	conditionInfo.DeletePartialMatch(prometheus.Labels{
-		"name":      name,
-		"namespace": namespace,
-		"type":      condType,
+		keyName:      name,
+		keyNamespace: namespace,
+		keyType:      condType,
 	})
 	conditionInfo.With(prometheus.Labels{
-		"name":      name,
-		"namespace": namespace,
-		"type":      condType,
-		"status":    status,
-		"reason":    reason,
+		keyName:      name,
+		keyNamespace: namespace,
+		keyType:      condType,
+		keyStatus:    status,
+		keyReason:    reason,
 	}).Set(1)
 }
 
 // cleanupMetrics removes all metrics for a deleted MCPServer.
 func cleanupMetrics(name, namespace string) {
 	labels := prometheus.Labels{
-		"name":      name,
-		"namespace": namespace,
+		keyName:      name,
+		keyNamespace: namespace,
 	}
 	conditionInfo.DeletePartialMatch(labels)
 	validationFailuresTotal.DeletePartialMatch(labels)

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	netpath "path"
+	"strings"
 	"testing"
 	"time"
 
@@ -225,18 +226,18 @@ func PrewarmImages(images ...string) env.Func {
 				nsResources := cfg.Client().Resources(prewarmNs)
 				var pods corev1.PodList
 				if listErr := nsResources.List(ctx, &pods, resources.WithLabelSelector("app="+dsName)); listErr == nil {
-					var details string
+					var details strings.Builder
 					for _, pod := range pods.Items {
 						for _, cs := range pod.Status.ContainerStatuses {
 							if cs.State.Waiting != nil {
-								details += fmt.Sprintf("pod %s container %s: %s (%s); ", pod.Name, cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
+								fmt.Fprintf(&details, "pod %s container %s: %s (%s); ", pod.Name, cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
 							} else if cs.State.Terminated != nil {
-								details += fmt.Sprintf("pod %s container %s: %s (exit code %d); ", pod.Name, cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.ExitCode)
+								fmt.Fprintf(&details, "pod %s container %s: %s (exit code %d); ", pod.Name, cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.ExitCode)
 							}
 						}
 					}
-					if details != "" {
-						return ctx, fmt.Errorf("prewarm image %s: %s: %w", img, details, err)
+					if details.Len() != 0 {
+						return ctx, fmt.Errorf("prewarm image %s: %s: %w", img, details.String(), err)
 					}
 				}
 				return ctx, fmt.Errorf("prewarm image %s: %w", img, err)


### PR DESCRIPTION
Raise the build toolchain to Go 1.27 and bring the supporting tooling in line with it:

- go.mod: toolchain go1.27.1 (the go directive stays at 1.26.0)
- Dockerfile: golang:1.27.1 across all build stages
- Makefile: controller-tools v0.21.0 (v0.20.0 fails to build under Go 1.27)
- .github/workflows/lint.yml: golangci-lint v2.13.0, the first release built with go1.27.1; earlier versions refuse to analyze a Go 1.27 target
- regenerate CRDs and applyconfiguration with controller-gen v0.21.0

Address the new lint findings that surface once the analyzers run against Go 1.27:

- .golangci.yml: set goconst ignore-tests
- extract repeated Prometheus label and logr key literals into named constants in internal/controller
- errors.AsType for the ValidationError type assertion (modernize)
- strings.Builder for incremental string construction in the e2e framework (modernize)
- nolint the intentional use of the deprecated Logging capability field in a handshake test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added apply-configuration extraction support for MCPServer resources and their status.
  - Added schema coverage for v1beta1 API types and related Kubernetes resources.

- **Improvements**
  - Added validation and Service reconciliation duration metrics.
  - Standardized metric labels and structured log fields for more consistent monitoring and troubleshooting.

- **Maintenance**
  - Updated the Go toolchain, controller-generation tooling, and linting workflow.
  - Added cert-manager deployment support for end-to-end testing.
  - Refined lint configuration and diagnostic message construction without changing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->