### PR TITLE
fix: gate TLS CA bundle hash on Verified condition, not Available

### DIFF
--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -472,7 +472,7 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	r.updateTLSCABundleHash(mcpServer, tlsCABundleHash, availableCondition)
+	r.updateTLSCABundleHash(mcpServer, tlsCABundleHash, verifiedCondition)
 
 	if capDiff != "" {
 		capabilityChangesTotal.WithLabelValues(mcpServer.Name, mcpServer.Namespace).Inc()
@@ -657,17 +657,17 @@ func (r *MCPServerReconciler) emitServerReady(mcpServer *mcpv1beta1.MCPServer) {
 	if r.Recorder == nil {
 		return
 	}
-	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, ReasonAvailable, eventActionServerReady, "MCPServer %s is ready; Ready=True", mcpServer.Name)
+	r.Recorder.Eventf(mcpServer, nil, corev1.EventTypeNormal, ReasonAvailable, eventActionServerReady, "MCPServer %s is ready; Available=True, Verified=True", mcpServer.Name)
 }
 
 func (r *MCPServerReconciler) maybeEmitDeploymentUnavailableEvent(
 	mcpServer *mcpv1beta1.MCPServer,
-	readyCondition metav1.Condition,
+	availableCondition metav1.Condition,
 ) {
-	if readyCondition.Status == metav1.ConditionFalse &&
-		readyCondition.Reason == ReasonDeploymentUnavailable &&
-		!duplicateDeploymentUnavailable(mcpServer.Status.Conditions, readyCondition.Message) {
-		r.emitDeploymentReconcileFailed(mcpServer, readyCondition.Message)
+	if availableCondition.Status == metav1.ConditionFalse &&
+		availableCondition.Reason == ReasonDeploymentUnavailable &&
+		!duplicateDeploymentUnavailable(mcpServer.Status.Conditions, availableCondition.Message) {
+		r.emitDeploymentReconcileFailed(mcpServer, availableCondition.Message)
 	}
 }
 

--- a/internal/controller/mcpserver_controller_handshake_test.go
+++ b/internal/controller/mcpserver_controller_handshake_test.go
@@ -451,7 +451,7 @@ var _ = Describe("MCPServer Controller - MCP Handshake Validation", func() {
 		Expect(serverReadyEvent).To(ContainSubstring(corev1.EventTypeNormal))
 		Expect(serverReadyEvent).To(ContainSubstring(ReasonAvailable))
 		Expect(serverReadyEvent).To(ContainSubstring(resourceName))
-		Expect(serverReadyEvent).To(ContainSubstring("Ready=True"))
+		Expect(serverReadyEvent).To(ContainSubstring("Available=True, Verified=True"))
 
 		By("Second reconcile — no duplicate ServerReady event")
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/mcpserver_controller_tls.go
+++ b/internal/controller/mcpserver_controller_tls.go
@@ -99,13 +99,12 @@ func buildTLSTransport(ctx context.Context, reader client.Reader, namespace stri
 func (r *MCPServerReconciler) updateTLSCABundleHash(
 	mcpServer *mcpv1beta1.MCPServer,
 	hash string,
-	readyCondition metav1.Condition,
+	verifiedCondition metav1.Condition,
 ) {
 	key := mcpServer.Namespace + "/" + mcpServer.Name
 	if hash == "" {
 		r.tlsCABundleHashes.Delete(key)
-	} else if readyCondition.Status == metav1.ConditionTrue &&
-		readyCondition.Reason == ReasonAvailable {
+	} else if verifiedCondition.Status == metav1.ConditionTrue {
 		r.tlsCABundleHashes.Store(key, hash)
 	}
 }


### PR DESCRIPTION
## Summary
- **Fix**: `updateTLSCABundleHash` was receiving `availableCondition` instead of `verifiedCondition`, storing the TLS CA bundle hash before the handshake passed. This violated the documented invariant that a failed handshake preserves the previous hash to force re-verification.
- **Cleanup**: Rename stale `readyCondition` parameters left over from the v1alpha1→v1beta1 migration to match the condition they actually receive (`availableCondition` / `verifiedCondition`).
- **Event message**: Update `emitServerReady` from `Ready=True` to `Available=True, Verified=True` to reflect the v1beta1 condition split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - TLS CA bundle state is now updated only after a successful verification handshake, improving connection status accuracy.
  - Deployment availability notifications now consistently reflect both availability and verification status.
  - Readiness-related event reporting has been aligned with the current availability and verification conditions.
  - Status events now report `Available=True` and `Verified=True` when the server is ready, providing clearer operational feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->