### PR TITLE
feat: honor TLS_GROUPS for TLS 1.3 curve/group preferences

### DIFF
--- a/cmd/tlsconfig.go
+++ b/cmd/tlsconfig.go
@@ -12,21 +12,34 @@ import (
 const (
 	envTLSMinVersion   = "TLS_MIN_VERSION"
 	envTLSCipherSuites = "TLS_CIPHER_SUITES"
+	envTLSGroups       = "TLS_GROUPS"
+)
+
+// Canonical TLS 1.3 group names, used both as the value re-emitted in the
+// TLS_GROUPS env var and as the keys/values in tlsGroupLookup.
+const (
+	groupX25519         = "X25519"
+	groupCurveP256      = "CurveP256"
+	groupCurveP384      = "CurveP384"
+	groupCurveP521      = "CurveP521"
+	groupX25519MLKEM768 = "X25519MLKEM768"
 )
 
 // tlsSettings holds validated TLS configuration parsed from the environment.
 // Both the tls.Config mutator and the env vars propagated to MCP server
 // containers are derived from this single source of truth.
 type tlsSettings struct {
-	minVersionStr   string   // original env value, empty if unset or invalid
-	minVersionCode  uint16   // parsed TLS version constant, 0 if unset or invalid
-	cipherSuitesStr string   // comma-separated list of validated cipher suite names
-	cipherSuiteIDs  []uint16 // parsed cipher suite IDs for validated names
+	minVersionStr   string        // original env value, empty if unset or invalid
+	minVersionCode  uint16        // parsed TLS version constant, 0 if unset or invalid
+	cipherSuitesStr string        // comma-separated list of validated cipher suite names
+	cipherSuiteIDs  []uint16      // parsed cipher suite IDs for validated names
+	groupsStr       string        // comma-separated list of validated, canonicalized group names
+	groupIDs        []tls.CurveID // parsed curve/group IDs for validated names
 }
 
-// parseTLSSettings reads TLS_MIN_VERSION and TLS_CIPHER_SUITES from the
-// environment, validates them, and returns a tlsSettings with only the
-// values that passed validation.
+// parseTLSSettings reads TLS_MIN_VERSION, TLS_CIPHER_SUITES and TLS_GROUPS
+// from the environment, validates them, and returns a tlsSettings with only
+// the values that passed validation.
 func parseTLSSettings() tlsSettings {
 	log := ctrl.Log.WithName("setup")
 
@@ -49,14 +62,23 @@ func parseTLSSettings() tlsSettings {
 		}
 	}
 
+	if raw := os.Getenv(envTLSGroups); raw != "" {
+		ids, names := parseTLSGroups(raw, log)
+		if len(ids) > 0 {
+			s.groupIDs = ids
+			s.groupsStr = strings.Join(names, ",")
+		}
+	}
+
 	if s.minVersionCode >= tls.VersionTLS13 && len(s.cipherSuiteIDs) > 0 {
 		log.Info("TLS 1.3 manages cipher suites automatically, configured suites will not be applied")
 	}
 
-	if s.minVersionStr != "" || s.cipherSuitesStr != "" {
+	if s.minVersionStr != "" || s.cipherSuitesStr != "" || s.groupsStr != "" {
 		log.Info("Applying TLS profile from environment",
 			"minVersion", s.minVersionStr,
-			"cipherSuiteCount", len(s.cipherSuiteIDs))
+			"cipherSuiteCount", len(s.cipherSuiteIDs),
+			"groupCount", len(s.groupIDs))
 	}
 
 	return s
@@ -72,13 +94,16 @@ func (s tlsSettings) envVars() []corev1.EnvVar {
 	if s.cipherSuitesStr != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: envTLSCipherSuites, Value: s.cipherSuitesStr})
 	}
