### PR TITLE
feat: surface NetworkPolicy posture as an MCPServer status condition

### DIFF
--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -56,6 +56,25 @@ const (
 	ReasonGatewayBindingNotFound = "BindingNotFound"
 )
 
+// NetworkPolicy posture condition type and reasons. This is an informational,
+// administrator-visible signal reporting whether the operator-managed
+// NetworkPolicy restricts ingress sources and egress destinations. It never
+// gates readiness (Available is computed independently).
+const (
+	ConditionTypeNetworkPolicyRestricted = "NetworkPolicyRestricted"
+
+	// ReasonNetworkPolicyRestricted (status True): both ingress source and egress
+	// destination are restricted (least-privilege).
+	ReasonNetworkPolicyRestricted = "Restricted"
+	// ReasonNetworkPolicyIngressUnrestricted (status False): ingress allows any source.
+	ReasonNetworkPolicyIngressUnrestricted = "IngressUnrestricted"
+	// ReasonNetworkPolicyEgressUnrestricted (status False): egress allows any destination.
+	ReasonNetworkPolicyEgressUnrestricted = "EgressUnrestricted"
+	// ReasonNetworkPolicyUnrestricted (status False): both directions are unrestricted
+	// (the default when Spec.Network is unset).
+	ReasonNetworkPolicyUnrestricted = "Unrestricted"
+)
+
 // MetricReasonReconcileError is the `reason` label on deployment/service failure counters
 // when the corresponding reconcile step returns an error.
 const MetricReasonReconcileError = "ReconcileError"

--- a/internal/controller/mcpserver_controller.go
+++ b/internal/controller/mcpserver_controller.go
@@ -318,14 +318,11 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			r.emitDeploymentReconcileFailed(mcpServer, availableCondition.Message)
 		}
 
-		conditions := []*v1ac.ConditionApplyConfiguration{
+		conditions := r.appendPersistentConditions(mcpServer, []*v1ac.ConditionApplyConfiguration{
 			conditionToAC(acceptedCondition),
 			conditionToAC(availableCondition),
 			conditionToAC(verifiedCondition),
-		}
-		if gwCond := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeGatewayRegistered); gwCond != nil {
-			conditions = append(conditions, conditionToAC(*gwCond))
-		}
+		})
 
 		status := acv1beta1.MCPServerStatus().
 			WithObservedGeneration(mcpServer.Generation).
@@ -458,6 +455,16 @@ func (r *MCPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		WithReadyReplicas(existingDeployment.Status.ReadyReplicas)
 
 	applyGatewayStatusToAC(status, gwStatus, acceptedCondition, availableCondition, verifiedCondition)
+
+	// Surface the NetworkPolicy posture as an informational, administrator-visible
+	// condition. Computed from the desired policy (no extra API call) and appended
+	// to the same apply so it does not prune the other conditions. It never gates
+	// readiness (Available is computed independently above).
+	networkPolicyCondition := r.networkPolicyPostureCondition(
+		mcpServer, mcpServer.Generation, mcpServer.Status.Conditions)
+	recordCondition(mcpServer.Name, mcpServer.Namespace,
+		networkPolicyCondition.Type, string(networkPolicyCondition.Status), networkPolicyCondition.Reason)
+	status.WithConditions(conditionToAC(networkPolicyCondition))
 
 	status = withAddressWhenVerified(status, verifiedCondition, mcpURL)
 
@@ -595,14 +602,11 @@ func (r *MCPServerReconciler) reconcilePermanentValidationError(
 
 	prevAccepted := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeAccepted)
 
-	conditions := []*v1ac.ConditionApplyConfiguration{
+	conditions := r.appendPersistentConditions(mcpServer, []*v1ac.ConditionApplyConfiguration{
 		conditionToAC(acceptedCondition),
 		conditionToAC(availableCondition),
 		conditionToAC(verifiedCondition),
-	}
-	if gwCond := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeGatewayRegistered); gwCond != nil {
-		conditions = append(conditions, conditionToAC(*gwCond))
-	}
+	})
 
 	status := acv1beta1.MCPServerStatus().
 		WithObservedGeneration(mcpServer.Generation).
