### PR TITLE
tls: apply client TLS profile with a TLS 1.2 floor via a shared helper

### DIFF
--- a/internal/controller/mcpserver_controller_handshake.go
+++ b/internal/controller/mcpserver_controller_handshake.go
@@ -98,11 +98,7 @@ func (r *MCPServerReconciler) reconcileHandshake(
 			return cond, nil
 		}
 		if tlsTransport != nil && tlsTransport.TLSClientConfig != nil && r.TLSProfile != nil {
-			floor := tlsTransport.TLSClientConfig.MinVersion
-			r.TLSProfile(tlsTransport.TLSClientConfig)
-			if tlsTransport.TLSClientConfig.MinVersion < floor {
-				tlsTransport.TLSClientConfig.MinVersion = floor
-			}
+			applyTLSProfileWithFloor(tlsTransport.TLSClientConfig, r.TLSProfile)
 		}
 	}
 

--- a/internal/controller/mcpserver_controller_tls.go
+++ b/internal/controller/mcpserver_controller_tls.go
@@ -93,6 +93,21 @@ func buildTLSTransport(ctx context.Context, reader client.Reader, namespace stri
 	return transport, nil
 }
 
+// applyTLSProfileWithFloor applies the operator-wide TLS profile (min version,
+// cipher suites and TLS 1.3 group/curve preferences) to the client config used
+// for MCP server handshakes, while guaranteeing the negotiated minimum version
+// never drops below the floor the transport was built with (TLS 1.2). Group
+// preferences and the X25519MLKEM768 hybrid only take effect once TLS 1.3 is
+// negotiated; the client keeps the TLS 1.2 floor so it can still reach servers
+// that do not speak TLS 1.3. Set TLS_MIN_VERSION=VersionTLS13 to require 1.3.
+func applyTLSProfileWithFloor(cfg *tls.Config, profile func(*tls.Config)) {
+	floor := cfg.MinVersion
+	profile(cfg)
+	if cfg.MinVersion < floor {
+		cfg.MinVersion = floor
+	}
+}
+
 // updateTLSCABundleHash persists the CA bundle hash in-memory only after the
 // status write succeeded and the handshake passed. A failed handshake preserves
 // the previous hash so re-verification is forced on the next reconcile.

