### PR TITLE
fix: recreate E2E prewarm namespace cleanly

### DIFF
--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -190,6 +190,8 @@ func PrewarmImages(images ...string) env.Func {
 				wait.WithContext(ctx),
 			)
 		}
+		// Delete/wait may populate the object with the old resourceVersion.
+		nsObj = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: prewarmNs}}
 		if err := r.Create(ctx, nsObj); err != nil {
 			return ctx, fmt.Errorf("creating prewarm namespace: %w", err)
 		}

--- a/test/e2e/framework/k8s.go
+++ b/test/e2e/framework/k8s.go
@@ -190,7 +190,6 @@ func PrewarmImages(images ...string) env.Func {
 				wait.WithContext(ctx),
 			)
 		}
-		// Delete/wait may populate the object with the old resourceVersion.
 		nsObj = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: prewarmNs}}
 		if err := r.Create(ctx, nsObj); err != nil {
 			return ctx, fmt.Errorf("creating prewarm namespace: %w", err)


### PR DESCRIPTION
## Problem

The E2E prewarm setup deletes `e2e-prewarm`, waits for deletion, and then reuses the same Namespace object for creation. The deletion wait can populate `metadata.resourceVersion`, causing Kubernetes to reject the create with:

```
resourceVersion should not be set on objects to be created
```

## Fix

Create a fresh Namespace object after the delete/wait path.

## Testing

- `go test ./test/e2e/framework` was attempted; envtest could not start locally because `/usr/local/kubebuilder/bin/etcd` is unavailable.

Assisted-by: 🤖 gpt-5.6-luna

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when recreating the prewarming namespace after it is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->