@@ -750,14 +754,11 @@ func (r *MCPServerReconciler) handleResourceFailure(
 		params.emitEvent(mcpServer, availableCondition.Message)
 	}
 
-	conditions := []*v1ac.ConditionApplyConfiguration{
+	conditions := r.appendPersistentConditions(mcpServer, []*v1ac.ConditionApplyConfiguration{
 		conditionToAC(acceptedCondition),
 		conditionToAC(availableCondition),
 		conditionToAC(verifiedCondition),
-	}
-	if gwCond := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeGatewayRegistered); gwCond != nil {
-		conditions = append(conditions, conditionToAC(*gwCond))
-	}
+	})
 
 	status := acv1beta1.MCPServerStatus().
 		WithObservedGeneration(mcpServer.Generation).
@@ -846,6 +847,28 @@ func (r *MCPServerReconciler) applyStatus(
 		client.FieldOwner(fieldManager),
 		client.ForceOwnership,
 	)
+}
+
+// appendPersistentConditions re-adds the status conditions that must survive
+// every apply. applyStatus uses Server-Side Apply under a single field manager,
+// so any condition that manager previously owned but omits from a later apply is
+// pruned. The GatewayRegistered condition is carried forward from existing
+// status, and the NetworkPolicy posture is recomputed from the desired policy,
+// so neither disappears on failure or short-circuit paths (both are otherwise
+// only set on the successful reconcile path).
+func (r *MCPServerReconciler) appendPersistentConditions(
+	mcpServer *mcpv1beta1.MCPServer,
+	conditions []*v1ac.ConditionApplyConfiguration,
+) []*v1ac.ConditionApplyConfiguration {
+	if gwCond := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeGatewayRegistered); gwCond != nil {
+		conditions = append(conditions, conditionToAC(*gwCond))
+	}
+	posture := r.networkPolicyPostureCondition(
+		mcpServer, mcpServer.Generation, mcpServer.Status.Conditions)
+	recordCondition(mcpServer.Name, mcpServer.Namespace,
+		posture.Type, string(posture.Status), posture.Reason)
+	conditions = append(conditions, conditionToAC(posture))
+	return conditions
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/mcpserver_controller_networkpolicy.go
+++ b/internal/controller/mcpserver_controller_networkpolicy.go
@@ -190,6 +190,57 @@ func buildEgressRules(mcpServer *mcpv1beta1.MCPServer) []networkingv1.NetworkPol
 	return []networkingv1.NetworkPolicyEgressRule{dnsRule, userRule}
 }
 