--- a/internal/controller/mcpserver_controller_tls_profile_test.go
+++ b/internal/controller/mcpserver_controller_tls_profile_test.go
@@ -18,64 +18,52 @@ package controller
 
 import (
 	"crypto/tls"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// TestApplyTLSProfileWithFloor verifies that the operator-wide TLS profile is
-// applied to the MCP-server client config (min version, cipher suites and TLS
-// 1.3 group/curve preferences) while never letting the negotiated minimum
-// version drop below the TLS 1.2 floor the transport is built with.
-func TestApplyTLSProfileWithFloor(t *testing.T) {
-	t.Run("group preferences propagate to the client config", func(t *testing.T) {
+// applyTLSProfileWithFloor applies the operator-wide TLS profile to the
+// MCP-server client config (min version, cipher suites and TLS 1.3
+// group/curve preferences) while never letting the negotiated minimum version
+// drop below the TLS 1.2 floor the transport is built with.
+var _ = Describe("applyTLSProfileWithFloor", func() {
+	It("propagates group preferences to the client config", func() {
 		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 		groups := []tls.CurveID{tls.X25519MLKEM768, tls.X25519}
 		profile := func(c *tls.Config) { c.CurvePreferences = groups }
 
 		applyTLSProfileWithFloor(cfg, profile)
 
-		if len(cfg.CurvePreferences) != 2 ||
-			cfg.CurvePreferences[0] != tls.X25519MLKEM768 ||
-			cfg.CurvePreferences[1] != tls.X25519 {
-			t.Errorf("CurvePreferences = %v, want [X25519MLKEM768 X25519]", cfg.CurvePreferences)
-		}
-		if cfg.MinVersion != tls.VersionTLS12 {
-			t.Errorf("MinVersion = %d, want TLS 1.2 floor %d", cfg.MinVersion, tls.VersionTLS12)
-		}
+		Expect(cfg.CurvePreferences).To(Equal(groups))
+		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 	})
 
-	t.Run("profile cannot lower min version below the TLS 1.2 floor", func(t *testing.T) {
+	It("does not let the profile lower the min version below the TLS 1.2 floor", func() {
 		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 		profile := func(c *tls.Config) { c.MinVersion = tls.VersionTLS10 }
 
 		applyTLSProfileWithFloor(cfg, profile)
 
-		if cfg.MinVersion != tls.VersionTLS12 {
-			t.Errorf("MinVersion = %d, want floor preserved at TLS 1.2 %d", cfg.MinVersion, tls.VersionTLS12)
-		}
+		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 	})
 
-	t.Run("profile can raise the min version to TLS 1.3", func(t *testing.T) {
+	It("lets the profile raise the min version to TLS 1.3", func() {
 		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 		profile := func(c *tls.Config) { c.MinVersion = tls.VersionTLS13 }
 
 		applyTLSProfileWithFloor(cfg, profile)
 
-		if cfg.MinVersion != tls.VersionTLS13 {
-			t.Errorf("MinVersion = %d, want TLS 1.3 %d", cfg.MinVersion, tls.VersionTLS13)
-		}
+		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
 	})
 
-	t.Run("groups-only profile keeps the floor and sets curves", func(t *testing.T) {
+	It("keeps the floor and sets curves for a groups-only profile", func() {
 		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
 		profile := func(c *tls.Config) { c.CurvePreferences = []tls.CurveID{tls.CurveP256} }
 
 		applyTLSProfileWithFloor(cfg, profile)
 
-		if cfg.MinVersion != tls.VersionTLS12 {
-			t.Errorf("MinVersion = %d, want TLS 1.2 floor %d", cfg.MinVersion, tls.VersionTLS12)
-		}
-		if len(cfg.CurvePreferences) != 1 || cfg.CurvePreferences[0] != tls.CurveP256 {
-			t.Errorf("CurvePreferences = %v, want [CurveP256]", cfg.CurvePreferences)
-		}
+		Expect(cfg.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		Expect(cfg.CurvePreferences).To(Equal([]tls.CurveID{tls.CurveP256}))
 	})
-}
+})

--- a/internal/controller/mcpserver_controller_tls_profile_test.go
+++ b/internal/controller/mcpserver_controller_tls_profile_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+// TestApplyTLSProfileWithFloor verifies that the operator-wide TLS profile is
+// applied to the MCP-server client config (min version, cipher suites and TLS
+// 1.3 group/curve preferences) while never letting the negotiated minimum
+// version drop below the TLS 1.2 floor the transport is built with.
+func TestApplyTLSProfileWithFloor(t *testing.T) {
+	t.Run("group preferences propagate to the client config", func(t *testing.T) {
+		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		groups := []tls.CurveID{tls.X25519MLKEM768, tls.X25519}
+		profile := func(c *tls.Config) { c.CurvePreferences = groups }
+
+		applyTLSProfileWithFloor(cfg, profile)
+
+		if len(cfg.CurvePreferences) != 2 ||
+			cfg.CurvePreferences[0] != tls.X25519MLKEM768 ||
+			cfg.CurvePreferences[1] != tls.X25519 {
+			t.Errorf("CurvePreferences = %v, want [X25519MLKEM768 X25519]", cfg.CurvePreferences)
+		}
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion = %d, want TLS 1.2 floor %d", cfg.MinVersion, tls.VersionTLS12)
+		}
+	})
+
+	t.Run("profile cannot lower min version below the TLS 1.2 floor", func(t *testing.T) {
+		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		profile := func(c *tls.Config) { c.MinVersion = tls.VersionTLS10 }
+
+		applyTLSProfileWithFloor(cfg, profile)
+
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion = %d, want floor preserved at TLS 1.2 %d", cfg.MinVersion, tls.VersionTLS12)
+		}
+	})
+
+	t.Run("profile can raise the min version to TLS 1.3", func(t *testing.T) {
+		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		profile := func(c *tls.Config) { c.MinVersion = tls.VersionTLS13 }
+
+		applyTLSProfileWithFloor(cfg, profile)
+
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %d, want TLS 1.3 %d", cfg.MinVersion, tls.VersionTLS13)
+		}
+	})
+
+	t.Run("groups-only profile keeps the floor and sets curves", func(t *testing.T) {
+		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		profile := func(c *tls.Config) { c.CurvePreferences = []tls.CurveID{tls.CurveP256} }
+
+		applyTLSProfileWithFloor(cfg, profile)
+
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion = %d, want TLS 1.2 floor %d", cfg.MinVersion, tls.VersionTLS12)
+		}
+		if len(cfg.CurvePreferences) != 1 || cfg.CurvePreferences[0] != tls.CurveP256 {
+			t.Errorf("CurvePreferences = %v, want [CurveP256]", cfg.CurvePreferences)
+		}
+	})
+}


### PR DESCRIPTION
Extract the "apply the operator-wide TLS profile, then re-assert the build-time minimum version floor" logic from the handshake path into a documented applyTLSProfileWithFloor helper, and cover it with unit tests.

Group/curve preferences and the X25519MLKEM768 hybrid only take effect once TLS 1.3 is negotiated; the client keeps its TLS 1.2 floor so it can still reach servers that do not speak TLS 1.3. Set TLS_MIN_VERSION=VersionTLS13 to require 1.3.

Fixes: https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS profile handling during MCP server connections.
  * Ensures configured TLS profiles cannot lower the minimum supported version below TLS 1.2 while still allowing secure TLS 1.3 upgrades.
  * Preserves configured cipher suite and curve preferences.

* **Tests**
  * Added coverage for TLS version floors, upgrades, curve preferences, and partial TLS profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->