+	if s.groupsStr != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: envTLSGroups, Value: s.groupsStr})
+	}
 	return envVars
 }
 
 // tlsConfigFunc returns a function that applies the validated TLS settings to
 // a tls.Config, or nil if no valid settings were parsed.
 func (s tlsSettings) tlsConfigFunc() func(*tls.Config) {
-	if s.minVersionCode == 0 && len(s.cipherSuiteIDs) == 0 {
+	if s.minVersionCode == 0 && len(s.cipherSuiteIDs) == 0 && len(s.groupIDs) == 0 {
 		return nil
 	}
 	return func(c *tls.Config) {
@@ -88,6 +113,9 @@ func (s tlsSettings) tlsConfigFunc() func(*tls.Config) {
 		// Go manages TLS 1.3 cipher suites automatically
 		if s.minVersionCode < tls.VersionTLS13 && len(s.cipherSuiteIDs) > 0 {
 			c.CipherSuites = s.cipherSuiteIDs
+		}
+		if len(s.groupIDs) > 0 {
+			c.CurvePreferences = s.groupIDs
 		}
 	}
 }
@@ -135,4 +163,61 @@ func parseCipherSuites(s string, log interface{ Info(string, ...any) }) ([]uint1
 	}
 
 	return suites, names
+}
+
+// tlsGroupLookup maps accepted TLS 1.3 named-group identifiers to their
+// crypto/tls CurveID. Keys are matched case-insensitively and cover the Go
+// canonical names plus the common IANA / OpenSSL aliases so the value can be
+// sourced from a platform TLS policy without translation. The canonical name
+// (used when re-emitting the value as an env var) is the Go constant name.
+var tlsGroupLookup = map[string]struct {
+	id        tls.CurveID
+	canonical string
+}{
+	"x25519":         {tls.X25519, groupX25519},
+	"curvep256":      {tls.CurveP256, groupCurveP256},
+	"p-256":          {tls.CurveP256, groupCurveP256},
+	"secp256r1":      {tls.CurveP256, groupCurveP256},
+	"curvep384":      {tls.CurveP384, groupCurveP384},
+	"p-384":          {tls.CurveP384, groupCurveP384},
+	"secp384r1":      {tls.CurveP384, groupCurveP384},
+	"curvep521":      {tls.CurveP521, groupCurveP521},
+	"p-521":          {tls.CurveP521, groupCurveP521},
+	"secp521r1":      {tls.CurveP521, groupCurveP521},
+	"x25519mlkem768": {tls.X25519MLKEM768, groupX25519MLKEM768},
+}
+
+// parseTLSGroups parses a comma-separated list of TLS 1.3 named groups
+// (elliptic curves and hybrid key-exchange groups) into CurveIDs suitable for
+// tls.Config.CurvePreferences. Unknown names are skipped with a log line,
+// mirroring parseCipherSuites. Returned names are canonicalized and
+// de-duplicated so re-parsing (e.g. in an operand container) is stable.
+func parseTLSGroups(s string, log interface{ Info(string, ...any) }) ([]tls.CurveID, []string) {
+	if s == "" {
+		return nil, nil
+	}
+
+	raw := strings.Split(s, ",")
+	groups := make([]tls.CurveID, 0, len(raw))
+	names := make([]string, 0, len(raw))
+	seen := make(map[tls.CurveID]bool, len(raw))
+
+	for _, name := range raw {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if g, ok := tlsGroupLookup[strings.ToLower(name)]; ok {
+			if seen[g.id] {
+				continue
+			}
+			seen[g.id] = true
+			groups = append(groups, g.id)
+			names = append(names, g.canonical)
+		} else {
+			log.Info("Skipping unknown TLS group", "group", name)
+		}
+	}
+
+	return groups, names
 }

--- a/cmd/tlsconfig_test.go
+++ b/cmd/tlsconfig_test.go
@@ -84,9 +84,77 @@ func TestParseCipherSuites(t *testing.T) {
 	})
 }
 