+// networkPolicyPostureCondition reports whether the operator-managed
+// NetworkPolicy restricts ingress sources and egress destinations. It derives
+// the posture from the desired policy built by createNetworkPolicy, using the
+// same restriction-detection helpers as the audit signal so the two never
+// disagree. The condition is informational and never gates readiness.
+func (r *MCPServerReconciler) networkPolicyPostureCondition(
+	mcpServer *mcpv1beta1.MCPServer,
+	generation int64,
+	existingConditions []metav1.Condition,
+) metav1.Condition {
+	netpol := r.createNetworkPolicy(mcpServer)
+	ingressRestricted := hasIngressSourceRestriction(netpol)
+	egressRestricted := hasEgressDestinationRestriction(netpol)
+
+	var (
+		status  metav1.ConditionStatus
+		reason  string
+		message string
+	)
+	switch {
+	case ingressRestricted && egressRestricted:
+		status = metav1.ConditionTrue
+		reason = ReasonNetworkPolicyRestricted
+		// Egress counts as restricted when a rule constrains either destinations
+		// or ports. Phrase the message for what is actually constrained so a
+		// ports-only egress (any destination reachable on those ports) is not
+		// reported as restricting destinations.
+		if egressDestinationsRestricted(netpol) {
+			message = "NetworkPolicy restricts both ingress sources and egress destinations"
+		} else {
+			message = "NetworkPolicy restricts ingress sources and limits egress to specific ports"
+		}
+	case ingressRestricted && !egressRestricted:
+		status = metav1.ConditionFalse
+		reason = ReasonNetworkPolicyEgressUnrestricted
+		message = "NetworkPolicy allows egress to any destination"
+	case !ingressRestricted && egressRestricted:
+		status = metav1.ConditionFalse
+		reason = ReasonNetworkPolicyIngressUnrestricted
+		message = "NetworkPolicy allows ingress from any source"
+	default:
+		status = metav1.ConditionFalse
+		reason = ReasonNetworkPolicyUnrestricted
+		message = "NetworkPolicy allows ingress from any source and egress to any destination"
+	}
+
+	c := newCondition(ConditionTypeNetworkPolicyRestricted, status, reason, message, generation)
+	preserveLastTransitionTime(&c, existingConditions)
+	return c
+}
+
 func hasIngressSourceRestriction(netpol *networkingv1.NetworkPolicy) bool {
 	for _, rule := range netpol.Spec.Ingress {
 		for _, peer := range rule.From {
@@ -204,6 +255,19 @@ func hasIngressSourceRestriction(netpol *networkingv1.NetworkPolicy) bool {
 func hasEgressDestinationRestriction(netpol *networkingv1.NetworkPolicy) bool {
 	for _, rule := range netpol.Spec.Egress {
 		if len(rule.To) > 0 || len(rule.Ports) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// egressDestinationsRestricted reports whether any egress rule limits the set of
+// destination peers (a non-empty To). This is narrower than
+// hasEgressDestinationRestriction, which also treats a ports-only rule as
+// restricted; it is used only to phrase the posture message accurately.
+func egressDestinationsRestricted(netpol *networkingv1.NetworkPolicy) bool {
+	for _, rule := range netpol.Spec.Egress {
+		if len(rule.To) > 0 {
 			return true
 		}
 	}

--- a/internal/controller/mcpserver_controller_networkpolicy_posture_controller_test.go
+++ b/internal/controller/mcpserver_controller_networkpolicy_posture_controller_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
+)
+
+var _ = Describe("MCPServer Controller - NetworkPolicy posture condition", func() {
+	ctx := context.Background()
+
+	reconcileOnce := func(name string) *mcpv1beta1.MCPServer {
+		reconciler := newReconcilerForTest(k8sClient, k8sClient.Scheme())
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: name, Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		mcpServer := &mcpv1beta1.MCPServer{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, mcpServer)).To(Succeed())
+		return mcpServer
+	}
+
+	postureCondition := func(mcpServer *mcpv1beta1.MCPServer) *metav1.Condition {
+		return meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeNetworkPolicyRestricted)
+	}
+
+	It("reports Unrestricted for an MCPServer with no network restrictions", func() {
+		name := "posture-default"
+		Expect(k8sClient.Create(ctx, newTestMCPServer(name))).To(Succeed())
+		defer func() {
+			mcpServer := &mcpv1beta1.MCPServer{}
+			if k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, mcpServer) == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		mcpServer := reconcileOnce(name)
+
+		cond := postureCondition(mcpServer)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(ReasonNetworkPolicyUnrestricted))
+		Expect(cond.ObservedGeneration).To(Equal(mcpServer.Generation))
+
+		By("appearing exactly once (not duplicated across reconciles)")
+		mcpServer = reconcileOnce(name)
+		count := 0
+		for _, c := range mcpServer.Status.Conditions {
+			if c.Type == ConditionTypeNetworkPolicyRestricted {
+				count++
+			}
+		}
+		Expect(count).To(Equal(1))
+	})
+
+	It("reports Restricted when both ingress and egress are restricted", func() {
+		name := "posture-restricted"
+		mcpServer := newTestMCPServer(name)
+		mcpServer.Spec.Network = &mcpv1beta1.NetworkConfig{
+			IngressFrom: []networkingv1.NetworkPolicyPeer{
+				{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"mcp-client": "true"}}},
+			},
+			EgressTo: []networkingv1.NetworkPolicyPeer{
+				{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/8"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, mcpServer) }()
+
+		got := reconcileOnce(name)
+		cond := postureCondition(got)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal(ReasonNetworkPolicyRestricted))
+	})
+
+	It("reports EgressUnrestricted when only ingress is restricted", func() {
+		name := "posture-ingress-only"
+		mcpServer := newTestMCPServer(name)
+		mcpServer.Spec.Network = &mcpv1beta1.NetworkConfig{
+			IngressFrom: []networkingv1.NetworkPolicyPeer{
+				{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"mcp-client": "true"}}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, mcpServer) }()
+
+		got := reconcileOnce(name)
+		cond := postureCondition(got)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(ReasonNetworkPolicyEgressUnrestricted))
+	})
+
+	It("transitions Unrestricted -> Restricted and advances lastTransitionTime", func() {
+		name := "posture-transition"
+		Expect(k8sClient.Create(ctx, newTestMCPServer(name))).To(Succeed())
+		defer func() {
+			mcpServer := &mcpv1beta1.MCPServer{}
+			if k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, mcpServer) == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		first := reconcileOnce(name)
+		firstCond := postureCondition(first)
+		Expect(firstCond).NotTo(BeNil())
+		Expect(firstCond.Reason).To(Equal(ReasonNetworkPolicyUnrestricted))
+		firstStamp := firstCond.LastTransitionTime
+
+		By("a no-op reconcile preserving lastTransitionTime")
+		steady := reconcileOnce(name)
+		Expect(postureCondition(steady).LastTransitionTime).To(Equal(firstStamp))
+
+		By("restricting both directions")
+		mcpServer := &mcpv1beta1.MCPServer{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, mcpServer)).To(Succeed())
+		mcpServer.Spec.Network = &mcpv1beta1.NetworkConfig{
+			IngressFrom: []networkingv1.NetworkPolicyPeer{
+				{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"mcp-client": "true"}}},
+			},
+			EgressTo: []networkingv1.NetworkPolicyPeer{
+				{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/8"}},
+			},
+		}
+		Expect(k8sClient.Update(ctx, mcpServer)).To(Succeed())
+
+		changed := reconcileOnce(name)
+		changedCond := postureCondition(changed)
+		Expect(changedCond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(changedCond.Reason).To(Equal(ReasonNetworkPolicyRestricted))
+		// On a real transition the stamp is recomputed to "now" and must never
+		// move backwards. Strict advancement is asserted in the pure unit test
+		// (TestNetworkPolicyPostureConditionPreservesTransitionTime); here the
+		// two reconciles can land in the same wall-clock second, which serializes
+		// to an equal metav1.Time, so we only assert monotonicity.
+		Expect(changedCond.LastTransitionTime.Before(&firstStamp)).To(BeFalse())
+	})
+
+	It("keeps the posture condition when reconcile fails on invalid config", func() {
+		// The posture is one of several conditions applied under a single field
+		// manager via Server-Side Apply. A failure/short-circuit path that omits it
+		// from the apply would prune the previously-set condition. This guards that
+		// the invalid-config path still carries the posture forward.
+		name := "posture-invalid-config"
+		mcpServer := newTestMCPServer(name)
+		mcpServer.Spec.Config.EnvFrom = []corev1.EnvFromSource{
+			{ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "does-not-exist"},
+			}},
+		}
+		Expect(k8sClient.Create(ctx, mcpServer)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, mcpServer) }()
+
+		got := reconcileOnce(name)
+
+		By("the reconcile landing on the invalid-config path")
+		available := meta.FindStatusCondition(got.Status.Conditions, ConditionTypeAvailable)
+		Expect(available).NotTo(BeNil())
+		Expect(available.Reason).To(Equal(ReasonConfigurationInvalid))
+
+		By("the NetworkPolicy posture condition still being present")
+		cond := postureCondition(got)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal(ReasonNetworkPolicyUnrestricted))
+	})
+
+	It("does not gate readiness: a False posture does not set Available for a posture reason (FR-006)", func() {
+		name := "posture-non-gating"
+		Expect(k8sClient.Create(ctx, newTestMCPServer(name))).To(Succeed())
+		defer func() {
+			mcpServer := &mcpv1beta1.MCPServer{}
+			if k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, mcpServer) == nil {
+				Expect(k8sClient.Delete(ctx, mcpServer)).To(Succeed())
+			}
+		}()
+
+		mcpServer := reconcileOnce(name)
+
+		By("the posture being False (Unrestricted)")
+		Expect(postureCondition(mcpServer).Status).To(Equal(metav1.ConditionFalse))
+
+		By("the Available condition being driven by deployment state, not the posture")
+		available := meta.FindStatusCondition(mcpServer.Status.Conditions, ConditionTypeAvailable)
+		Expect(available).NotTo(BeNil())
+		postureReasons := []string{
+			ReasonNetworkPolicyRestricted,
+			ReasonNetworkPolicyIngressUnrestricted,
+			ReasonNetworkPolicyEgressUnrestricted,
+			ReasonNetworkPolicyUnrestricted,
+		}
+		Expect(postureReasons).NotTo(ContainElement(available.Reason))
+	})
+})

