### PR TITLE
fix(ci): give each workflow a unique job name

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   govulncheck:
-    name: Run on Ubuntu
+    name: Govulncheck
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   lint:
-    name: Run on Ubuntu
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test-e2e:
-    name: Run on Ubuntu
+    name: E2E Tests
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code


### PR DESCRIPTION
## Problem

Several workflows currently expose the same GitHub check name `Run on Ubuntu`: the `E2E Tests`, `Govulncheck`, `Tests`, and `Lint` workflows each used the same job name. GitHub branch protection and rulesets identify required checks by status context, not workflow name, so requiring `Run on Ubuntu` forces all four checks to be required together. A failure in Govulncheck, Tests, or Lint can block a PR even when the E2E check passes.

## Change

Rename each job to a distinct, descriptive name:

| Workflow | Old job name | New job name |
| --- | --- | --- |
| E2E Tests | `Run on Ubuntu` | `E2E Tests` |
| Govulncheck | `Run on Ubuntu` | `Govulncheck` |
| Tests | `Run on Ubuntu` | `Tests` |
| Lint | `Run on Ubuntu` | `Lint` |

This lets downstream repositories require each check independently after syncing the updated workflows. No unrelated behavior changes.

Fixes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow labels to clearly identify vulnerability checks, linting, end-to-end tests, and standard tests.
  * Workflow execution platforms, steps, and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->