### PR TITLE
fix: use v1beta1 MCPServer in httproute provider controller

### DIFF
--- a/internal/controller/providers/httproute/controller.go
+++ b/internal/controller/providers/httproute/controller.go
@@ -39,6 +39,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	mcpcontroller "github.com/kubernetes-sigs/mcp-lifecycle-operator/internal/controller"
 	"github.com/kubernetes-sigs/mcp-lifecycle-operator/internal/controller/providers"
 )
@@ -98,7 +99,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	logger.Info("Reconciling MCPGatewayBinding", "name", binding.Name, "namespace", binding.Namespace)
 
-	mcpServer := &mcpv1alpha1.MCPServer{}
+	mcpServer := &mcpv1beta1.MCPServer{}
 	if err := r.Get(ctx, client.ObjectKey{Name: binding.Spec.MCPServerRef, Namespace: binding.Namespace}, mcpServer); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
@@ -323,7 +324,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Watches(
-			&mcpv1alpha1.MCPServer{},
+			&mcpv1beta1.MCPServer{},
 			handler.EnqueueRequestsFromMapFunc(r.findBindingsForMCPServer),
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).

--- a/internal/controller/providers/httproute/controller_test.go
+++ b/internal/controller/providers/httproute/controller_test.go
@@ -26,11 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 	mcpcontroller "github.com/kubernetes-sigs/mcp-lifecycle-operator/internal/controller"
 )
 
@@ -40,20 +43,20 @@ const (
 	testGatewayNS   = "gateway-ns"
 )
 
-func newTestMCPServer(name string) *mcpv1alpha1.MCPServer {
-	return &mcpv1alpha1.MCPServer{
+func newTestMCPServer(name string) *mcpv1beta1.MCPServer {
+	return &mcpv1beta1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
 		},
-		Spec: mcpv1alpha1.MCPServerSpec{
-			Source: mcpv1alpha1.Source{
-				Type: mcpv1alpha1.SourceTypeContainerImage,
-				ContainerImage: &mcpv1alpha1.ContainerImageSource{
+		Spec: mcpv1beta1.MCPServerSpec{
+			Source: mcpv1beta1.Source{
+				Type: mcpv1beta1.SourceTypeContainerImage,
+				ContainerImage: &mcpv1beta1.ContainerImageSource{
 					Ref: "docker.io/library/test-image:latest",
 				},
 			},
-			Config: mcpv1alpha1.ServerConfig{
+			Config: mcpv1beta1.ServerConfig{
 				Port: 8080,
 			},
 		},
@@ -142,7 +145,7 @@ var _ = Describe("HTTPRoute Provider Controller", func() {
 			&gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: bindingName, Namespace: testNamespace}},
 			&mcpv1alpha1.MCPGatewayBinding{ObjectMeta: metav1.ObjectMeta{Name: bindingName, Namespace: testNamespace}},
 			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName, Namespace: testNamespace}},
-			&mcpv1alpha1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: mcpServerName, Namespace: testNamespace}},
+			&mcpv1beta1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: mcpServerName, Namespace: testNamespace}},
 		} {
 			_ = k8sClient.Delete(ctx, obj)
 		}
@@ -707,7 +710,7 @@ var _ = Describe("HTTPRoute Provider Controller", func() {
 			createBinding(ProviderName)
 
 			r := newReconciler()
-			server := &mcpv1alpha1.MCPServer{
+			server := &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      mcpServerName,
 					Namespace: testNamespace,
@@ -722,7 +725,7 @@ var _ = Describe("HTTPRoute Provider Controller", func() {
 			createBinding(ProviderName)
 
 			r := newReconciler()
-			server := &mcpv1alpha1.MCPServer{
+			server := &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "other-server",
 					Namespace: testNamespace,
@@ -736,7 +739,7 @@ var _ = Describe("HTTPRoute Provider Controller", func() {
 			createBinding("custom-vendor")
 
 			r := newReconciler()
-			server := &mcpv1alpha1.MCPServer{
+			server := &mcpv1beta1.MCPServer{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      mcpServerName,
 					Namespace: testNamespace,
@@ -744,6 +747,21 @@ var _ = Describe("HTTPRoute Provider Controller", func() {
 			}
 			requests := r.findBindingsForMCPServer(ctx, server)
 			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Describe("SetupWithManager", func() {
+		It("should register the controller when the HTTPRoute CRD is present", func() {
+			mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+				Scheme:  k8sClient.Scheme(),
+				Metrics: metricsserver.Options{BindAddress: "0"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The Gateway API HTTPRoute CRD is installed by the suite, so setup
+			// should wire up the controller (including the MCPServer watch) rather
+			// than skip it.
+			Expect(Setup(mgr)).To(Succeed())
 		})
 	})
 })

--- a/internal/controller/providers/httproute/suite_test.go
+++ b/internal/controller/providers/httproute/suite_test.go
@@ -37,6 +37,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	mcpv1alpha1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1alpha1"
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
 )
 
 var (
@@ -59,6 +60,8 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	err = mcpv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = mcpv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = gatewayv1.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The reference Gateway API HTTPRoute provider controller (added in #275) read and watched MCPServer via the deprecated v1alpha1 type, while #334 switched all controllers to v1beta1. It worked only because the conversion webhook down-converts on read, a hidden dependency on v1alpha1 staying served.

Switch the Get and the Watches source to v1beta1.MCPServer, and register v1beta1 in the test suite scheme and fixtures. Only Spec.Config.Path and Spec.Config.Port are used, which exist identically on both versions, so this is behavior-preserving. MCPGatewayBinding stays on v1alpha1 since it has no v1beta1 version yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTPRoute integration to use the current MCPServer API version.
  * Improved compatibility when reconciling MCPServer references and monitoring their changes.
  * Updated related test coverage to validate the current API version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->