--- a/internal/controller/mcpserver_controller_networkpolicy_posture_test.go
+++ b/internal/controller/mcpserver_controller_networkpolicy_posture_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 The Kubernetes Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	mcpv1beta1 "github.com/kubernetes-sigs/mcp-lifecycle-operator/api/v1beta1"
+)
+
+// postureTestServer builds a minimal MCPServer with the given network config.
+// createNetworkPolicy only reads Name, Namespace, Config.Port and Network, so a
+// full source/image spec is not needed here.
+func postureTestServer(name string, network *mcpv1beta1.NetworkConfig) *mcpv1beta1.MCPServer {
+	return &mcpv1beta1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: mcpv1beta1.MCPServerSpec{
+			Config:  mcpv1beta1.ServerConfig{Port: 8080},
+			Network: network,
+		},
+	}
+}
+
+func TestNetworkPolicyPostureCondition(t *testing.T) {
+	r := &MCPServerReconciler{}
+
+	restrictedIngress := []networkingv1.NetworkPolicyPeer{
+		{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"mcp-client": "true"}}},
+	}
+	restrictedEgress := []networkingv1.NetworkPolicyPeer{
+		{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/8"}},
+	}
+
+	tests := []struct {
+		name           string
+		network        *mcpv1beta1.NetworkConfig
+		wantStatus     metav1.ConditionStatus
+		wantReason     string
+		wantMsgKeyword string // substring that must appear so an admin sees the open direction
+		wantMsgAbsent  string // substring that must NOT appear (guards against overstating restriction)
+	}{
+		{
+			name:           "both restricted",
+			network:        &mcpv1beta1.NetworkConfig{IngressFrom: restrictedIngress, EgressTo: restrictedEgress},
+			wantStatus:     metav1.ConditionTrue,
+			wantReason:     ReasonNetworkPolicyRestricted,
+			wantMsgKeyword: "restricts",
+		},
+		{
+			name:           "ingress restricted, egress open",
+			network:        &mcpv1beta1.NetworkConfig{IngressFrom: restrictedIngress},
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     ReasonNetworkPolicyEgressUnrestricted,
+			wantMsgKeyword: "egress",
+		},
+		{
+			name:           "egress restricted, ingress open",
+			network:        &mcpv1beta1.NetworkConfig{EgressTo: restrictedEgress},
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     ReasonNetworkPolicyIngressUnrestricted,
+			wantMsgKeyword: "ingress",
+		},
+		{
+			name:           "both unrestricted (default, no Spec.Network)",
+			network:        nil,
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     ReasonNetworkPolicyUnrestricted,
+			wantMsgKeyword: "ingress",
+		},
+		{
+			// DNS-only egress: user sets egress ports, which yields the operator's
+			// DNS rule + a user rule constraining ports. hasEgressDestinationRestriction
+			// treats this as restricted, so posture must agree (spec Edge Cases).
+			name: "dns-only egress counts as restricted",
+			network: &mcpv1beta1.NetworkConfig{
+				IngressFrom: restrictedIngress,
+				EgressPorts: []networkingv1.NetworkPolicyPort{
+					{Port: ptrIntStr(443), Protocol: ptr.To(corev1.ProtocolTCP)},
+				},
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: ReasonNetworkPolicyRestricted,
+			// Ports-only egress restricts the reachable ports but not the set of
+			// destinations, so the message must not claim destinations are limited.
+			wantMsgKeyword: "ports",
+			wantMsgAbsent:  "destinations",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer := postureTestServer("posture-"+strings.ReplaceAll(tt.name, " ", "-"), tt.network)
+			mcpServer.Generation = 7
+
+			c := r.networkPolicyPostureCondition(mcpServer, mcpServer.Generation, nil)
+
+			if c.Type != ConditionTypeNetworkPolicyRestricted {
+				t.Errorf("Type = %q, want %q", c.Type, ConditionTypeNetworkPolicyRestricted)
+			}
+			if c.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", c.Status, tt.wantStatus)
+			}
+			if c.Reason != tt.wantReason {
+				t.Errorf("Reason = %q, want %q", c.Reason, tt.wantReason)
+			}
+			if c.ObservedGeneration != 7 {
+				t.Errorf("ObservedGeneration = %d, want 7", c.ObservedGeneration)
+			}
+			if !strings.Contains(strings.ToLower(c.Message), tt.wantMsgKeyword) {
+				t.Errorf("Message = %q, want it to contain %q", c.Message, tt.wantMsgKeyword)
+			}
+			if tt.wantMsgAbsent != "" && strings.Contains(strings.ToLower(c.Message), tt.wantMsgAbsent) {
+				t.Errorf("Message = %q, want it to NOT contain %q", c.Message, tt.wantMsgAbsent)
+			}
+			// Status True only when Restricted (contract "Stable enum").
+			if (c.Status == metav1.ConditionTrue) != (c.Reason == ReasonNetworkPolicyRestricted) {
+				t.Errorf("status/reason invariant violated: status=%q reason=%q", c.Status, c.Reason)
+			}
+		})
+	}
+}
+
+// TestNetworkPolicyPostureConditionPreservesTransitionTime verifies the
+// LastTransitionTime is preserved when the status is unchanged and advances on
+// a real transition (SC-003, mirrors newAvailableCondition behaviour).
+func TestNetworkPolicyPostureConditionPreservesTransitionTime(t *testing.T) {
+	r := &MCPServerReconciler{}
+	earlier := metav1.NewTime(time.Now().Add(-time.Hour))
+
+	// Existing condition: unrestricted, stamped an hour ago.
+	existing := []metav1.Condition{{
+		Type:               ConditionTypeNetworkPolicyRestricted,
+		Status:             metav1.ConditionFalse,
+		Reason:             ReasonNetworkPolicyUnrestricted,
+		LastTransitionTime: earlier,
+	}}
+
+	// Steady state: still unrestricted -> timestamp preserved.
+	same := r.networkPolicyPostureCondition(postureTestServer("np-steady", nil), 1, existing)
+	if !same.LastTransitionTime.Equal(&earlier) {
+		t.Errorf("steady-state LastTransitionTime = %v, want preserved %v", same.LastTransitionTime, earlier)
+	}
+
+	// Transition to restricted -> timestamp advances.
+	restricted := &mcpv1beta1.NetworkConfig{
+		IngressFrom: []networkingv1.NetworkPolicyPeer{
+			{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}}},
+		},
+		EgressTo: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/8"}}},
+	}
+	changed := r.networkPolicyPostureCondition(postureTestServer("np-changed", restricted), 2, existing)
+	if changed.LastTransitionTime.Equal(&earlier) {
+		t.Errorf("transition LastTransitionTime should advance, got preserved %v", earlier)
+	}
+}
+
+func ptrIntStr(v int32) *intstr.IntOrString {
+	p := intstr.FromInt32(v)
+	return &p
+}


### PR DESCRIPTION
Add an informational NetworkPolicyRestricted condition to MCPServer status so administrators can see whether the operator-managed NetworkPolicy restricts ingress sources and egress destinations, instead of having to read controller logs or audit events.

The condition is derived from the desired policy built by createNetworkPolicy using the same ingress/egress restriction detectors as the audit signal, so the two never disagree. Status is True only when both directions are restricted; otherwise it is False with a reason naming the open direction (IngressUnrestricted, EgressUnrestricted, or Unrestricted).

The condition is purely informational and never gates readiness: Available is computed independently. There is no CRD schema change and the generated NetworkPolicy is unchanged. LastTransitionTime is preserved across reconciles when the posture is unchanged.

Fixes https://github.com/kubernetes-sigs/mcp-lifecycle-operator/issues/393 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an administrator-visible NetworkPolicy posture condition to MCPServer status.
  * Reports whether ingress and egress traffic are restricted, including separate indicators for partially restricted policies.
  * Preserves condition transition times and does not affect readiness or availability status.

* **Tests**
  * Added coverage for restriction states, repeated reconciliations, transition timestamps, and readiness independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->