+func TestParseTLSGroups(t *testing.T) {
+	log := noopLogger{}
+
+	t.Run("Go canonical names", func(t *testing.T) {
+		ids, names := parseTLSGroups("X25519,CurveP384", log)
+		if len(ids) != 2 || ids[0] != tls.X25519 || ids[1] != tls.CurveP384 {
+			t.Fatalf("ids = %v, want [X25519 CurveP384]", ids)
+		}
+		if len(names) != 2 || names[0] != groupX25519 || names[1] != groupCurveP384 {
+			t.Errorf("names = %v, want [X25519 CurveP384]", names)
+		}
+	})
+
+	t.Run("IANA aliases are canonicalized case-insensitively", func(t *testing.T) {
+		ids, names := parseTLSGroups("secp256r1, P-521 , x25519", log)
+		want := []tls.CurveID{tls.CurveP256, tls.CurveP521, tls.X25519}
+		if len(ids) != len(want) {
+			t.Fatalf("expected %d groups, got %d (%v)", len(want), len(ids), ids)
+		}
+		for i := range want {
+			if ids[i] != want[i] {
+				t.Errorf("ids[%d] = %d, want %d", i, ids[i], want[i])
+			}
+		}
+		if len(names) != 3 || names[0] != groupCurveP256 || names[1] != groupCurveP521 || names[2] != groupX25519 {
+			t.Errorf("names = %v, want [CurveP256 CurveP521 X25519]", names)
+		}
+	})
+
+	t.Run("post-quantum hybrid group", func(t *testing.T) {
+		ids, names := parseTLSGroups("X25519MLKEM768", log)
+		if len(ids) != 1 || ids[0] != tls.X25519MLKEM768 {
+			t.Fatalf("ids = %v, want [X25519MLKEM768]", ids)
+		}
+		if len(names) != 1 || names[0] != groupX25519MLKEM768 {
+			t.Errorf("names = %v, want [X25519MLKEM768]", names)
+		}
+	})
+
+	t.Run("unknown names are skipped", func(t *testing.T) {
+		ids, names := parseTLSGroups("X25519,x448,bogus", log)
+		if len(ids) != 1 || ids[0] != tls.X25519 {
+			t.Fatalf("ids = %v, want [X25519]", ids)
+		}
+		if len(names) != 1 || names[0] != groupX25519 {
+			t.Errorf("names = %v, want [X25519]", names)
+		}
+	})
+
+	t.Run("duplicates are de-duplicated", func(t *testing.T) {
+		ids, names := parseTLSGroups("X25519,x25519,secp256r1,CurveP256", log)
+		if len(ids) != 2 || ids[0] != tls.X25519 || ids[1] != tls.CurveP256 {
+			t.Fatalf("ids = %v, want [X25519 CurveP256]", ids)
+		}
+		if len(names) != 2 {
+			t.Errorf("names = %v, want 2 entries", names)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		ids, names := parseTLSGroups("", log)
+		if ids != nil || names != nil {
+			t.Errorf("expected nil, nil; got %v, %v", ids, names)
+		}
+	})
+}
+
 func TestParseTLSSettings_Unset(t *testing.T) {
 	t.Setenv(envTLSMinVersion, "")
 	t.Setenv(envTLSCipherSuites, "")
+	t.Setenv(envTLSGroups, "")
 
 	s := parseTLSSettings()
 	if fn := s.tlsConfigFunc(); fn != nil {
@@ -94,6 +162,51 @@ func TestParseTLSSettings_Unset(t *testing.T) {
 	}
 	if envVars := s.envVars(); envVars != nil {
 		t.Errorf("expected nil envVars when env vars are unset, got %v", envVars)
+	}
+}
+
+func TestParseTLSSettings_AppliesGroups(t *testing.T) {
+	t.Setenv(envTLSMinVersion, "")
+	t.Setenv(envTLSCipherSuites, "")
+	t.Setenv(envTLSGroups, "X25519MLKEM768,X25519")
+
+	s := parseTLSSettings()
+
+	fn := s.tlsConfigFunc()
+	if fn == nil {
+		t.Fatal("expected non-nil TLS config function when only groups are set")
+	}
+	cfg := &tls.Config{}
+	fn(cfg)
+	if len(cfg.CurvePreferences) != 2 ||
+		cfg.CurvePreferences[0] != tls.X25519MLKEM768 ||
+		cfg.CurvePreferences[1] != tls.X25519 {
+		t.Errorf("CurvePreferences = %v, want [X25519MLKEM768 X25519]", cfg.CurvePreferences)
+	}
+
+	envVars := s.envVars()
+	if len(envVars) != 1 {
+		t.Fatalf("expected 1 env var, got %d (%v)", len(envVars), envVars)
+	}
+	if envVars[0].Name != envTLSGroups || envVars[0].Value != "X25519MLKEM768,X25519" {
+		t.Errorf("envVars[0] = %s=%s, want TLS_GROUPS=X25519MLKEM768,X25519", envVars[0].Name, envVars[0].Value)
+	}
+}
+
+func TestParseTLSSettings_GroupsUnsetLeavesCurvePreferences(t *testing.T) {
+	t.Setenv(envTLSMinVersion, "VersionTLS13")
+	t.Setenv(envTLSCipherSuites, "")
+	t.Setenv(envTLSGroups, "")
+
+	s := parseTLSSettings()
+	fn := s.tlsConfigFunc()
+	if fn == nil {
+		t.Fatal("expected non-nil TLS config function")
+	}
+	cfg := &tls.Config{}
+	fn(cfg)
+	if cfg.CurvePreferences != nil {
+		t.Errorf("CurvePreferences should be nil when groups unset, got %v", cfg.CurvePreferences)
 	}
 }
 


### PR DESCRIPTION
Extend the operator's TLS profile plumbing to parse a TLS_GROUPS env var and apply the configured TLS 1.3 named groups (elliptic curves and the X25519MLKEM768 hybrid key exchange) as tls.Config.CurvePreferences.

The value is applied to the operator's webhook and metrics serving endpoints (via tlsConfigFunc, already wired in cmd/main.go) and propagated to MCP server containers (via envVars). Group names are matched case-insensitively, accepting Go canonical names and common IANA/OpenSSL aliases, canonicalized on output, de-duplicated, and unknown names are skipped with a log line, mirroring parseCipherSuites.

Fixes: https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/378